### PR TITLE
Scan for disallowed calls in vendor dir

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -6,6 +6,9 @@
 	"autoload": {
 		"psr-4": {"MichalSpacekCz\\": "app/"}
 	},
+	"config": {
+		"sort-packages": true
+	},
 	"require": {
 		"php": ">= 7.4.0",
 		"ext-ctype": "*",
@@ -40,15 +43,19 @@
 		"contributte/translation": "^0.8"
 	},
 	"require-dev": {
+		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"nette/tester": "^2.0",
+		"php-parallel-lint/php-console-color": "^0.3",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
+		"phpstan/phpdoc-parser": "^0.4.9",
 		"phpstan/phpstan": "^0.12",
 		"phpstan/phpstan-nette": "^0.12",
 		"roave/security-advisories": "dev-latest",
+		"slevomat/coding-standard": "^6.4",
 		"spaze/coding-standard": "^0.0",
 		"spaze/phpstan-disallowed-calls": "^1.2",
-		"slevomat/coding-standard": "^6.4"
+		"squizlabs/php_codesniffer": "^3.5"
 	},
 	"replace": {
 		"paragonie/random_compat": "9.99.99",

--- a/site/composer.json
+++ b/site/composer.json
@@ -70,6 +70,7 @@
 		"phpstan": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon",
 		"phpstan-prod": "vendor/phpstan/phpstan/phpstan --ansi analyse --no-progress --configuration phpstan.neon",
 		"phpstan-vendor": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-vendor.neon",
+		"phpstan-vendor-prod": "vendor/phpstan/phpstan/phpstan --ansi analyse --no-progress --configuration phpstan-vendor.neon",
 		"tester": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage coverage.html --coverage-src app/ tests/",
 		"tester-prod": "vendor/nette/tester/src/tester -p php -C --colors 1 tests/",
 		"add-missing-extensions-prod": "apt-fast install -y --no-install-recommends php7.4-intl",
@@ -77,12 +78,14 @@
 			"@lint",
 			"@phpcs",
 			"@phpstan",
+			"@phpstan-vendor",
 			"@tester"
 		],
 		"test-prod": [
 			"@lint",
 			"@phpcs",
 			"@phpstan-prod",
+			"@phpstan-vendor-prod",
 			"@tester-prod"
 		]
 	}

--- a/site/composer.json
+++ b/site/composer.json
@@ -62,6 +62,7 @@
 		"phpcs": "vendor/squizlabs/php_codesniffer/bin/phpcs app/ public/ tests/",
 		"phpstan": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon",
 		"phpstan-prod": "vendor/phpstan/phpstan/phpstan --ansi analyse --no-progress --configuration phpstan.neon",
+		"phpstan-vendor": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-vendor.neon",
 		"tester": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage coverage.html --coverage-src app/ tests/",
 		"tester-prod": "vendor/nette/tester/src/tester -p php -C --colors 1 tests/",
 		"add-missing-extensions-prod": "apt-fast install -y --no-install-recommends php7.4-intl",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e1ad7a668950c96e32669bf4474e52d8",
