### PR TITLE
GitHub Actions speedup

### DIFF
--- a/.github/workflows/composer-vulns.yml
+++ b/.github/workflows/composer-vulns.yml
@@ -1,0 +1,20 @@
+name: Checks composer.lock for known vulnz in package deps
+
+on:
+  push:
+  schedule:
+    - cron:  '25 * * * *'
+
+jobs:
+  composer-vulnz:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/cache@v2
+      id: cache-db
+      with:
+          path: ~/.symfony/cache
+          key: db
+    - uses: symfonycorp/security-checker-action@v2
+      with:
+          lock: site/composer.lock

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,43 +3,121 @@ name: PHP Tests
 on: [push]
 
 jobs:
-  build:
-
+  info:
     runs-on: ubuntu-latest
-
     strategy:
       matrix:
         php-version:
           - "8.1"
-
     steps:
-    - uses: actions/checkout@v2
-
     - name: OS info
       run: cat /etc/os-release
-
-    - name: "Install PHP"
-      uses: shivammathur/setup-php@v2
-      with:
-        coverage: "none"
-        php-version: "${{ matrix.php-version }}"
-        extensions: intl
-
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - name: PHP info
       run: |
         php -v
         php -m
 
+  composer-validate:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
     - name: Validate composer.json and composer.lock
       run: composer --working-dir=site validate
 
-    - name: Run tests
-      run: composer --working-dir=site test
+  lint:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site lint
 
+  lint-neon:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site lint-neon
+
+  phpcs:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get PHP_CodeSniffer cache file pattern
+      id: phpcs-cache
+      run: echo "::set-output name=file::$(php -r "echo sys_get_temp_dir() . '/phpcs.*';")"
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.phpcs-cache.outputs.file }}
+        key: phpcs-cache-php${{ matrix.php-version }}
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site phpcs
+
+  phpstan:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get PHPStan result cache directory
+      id: phpstan-cache
+      run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.phpstan-cache.outputs.dir }}
+        key: phpstan-cache-php${{ matrix.php-version }}
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site phpstan
+
+  phpstan-vendor:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get PHPStan result cache directory
+      id: phpstan-cache
+      run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
+    - uses: actions/cache@v2
+      with:
+        path: ${{ steps.phpstan-cache.outputs.dir }}
+        key: phpstan-vendor-cache-php${{ matrix.php-version }}
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site phpstan-vendor
+
+  tester:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+    - uses: actions/checkout@v2
+    - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - run: composer --working-dir=site tester
     - name: Failed test output, if any
       if: failure()
       run: for i in $(find ./site/tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
-
     - name: Upload test code coverage
       uses: actions/upload-artifact@v2
       if: success()

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -15,15 +15,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - uses: actions/cache@v2
-      id: cache-db
-      with:
-          path: ~/.symfony/cache
-          key: db
-    - uses: symfonycorp/security-checker-action@v2    
-      with:
-          lock: site/composer.lock
-
     - name: OS info
       run: cat /etc/os-release
 


### PR DESCRIPTION
Runs tests in parallel for speedup. Downside is that `matrix.php-version` has to be specified multiple times but guess that's acceptable. Further speedup by using PHPStan and PHPCS result caches.

Run Symfony security checker also every hour because if I don't push soon enough, I might miss the *memo*.

