### PR TITLE
Run tests on PHP 8.0

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -7,8 +7,15 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        php-version:
+          - 7.4
+          - 8.0
+
     steps:
     - uses: actions/checkout@v2
+
     - uses: actions/cache@v2
       id: cache-db
       with:
@@ -18,11 +25,17 @@ jobs:
       with:
           lock: site/composer.lock
 
-    - name: Add missing PHP extensions
-      run: composer --working-dir=site add-missing-extensions-prod
-
     - name: OS info
       run: cat /etc/os-release
+
+    - name: "Install PHP"
+      uses: shivammathur/setup-php@v2
+      with:
+        coverage: "none"
+        php-version: "${{ matrix.php-version }}"
+
+    - name: Add missing PHP extensions
+      run: composer --working-dir=site add-missing-extensions-prod
 
     - name: PHP info
       run: |

--- a/site/app/CompanyInfo/Ares.php
+++ b/site/app/CompanyInfo/Ares.php
@@ -47,6 +47,7 @@ class Ares implements CompanyDataInterface
 			if (!$xml) {
 				throw new RuntimeException("Can't parse XML received for company {$companyId}");
 			}
+			/** @var array<string, string> $ns */
 			$ns = $xml->getDocNamespaces();
 			$result = $xml->children($ns['are'])->children($ns['D'])->VH;
 			$data = $xml->children($ns['are'])->children($ns['D'])->VBAS;

