### PR TITLE
Remove trusted types requirement, it generates a lot of reports

### DIFF
--- a/site/config/contentsecuritypolicy.neon
+++ b/site/config/contentsecuritypolicy.neon
@@ -82,8 +82,3 @@ contentSecurityPolicy:
 			@extends: www.*.*
 		upckeys.*.*:
 			@extends: www.*.*
-	policiesReportOnly:
-		*.*.*:
-			require-trusted-types-for: "'script'"
-			report-uri: %reporting.contentSecurityPolicy%
-			report-to: default


### PR DESCRIPTION
For example jQuery 3.x is not ready https://github.com/jquery/jquery/issues/4409

Partially reverts #8