+    "content-hash": "e43e6486df3e56596cc848fa8bc491f5",
     "packages": [
         {
             "name": "contributte/translation",

--- a/site/disallowed-calls.neon
+++ b/site/disallowed-calls.neon
@@ -2,3 +2,8 @@ parameters:
 	disallowedFunctionCalls:
 		-
 			function: 'pcntl_*()'
+
+includes:
+	- vendor/spaze/phpstan-disallowed-calls/extension.neon
+	- vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
+	- vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon

--- a/site/phpstan-vendor.neon
+++ b/site/phpstan-vendor.neon
@@ -1,0 +1,64 @@
+parameters:
+	customRulesetUsed: true
+	paths:
+		- vendor
+	excludePaths:
+		analyseAndScan:
+			# `require` packages
+			- vendor/paragonie/halite/test/*  # phpunit/phpunit not installed, PHPUnit\Framework\TestCase missing
+			- vendor/paragonie/constant_time_encoding/tests/*  # phpunit/phpunit not installed, PHPUnit\Framework\TestCase missing
+			- vendor/paragonie/hidden-string/test/*  # phpunit/phpunit not installed, PHPUnit\Framework\TestCase missing
+			- vendor/nette/forms/src/compatibility.php  # throws `Class 'Nette\Forms\SubmitterControl' not found` for some reason
+			- vendor/symfony/translation-contracts/Test/*  # Symfony packages not installed
+			- vendor/symfony/translation/Command/XliffLintCommand.php
+			- vendor/symfony/translation/DataCollector/TranslationDataCollector.php
+			- vendor/symfony/translation/DataCollectorTranslator.php
+			- vendor/symfony/translation/DependencyInjection/*Pass.php
+			- vendor/symfony/translation/Loader/YamlFileLoader.php
+			- vendor/texy/texy/examples/*/demo-*.php  # kukulich/fshl not installed
+			- vendor/tracy/tracy/src/Bridges/Psr/*  # psr/log not installed, Psr\Log\LogLevel constants missing intentionally
+			# `require-dev` packages
+			- vendor/dealerdirect/phpcodesniffer-composer-installer/*  # required by slevomat/coding-standard (excluded as well)
+			- vendor/phpstan/*
+			- vendor/slevomat/coding-standard/*
+			- vendor/squizlabs/php_codesniffer/*
+
+	disallowedFunctionCalls:
+		# local disallowed-calls.neon
+		-
+			function: 'pcntl_*()'
+			allowIn:
+				- vendor/nette/tester/src/Runner/Runner.php
+		# bundled disallowed-dangerous-calls.neon
+		-
+			function: 'eval()'
+			message: 'eval is evil, please write more code and do not use eval()'
+			allowIn:
+				- vendor/latte/latte/src/Latte/Engine.php  # called only when temp dir is not set
+				- vendor/nette/application/src/Bridges/ApplicationDI/RoutingExtension.php  # called in afterCompile
+		-
+			function: 'print_r()'
+			message: 'use some logger instead'
+			allowIn:
+				- vendor/texy/texy/examples/*
+			allowParamsAnywhere:
+				2: true
+		-
+			function: 'putenv()'
+			message: 'might overwrite existing variables'
+			allowIn:
+				- vendor/nette/tester/src/Runner/Job.php
+		# bundled disallowed-execution-calls.neon
+		-
+			function: 'exec()'
+			allowIn:
+				- vendor/tracy/tracy/src/Tracy/Debugger/Debugger.php  # can run a browser if configured
+		-
+			function: 'proc_open()'
+			allowIn:
+				- vendor/nette/tester/src/Runner/Job.php
+				- vendor/nette/tester/src/Runner/PhpInterpreter.php
+				- vendor/php-parallel-lint/php-parallel-lint/src/Process/Process.php
+
+includes:
+	- disallowed-calls.neon

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -8,7 +8,4 @@ parameters:
 includes:
 	- vendor/phpstan/phpstan-nette/extension.neon
 	- vendor/phpstan/phpstan-nette/rules.neon
-	- vendor/spaze/phpstan-disallowed-calls/extension.neon
-	- vendor/spaze/phpstan-disallowed-calls/disallowed-dangerous-calls.neon
-	- vendor/spaze/phpstan-disallowed-calls/disallowed-execution-calls.neon
 	- disallowed-calls.neon

--- a/site/vendor/composer/InstalledVersions.php
+++ b/site/vendor/composer/InstalledVersions.php
@@ -12,6 +12,7 @@
 
 namespace Composer;
 
+use Composer\Autoload\ClassLoader;
 use Composer\Semver\VersionParser;
 
 
@@ -29,7 +30,7 @@ private static $installed = array (
     'aliases' => 
     array (
     ),
-    'reference' => '055c7ecbd484426e18627c3ebe84abcfd9156b2e',
+    'reference' => 'be25aac664cc6ad22506c2e74291469d64efd0e6',
     'name' => 'spaze/michalspacek.cz',
   ),
   'versions' => 
@@ -415,7 +416,7 @@ private static $installed = array (
       'aliases' => 
       array (
       ),
-      'reference' => '055c7ecbd484426e18627c3ebe84abcfd9156b2e',
+      'reference' => 'be25aac664cc6ad22506c2e74291469d64efd0e6',
     ),
     'spaze/mysql-session-handler' => 
     array (
@@ -582,6 +583,8 @@ private static $installed = array (
     ),
   ),
 );
+private static $canGetVendors;
+private static $installedByVendor = array();
 
 
 
@@ -591,7 +594,17 @@ private static $installed = array (
 
 public static function getInstalledPackages()
 {
-return array_keys(self::$installed['versions']);
+$packages = array();
+foreach (self::getInstalled() as $installed) {
+$packages[] = array_keys($installed['versions']);
+}
+
+
+if (1 === \count($packages)) {
+return $packages[0];
+}
+
+return array_keys(array_flip(\call_user_func_array('array_merge', $packages)));
 }
 
 
@@ -604,7 +617,13 @@ return array_keys(self::$installed['versions']);
 
 public static function isInstalled($packageName)
 {
-return isset(self::$installed['versions'][$packageName]);
+foreach (self::getInstalled() as $installed) {
+if (isset($installed['versions'][$packageName])) {
+return true;
+}
+}
+
+return false;
 }
 
 
@@ -639,25 +658,29 @@ return $provided->matches($constraint);
 
 public static function getVersionRanges($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
 $ranges = array();
-if (isset(self::$installed['versions'][$packageName]['pretty_version'])) {
-$ranges[] = self::$installed['versions'][$packageName]['pretty_version'];
+if (isset($installed['versions'][$packageName]['pretty_version'])) {
+$ranges[] = $installed['versions'][$packageName]['pretty_version'];
 }
-if (array_key_exists('aliases', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['aliases']);
+if (array_key_exists('aliases', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['aliases']);
 }
-if (array_key_exists('replaced', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['replaced']);
+if (array_key_exists('replaced', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['replaced']);
 }
-if (array_key_exists('provided', self::$installed['versions'][$packageName])) {
-$ranges = array_merge($ranges, self::$installed['versions'][$packageName]['provided']);
+if (array_key_exists('provided', $installed['versions'][$packageName])) {
+$ranges = array_merge($ranges, $installed['versions'][$packageName]['provided']);
 }
 
 return implode(' || ', $ranges);
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -666,15 +689,19 @@ return implode(' || ', $ranges);
 
 public static function getVersion($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['version'])) {
+if (!isset($installed['versions'][$packageName]['version'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['version'];
+return $installed['versions'][$packageName]['version'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -683,15 +710,19 @@ return self::$installed['versions'][$packageName]['version'];
 
 public static function getPrettyVersion($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['pretty_version'])) {
+if (!isset($installed['versions'][$packageName]['pretty_version'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['pretty_version'];
+return $installed['versions'][$packageName]['pretty_version'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -700,15 +731,19 @@ return self::$installed['versions'][$packageName]['pretty_version'];
 
 public static function getReference($packageName)
 {
-if (!isset(self::$installed['versions'][$packageName])) {
-throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
+foreach (self::getInstalled() as $installed) {
+if (!isset($installed['versions'][$packageName])) {
+continue;
 }
 
-if (!isset(self::$installed['versions'][$packageName]['reference'])) {
+if (!isset($installed['versions'][$packageName]['reference'])) {
 return null;
 }
 
-return self::$installed['versions'][$packageName]['reference'];
+return $installed['versions'][$packageName]['reference'];
+}
+
+throw new \OutOfBoundsException('Package "' . $packageName . '" is not installed');
 }
 
 
@@ -717,7 +752,9 @@ return self::$installed['versions'][$packageName]['reference'];
 
 public static function getRootPackage()
 {
-return self::$installed['root'];
+$installed = self::getInstalled();
+
+return $installed[0]['root'];
 }
 
 
@@ -752,5 +789,33 @@ return self::$installed;
 public static function reload($data)
 {
 self::$installed = $data;
+self::$installedByVendor = array();
+}
+
+
+
+
+private static function getInstalled()
+{
+if (null === self::$canGetVendors) {
+self::$canGetVendors = method_exists('Composer\Autoload\ClassLoader', 'getRegisteredLoaders');
+}
+
+$installed = array();
+
+if (self::$canGetVendors) {
+
+foreach (ClassLoader::getRegisteredLoaders() as $vendorDir => $loader) {
+if (isset(self::$installedByVendor[$vendorDir])) {
+$installed[] = self::$installedByVendor[$vendorDir];
+} elseif (is_file($vendorDir.'/composer/installed.php')) {
+$installed[] = self::$installedByVendor[$vendorDir] = require $vendorDir.'/composer/installed.php';
+}
+}
+}
+
+$installed[] = self::$installed;
+
+return $installed;
 }
 }

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -6,7 +6,7 @@
     'aliases' => 
     array (
     ),
-    'reference' => '055c7ecbd484426e18627c3ebe84abcfd9156b2e',
+    'reference' => 'be25aac664cc6ad22506c2e74291469d64efd0e6',
     'name' => 'spaze/michalspacek.cz',
   ),
   'versions' => 
@@ -392,7 +392,7 @@
       'aliases' => 
       array (
       ),
-      'reference' => '055c7ecbd484426e18627c3ebe84abcfd9156b2e',
+      'reference' => 'be25aac664cc6ad22506c2e74291469d64efd0e6',
     ),
     'spaze/mysql-session-handler' => 
     array (


### PR DESCRIPTION
Use spaze/phpstan-disallowed-calls to scan for disallowed calls in `vendor/` too. Just to make sure there are no known dangerous calls in dependencies.

Dev dependencies should be deleted in production (that's what spaze/stupid-git-deploy does by scanning and deleting `composer.json`'s `require-dev`).

Not fully convinced this is a good or useful idea but *ví vil sí*.