--- a/site/app/Post/Post.php
+++ b/site/app/Post/Post.php
@@ -315,6 +315,8 @@ class Post
 	{
 		$this->database->beginTransaction();
 		try {
+			/** @var DateTimeZone|false $timeZone */
+			$timeZone = $post->published->getTimezone();
 			$this->database->query(
 				'INSERT INTO blog_posts',
 				array(
@@ -326,7 +328,7 @@ class Post
 					'lead' => $post->leadTexy,
 					'text' => $post->textTexy,
 					'published' => $post->published,
-					'published_timezone' => $post->published->getTimezone()->getName(),
+					'published_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 					'originally' => $post->originallyTexy,
 					'key_twitter_card_type' => ($post->twitterCard !== null ? $this->getTwitterCardId($post->twitterCard) : null),
 					'og_image' => $post->ogImage,
@@ -355,6 +357,8 @@ class Post
 	{
 		$this->database->beginTransaction();
 		try {
+			/** @var DateTimeZone|false $timeZone */
+			$timeZone = $post->published->getTimezone();
 			$this->database->query(
 				'UPDATE blog_posts SET ? WHERE id_blog_post = ?',
 				array(
@@ -366,7 +370,7 @@ class Post
 					'lead' => $post->leadTexy,
 					'text' => $post->textTexy,
 					'published' => $post->published,
-					'published_timezone' => $post->published->getTimezone()->getName(),
+					'published_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 					'originally' => $post->originallyTexy,
 					'key_twitter_card_type' => ($post->twitterCard !== null ? $this->getTwitterCardId($post->twitterCard) : null),
 					'og_image' => $post->ogImage,
@@ -380,12 +384,14 @@ class Post
 			);
 			$now = new DateTime();
 			if ($post->editSummary) {
+				/** @var DateTimeZone|false $timeZone */
+				$timeZone = $now->getTimezone();
 				$this->database->query(
 					'INSERT INTO blog_post_edits',
 					array(
 						'key_blog_post' => $post->postId,
 						'edited_at' => $now,
-						'edited_at_timezone' => $now->getTimezone()->getName(),
+						'edited_at_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 						'summary' => $post->editSummary,
 					)
 				);

--- a/site/app/Training/Files.php
+++ b/site/app/Training/Files.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training;
 
 use DateTime;
+use DateTimeZone;
 use Nette\Database\Context;
 use Nette\Database\Row;
 use Nette\Http\FileUpload;
@@ -126,12 +127,14 @@ class Files
 		$datetime = new DateTime();
 		$this->database->beginTransaction();
 
+		/** @var DateTimeZone|false $timeZone */
+		$timeZone = $datetime->getTimezone();
 		$this->database->query(
 			'INSERT INTO files',
 			array(
 				'filename'       => $name,
 				'added'          => $datetime,
-				'added_timezone' => $datetime->getTimezone()->getName(),
+				'added_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 			)
 		);
 		$fileId = $this->database->getInsertId();

--- a/site/app/Training/Price.php
+++ b/site/app/Training/Price.php
@@ -42,7 +42,7 @@ class Price
 			return '';
 		}
 
-		return $this->getNumberFormatter($this->price)->formatCurrency($this->price, 'CZK');
+		return $this->formatCurrency($this->price);
 	}
 
 
@@ -75,17 +75,20 @@ class Price
 			return '';
 		}
 
-		return $this->getNumberFormatter($priceVat)->formatCurrency($priceVat, 'CZK');
+		return $this->formatCurrency($priceVat);
 	}
 
 
-	private function getNumberFormatter(float $price): NumberFormatter
+	private function formatCurrency(float $price): string
 	{
 		$formatter = new NumberFormatter('cs_CZ', NumberFormatter::CURRENCY);
 		if (fmod($price, 1) === (float)0) {
 			$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
 		}
-		return $formatter;
+
+		/** @var string $formatted */
+		$formatted = $formatter->formatCurrency($price, 'CZK');
+		return $formatted;
 	}
 
 }

--- a/site/app/Training/Reviews.php
+++ b/site/app/Training/Reviews.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training;
 
 use DateTime;
+use DateTimeZone;
 use MichalSpacekCz\Formatter\Texy;
 use Nette\Database\Context;
 use Nette\Database\Row;
@@ -193,6 +194,8 @@ class Reviews
 	public function addReview(int $dateId, string $name, string $company, ?string $jobTitle, string $review, ?string $href, bool $hidden, ?int $ranking): void
 	{
 		$datetime = new DateTime();
+		/** @var DateTimeZone|false $timeZone */
+		$timeZone = $datetime->getTimezone();
 		$this->database->query(
 			'INSERT INTO training_reviews ?',
 			array(
@@ -203,7 +206,7 @@ class Reviews
 				'review' => $review,
 				'href' => $href,
 				'added' => $datetime,
-				'added_timezone' => $datetime->getTimezone()->getName(),
+				'added_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 				'hidden' => $hidden,
 				'ranking' => $ranking,
 			)

--- a/site/app/Training/Statuses.php
+++ b/site/app/Training/Statuses.php
@@ -227,12 +227,14 @@ class Statuses
 			$datetime->format(DateTime::ATOM),
 		));
 
+		/** @var DateTimeZone|false $timeZone */
+		$timeZone = $datetime->getTimezone();
 		$this->database->query(
 			'UPDATE training_applications SET ? WHERE id_application = ?',
 			array(
 				'key_status'           => $statusId,
 				'status_time'          => $datetime,
-				'status_time_timezone' => $datetime->getTimezone()->getName(),
+				'status_time_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 			),
 			$applicationId
 		);

--- a/site/app/UpcKeys/Technicolor.php
+++ b/site/app/UpcKeys/Technicolor.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\UpcKeys;
 
 use DateTime;
+use DateTimeZone;
 use Nette\Database\Context;
 use Nette\Database\Drivers\MySqlDriver;
 use Nette\Utils\Json;
@@ -241,12 +242,14 @@ class Technicolor implements RouterInterface
 		$datetime = new DateTime();
 		$this->database->beginTransaction();
 		try {
+			/** @var DateTimeZone|false $timeZone */
+			$timeZone = $datetime->getTimezone();
 			$this->database->query(
 				'INSERT INTO ssids',
 				array(
 					'ssid' => $ssid,
 					'added' => $datetime,
-					'added_timezone' => $datetime->getTimezone()->getName(),
+					'added_timezone' => ($timeZone ? $timeZone->getName() : date_default_timezone_get()),
 				)
 			);
 			$ssidId = $this->database->getInsertId();

--- a/site/app/Www/Presenters/PostPresenter.php
+++ b/site/app/Www/Presenters/PostPresenter.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Www\Presenters;
 
+use DateInterval;
 use MichalSpacekCz\Post\LocaleUrls;
 use MichalSpacekCz\Post\Post;
 use MichalSpacekCz\Training\Dates;
@@ -59,7 +60,9 @@ class PostPresenter extends BasePresenter
 		$this->template->pageHeader = $post->title;
 		$this->template->upcomingTrainings = $this->trainingDates->getPublicUpcoming();
 		$this->template->edits = $edits;
-		if ($edits && current($edits)->editedAt->diff($post->published)->days >= $this->blogPost->getUpdatedInfoThreshold()) {
+		/** @var DateInterval|false $interval */
+		$interval = ($edits ? current($edits)->editedAt->diff($post->published) : false);
+		if ($edits && $interval && $interval->days >= $this->blogPost->getUpdatedInfoThreshold()) {
 			$this->template->edited = current($edits)->editedAt;
 		}
 

--- a/site/composer.json
+++ b/site/composer.json
@@ -59,16 +59,16 @@
 	"scripts": {
 		"lint": "vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors app/ public/ tests/",
 		"phpcs": "vendor/squizlabs/php_codesniffer/bin/phpcs app/ public/ tests/",
-		"phpstan-dev": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon app/",
+		"phpstan": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon app/",
 		"phpstan-prod": "vendor/phpstan/phpstan/phpstan --ansi analyse --no-progress --configuration phpstan.neon app/",
-		"tester-dev": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage coverage.html --coverage-src app/ tests/",
+		"tester": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage coverage.html --coverage-src app/ tests/",
 		"tester-prod": "vendor/nette/tester/src/tester -p php -C --colors 1 tests/",
 		"add-missing-extensions-prod": "apt-fast install -y --no-install-recommends php7.4-intl",
 		"test": [
 			"@lint",
 			"@phpcs",
-			"@phpstan-dev",
-			"@tester-dev"
+			"@phpstan",
+			"@tester"
 		],
 		"test-prod": [
 			"@lint",


### PR DESCRIPTION
Run tests on PHP 8.0 before switching to it.

Need to use shivammathur/setup-php@v2 because ubuntu-latest will use Ubuntu 20.04 soon and only PHP 7.4 will be supported https://github.com/actions/virtual-environments/issues/1816