### PR TITLE
TLS certificate monitor

### DIFF
--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -44,3 +44,14 @@ jobs:
       with:
         name: testssl.sh reports
         path: 'output/*'
+
+  certmonitor:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.1"
+    steps:
+      - uses: actions/checkout@v2
+      - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+      - run: php site/bin/certmonitor.php

--- a/site/app/Admin/Presenters/HomepagePresenter.php
+++ b/site/app/Admin/Presenters/HomepagePresenter.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Admin\Presenters;
 
 use DateTime;
-use MichalSpacekCz\Http\Certificates;
+use MichalSpacekCz\Tls\Certificates;
 use MichalSpacekCz\Training\Applications;
 use MichalSpacekCz\Training\Dates;
 use MichalSpacekCz\Training\Mails;

--- a/site/app/Admin/Presenters/HomepagePresenter.php
+++ b/site/app/Admin/Presenters/HomepagePresenter.php
@@ -4,12 +4,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Admin\Presenters;
 
 use DateTime;
+use MichalSpacekCz\Tls\Certificate;
 use MichalSpacekCz\Tls\Certificates;
 use MichalSpacekCz\Training\Applications;
 use MichalSpacekCz\Training\Dates;
 use MichalSpacekCz\Training\Mails;
 use MichalSpacekCz\Training\Trainings;
-use Nette\Database\Row;
 
 class HomepagePresenter extends BasePresenter
 {
@@ -72,13 +72,13 @@ class HomepagePresenter extends BasePresenter
 	/**
 	 * Check if at least one certificate is expired or expires soon.
 	 *
-	 * @param Row[] $certificates
+	 * @param array<int, Certificate> $certificates
 	 * @return bool
 	 */
 	private function certsNeedAttention(array $certificates): bool
 	{
 		foreach ($certificates as $certificate) {
-			if ($certificate->expired || $certificate->expiringSoon) {
+			if ($certificate->isExpired() || $certificate->isExpiringSoon()) {
 				return true;
 			}
 		}

--- a/site/app/Admin/Presenters/templates/Homepage/default.latte
+++ b/site/app/Admin/Presenters/templates/Homepage/default.latte
@@ -1,3 +1,4 @@
+{varType MichalSpacekCz\Tls\Certificate[] $certificates}
 {define #content}
 {import "../Trainings/default.latte"}
 <div n:foreach="$flashes as $flash" class="flash {$flash->type}"><strong>{$flash->message}</strong></div>
@@ -15,29 +16,29 @@
 <tbody>
 <tr n:foreach="$certificates as $cert">
 	<td><small>{$iterator->getCounter()}.</small></td>
-	<td><small title="{if $cert->expired}Expiroval{else}Funkční{/if}" n:class="$cert->expired ? error">{if $cert->expired}<i class="fas fa-fw fa-times"></i>{else}<i class="fas fa-fw fa-check"></i>{/if}</small></td>
-	<td><strong n:tag-if="$cert->expiringSoon || $cert->expired" n:class="$cert->expired ? error">{$cert->cn}<small n:if="$cert->ext">-{$cert->ext}</small></strong></td>
-	<td>{$cert->notBefore|localeDay} <small>{$cert->notBefore|date:'H:i'}</small></td>
+	<td><small title="{if $cert->isExpired()}Expiroval{else}Funkční{/if}" n:class="$cert->isExpired() ? error">{if $cert->isExpired()}<i class="fas fa-fw fa-times"></i>{else}<i class="fas fa-fw fa-check"></i>{/if}</small></td>
+	<td><strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()" n:class="$cert->isExpired() ? error">{$cert->getCommonName()}<small n:if="$cert->getCommonNameExt()">-{$cert->getCommonNameExt()}</small></strong></td>
+	<td>{$cert->getNotBefore()|localeDay} <small>{$cert->getNotBefore()|date:'H:i'}</small></td>
 	<td>
 		<small>
-            {if $cert->validDays === 0}
+            {if $cert->getValidDays() === 0}
 				dnes
             {else}
-                {_messages.certificates.admin.validdays, $cert->validDays}
+                {_messages.certificates.admin.validdays, $cert->getValidDays()}
             {/if}
 		</small>
 	</td>
 	<td> &mdash; </td>
-	<td><strong n:tag-if="$cert->expiringSoon || $cert->expired" n:class="$cert->expired ? error">{$cert->notAfter|localeDay} <small>{$cert->notAfter|date:'H:i'}</small></strong></td>
+	<td><strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()" n:class="$cert->isExpired() ? error">{$cert->getNotAfter()|localeDay} <small>{$cert->getNotAfter()|date:'H:i'}</small></strong></td>
 	<td>
-		<strong n:tag-if="$cert->expiringSoon || $cert->expired">
-			<small n:class="$cert->expired ? error">
-				{if $cert->expiryDays === 0}
+		<strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()">
+			<small n:class="$cert->isExpired() ? error">
+				{if $cert->getExpiryDays() === 0}
 					dnes
-				{elseif $cert->expired}
-					{_messages.certificates.admin.expireddaysago, $cert->expiryDays}
+				{elseif $cert->isExpired()}
+					{_messages.certificates.admin.expireddaysago, $cert->getExpiryDays()}
 				{else}
-					{_messages.certificates.admin.expiresindays, $cert->expiryDays}
+					{_messages.certificates.admin.expiresindays, $cert->getExpiryDays()}
 				{/if}
 			</small>
 		</strong>

--- a/site/app/Api/Presenters/CertificatesPresenter.php
+++ b/site/app/Api/Presenters/CertificatesPresenter.php
@@ -34,11 +34,7 @@ class CertificatesPresenter extends BasePresenter
 
 	public function actionDefault(): never
 	{
-		$cns = [];
-		foreach ($this->certificates->getNewest() as $certificate) {
-			$cns[] = $certificate->getCommonName();
-		}
-		$this->sendJson($cns);
+		$this->sendJson($this->certificates->getNewest());
 	}
 
 

--- a/site/app/Api/Presenters/CertificatesPresenter.php
+++ b/site/app/Api/Presenters/CertificatesPresenter.php
@@ -36,7 +36,7 @@ class CertificatesPresenter extends BasePresenter
 	{
 		$cns = [];
 		foreach ($this->certificates->getNewest() as $certificate) {
-			$cns[] = $certificate->cn;
+			$cns[] = $certificate->getCommonName();
 		}
 		$this->sendJson($cns);
 	}

--- a/site/app/Api/Presenters/CertificatesPresenter.php
+++ b/site/app/Api/Presenters/CertificatesPresenter.php
@@ -3,7 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Api\Presenters;
 
-use MichalSpacekCz\Http\Certificates;
+use MichalSpacekCz\Tls\Certificates;
 use MichalSpacekCz\Www\Presenters\BasePresenter;
 use Nette\Security\AuthenticationException;
 use RuntimeException;

--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -3,97 +3,46 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application;
 
-use MichalSpacekCz\Http\SecurityHeaders;
-use Nette\Application\Application;
-use Nette\Application\Request;
-use Nette\Application\Response;
-use Nette\Application\UI\Presenter;
 use Nette\Bootstrap\Configurator;
 use Nette\DI\Container;
-use Nette\Http\IResponse;
-use Nette\SmartObject;
+use Nette\Utils\Arrays;
 
 class Bootstrap
 {
 
-	use SmartObject;
-
-
-	/** @var string */
-	private const MODE_PRODUCTION = 'production';
-
-	/** @var string */
 	private const MODE_DEVELOPMENT = 'development';
 
-	private Container $container;
 
-	private IResponse $httpResponse;
-
-	private SecurityHeaders $securityHeaders;
-
-	private string $siteDir;
-
-	private string $logDir;
-
-	private string $tempDir;
-
-	private string $environment;
-
-	private string $timeZone;
-
-
-	public function __construct(string $siteDir, string $logDir, string $tempDir, ?string $environment, string $timeZone)
-	{
-		$this->siteDir = $siteDir;
-		$this->logDir = $logDir;
-		$this->tempDir = $tempDir;
-		$this->environment = $environment ?? self::MODE_PRODUCTION;
-		$this->timeZone = $timeZone;
+	public function __construct(
+		private string $siteDir,
+	) {
 	}
 
 
-	public function run(): void
+	public function boot(): Container
 	{
-		$configurator = new Configurator();
-		$configurator->addParameters(['siteDir' => $this->siteDir]);
+		return $this->createConfigurator(
+			($_SERVER['ENVIRONMENT'] ?? null) === self::MODE_DEVELOPMENT,
+			$this->siteDir . '/config/extra-' . $_SERVER['SERVER_NAME'] . '.neon',
+		)->createContainer();
+	}
 
-		$configurator->setDebugMode($this->isDebugMode());
-		$configurator->enableDebugger($this->logDir);
-		$configurator->setTimeZone($this->timeZone);
-		$configurator->setTempDirectory($this->tempDir);
 
-		$configurator->createRobotLoader()
-			->addDirectory($this->siteDir . '/app')
-			->register();
-
-		$existingFiles = array_filter($this->getConfigurationFiles(), function ($path) {
-			return is_file($path);
-		});
-		foreach ($existingFiles as $filename) {
-			$configurator->addConfig($filename);
-		}
-
-		$this->container = $configurator->createContainer();
-		$this->httpResponse = $this->container->getByType(IResponse::class);
-		$this->securityHeaders = $this->container->getByType(SecurityHeaders::class);
-		$this->redirectToSecure();
-
-		$application = $this->container->getByType(Application::class);
-		$application->onRequest[] = function (Application $sender, Request $request): void {
-			$action = $request->getParameter(Presenter::ACTION_KEY) ?? Presenter::DEFAULT_ACTION;
-			$this->securityHeaders->setCsp($request->getPresenterName(), $action);
-		};
-		$application->onResponse[] = function (Application $sender, Response $response): void {
-			$this->securityHeaders->sendHeaders();
-		};
-		$application->run();
+	public function bootCli(): Container
+	{
+		$_SERVER['HTTPS'] = 'on';
+		$debugMode = ($_SERVER['PHP_CLI_ENVIRONMENT'] ?? null) === self::MODE_DEVELOPMENT || Arrays::contains($_SERVER['argv'], '--debug');
+		return $this->createConfigurator(
+			$debugMode,
+			$this->siteDir . '/config/' . ($debugMode ? 'extra-cli-debug.neon' : 'extra-cli.neon'),
+		)->createContainer();
 	}
 
 
 	/**
 	 * @return string[]
 	 */
-	private function getConfigurationFiles(): array
+	private function getConfigurationFiles(string $extraConfig): array
 	{
 		return array_unique(array(
 			$this->siteDir . '/config/extensions.neon',
@@ -103,27 +52,34 @@ class Bootstrap
 			$this->siteDir . '/config/presenters.neon',
 			$this->siteDir . '/config/services.neon',
 			$this->siteDir . '/config/routes.neon',
-			$this->siteDir . '/config/extra-' . $_SERVER['SERVER_NAME'] . '.neon',
+			$extraConfig,
 			$this->siteDir . '/config/local.neon',
 		));
 	}
 
 
-	private function isDebugMode(): bool
+	private function createConfigurator(bool $debugMode, string $extraConfig): Configurator
 	{
-		return ($this->environment === self::MODE_DEVELOPMENT);
-	}
+		$configurator = new Configurator();
+		$configurator->addParameters(['siteDir' => $this->siteDir]);
 
+		$configurator->setDebugMode($debugMode);
+		$configurator->enableDebugger($this->siteDir . '/log');
+		$configurator->setTimeZone('Europe/Prague');
+		$configurator->setTempDirectory($this->siteDir . '/temp');
 
-	private function redirectToSecure(): void
-	{
-		$fqdn = $this->container->getParameters()['domain']['fqdn'];
-		$uri = $_SERVER['REQUEST_URI'];
-		if ($_SERVER['HTTP_HOST'] !== $fqdn) {
-			$this->securityHeaders->setDefaultCsp()->sendHeaders();
-			$this->httpResponse->redirect("https://{$fqdn}{$uri}", IResponse::S301_MOVED_PERMANENTLY);
-			exit();
+		$configurator->createRobotLoader()
+			->addDirectory($this->siteDir . '/app')
+			->register();
+
+		$existingFiles = array_filter($this->getConfigurationFiles($extraConfig), function ($path) {
+			return is_file($path);
+		});
+		foreach ($existingFiles as $filename) {
+			$configurator->addConfig($filename);
 		}
+
+		return $configurator;
 	}
 
 }

--- a/site/app/Application/RouterFactory.php
+++ b/site/app/Application/RouterFactory.php
@@ -218,7 +218,7 @@ class RouterFactory
 				}
 			}
 			$hostMask = sprintf(
-				'//%s/%s%s',
+				'https://%s/%s%s',
 				str_ends_with($domain, '.') ? rtrim($domain, '.') : "{$host}.{$this->rootDomainMapping[$domain]}",
 				$maskPrefix,
 				$mask,

--- a/site/app/Application/WebApplication.php
+++ b/site/app/Application/WebApplication.php
@@ -1,0 +1,49 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use MichalSpacekCz\Http\SecurityHeaders;
+use Nette\Application\Application;
+use Nette\Application\Request;
+use Nette\Application\UI\Presenter;
+use Nette\Http\IResponse;
+
+class WebApplication
+{
+
+	public function __construct(
+		private IResponse $httpResponse,
+		private SecurityHeaders $securityHeaders,
+		private Application $application,
+		private string $fqdn,
+	) {
+	}
+
+
+	public function run(): void
+	{
+		$this->redirectToSecure();
+
+		$this->application->onRequest[] = function (Application $sender, Request $request): void {
+			$action = $request->getParameter(Presenter::ACTION_KEY) ?? Presenter::DEFAULT_ACTION;
+			$this->securityHeaders->setCsp($request->getPresenterName(), $action);
+		};
+		$this->application->onResponse[] = function (): void {
+			$this->securityHeaders->sendHeaders();
+		};
+		$this->application->run();
+	}
+
+
+	private function redirectToSecure(): void
+	{
+		$uri = $_SERVER['REQUEST_URI'];
+		if ($_SERVER['HTTP_HOST'] !== $this->fqdn) {
+			$this->securityHeaders->setDefaultCsp()->sendHeaders();
+			$this->httpResponse->redirect("https://{$this->fqdn}{$uri}", IResponse::S301_MOVED_PERMANENTLY);
+			exit();
+		}
+	}
+
+}

--- a/site/app/DateTime/DateTime.php
+++ b/site/app/DateTime/DateTime.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime;
+
+class DateTime
+{
+
+	/**
+	 * Same as DATE_RFC3339_EXTENDED except it uses microseconds (`.u`) instead of milliseconds (`.v`).
+	 *
+	 * @var string
+	 */
+	public const DATE_RFC3339_MICROSECONDS = 'Y-m-d\TH:i:s.uP';
+
+}

--- a/site/app/DateTime/DateTimeParser.php
+++ b/site/app/DateTime/DateTimeParser.php
@@ -1,0 +1,27 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+
+class DateTimeParser
+{
+
+	/**
+	 * Similar to \Nette\Utils\DateTime::createFromFormat() except this method returns \DateTimeImmutable.
+	 *
+	 * @throws CannotParseDateTimeException
+	 */
+	public static function createFromFormat(string $format, string $datetime, DateTimeZone $timezone = null): DateTimeImmutable
+	{
+		$date = DateTimeImmutable::createFromFormat($format, $datetime, $timezone);
+		if ($date === false) {
+			throw new CannotParseDateTimeException($format, $datetime);
+		}
+		return $date;
+	}
+
+}

--- a/site/app/DateTime/Exceptions/CannotParseDateTimeException.php
+++ b/site/app/DateTime/Exceptions/CannotParseDateTimeException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime\Exceptions;
+
+use Throwable;
+
+class CannotParseDateTimeException extends DateTimeException
+{
+
+	public function __construct(string $format, string $datetime, Throwable $previous = null)
+	{
+		parent::__construct("Cannot parse '{$datetime}' using format '{$format}'", $previous);
+	}
+
+}

--- a/site/app/DateTime/Exceptions/DateTimeException.php
+++ b/site/app/DateTime/Exceptions/DateTimeException.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime\Exceptions;
+
+use Exception;
+use Nette\Utils\Json;
+use Throwable;
+
+abstract class DateTimeException extends Exception
+{
+
+	public function __construct(string $message, Throwable $previous = null)
+	{
+		$message .= ' ' . Json::encode(date_get_last_errors());
+		parent::__construct($message, 0, $previous);
+	}
+
+}

--- a/site/app/Http/Exceptions/HttpStreamException.php
+++ b/site/app/Http/Exceptions/HttpStreamException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\Exceptions;
+
+use Exception;
+use Throwable;
+
+class HttpStreamException extends Exception
+{
+
+	public function __construct(int $notificationCode, string $message, int $messageCode, ?Throwable $previous = null)
+	{
+		parent::__construct(trim($message) . " ({$notificationCode})", $messageCode, $previous);
+	}
+
+}

--- a/site/app/Http/HttpHeader.php
+++ b/site/app/Http/HttpHeader.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http;
+
+class HttpHeader
+{
+
+	public static function normalizeValue(string $value): string
+	{
+		return str_replace('\\', '/', $value);
+	}
+
+}

--- a/site/app/Http/HttpStreamContext.php
+++ b/site/app/Http/HttpStreamContext.php
@@ -1,0 +1,37 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http;
+
+use MichalSpacekCz\Http\Exceptions\HttpStreamException;
+
+class HttpStreamContext
+{
+
+	/**
+	 * @param array<string, string|bool> $sslOptions
+	 * @param array<string, string|int> $httpOptions
+	 * @param string $userAgent
+	 * @return resource
+	 */
+	public function create(string $userAgent, array $httpOptions, array $sslOptions = [])
+	{
+		return stream_context_create(
+			[
+				'ssl' => $sslOptions,
+				'http' => $httpOptions + [
+					'ignore_errors' => true,
+					'user_agent' => HttpHeader::normalizeValue($userAgent),
+				],
+			],
+			[
+				'notification' => function (int $notificationCode, int $severity, ?string $message, int $messageCode): void {
+					if ($severity === STREAM_NOTIFY_SEVERITY_ERR) {
+						throw new HttpStreamException($notificationCode, $message, $messageCode);
+					}
+				},
+			],
+		);
+	}
+
+}

--- a/site/app/Tls/Certificate.php
+++ b/site/app/Tls/Certificate.php
@@ -1,0 +1,93 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use DateTimeImmutable;
+use MichalSpacekCz\Tls\Exceptions\CertificateException;
+
+class Certificate
+{
+
+	private int $validDays;
+	private int $expiryDays;
+	private bool $expired;
+	private bool $expiringSoon;
+
+
+	/**
+	 * @throws CertificateException
+	 */
+	public function __construct(
+		private string $commonName,
+		private ?string $commonNameExt,
+		private DateTimeImmutable $notBefore,
+		private DateTimeImmutable $notAfter,
+		private int $expiringThreshold,
+	) {
+		$now = new DateTimeImmutable();
+
+		$validDays = $this->notBefore->diff($now)->days;
+		if ($validDays === false) {
+			throw new CertificateException('Unknown number of valid days');
+		}
+		$this->validDays = $validDays;
+		$expiryDays = $this->notAfter->diff($now)->days;
+		if ($expiryDays === false) {
+			throw new CertificateException('Unknown number of expiry days');
+		}
+		$this->expiryDays = $expiryDays;
+
+		$this->expired = $this->notAfter < $now;
+		$this->expiringSoon = !$this->expired && $this->expiryDays < $this->expiringThreshold;
+	}
+
+
+	public function getCommonName(): string
+	{
+		return $this->commonName;
+	}
+
+
+	public function getCommonNameExt(): ?string
+	{
+		return $this->commonNameExt;
+	}
+
+
+	public function getNotBefore(): DateTimeImmutable
+	{
+		return $this->notBefore;
+	}
+
+
+	public function getNotAfter(): DateTimeImmutable
+	{
+		return $this->notAfter;
+	}
+
+
+	public function getValidDays(): int
+	{
+		return $this->validDays;
+	}
+
+
+	public function getExpiryDays(): int
+	{
+		return $this->expiryDays;
+	}
+
+
+	public function isExpired(): bool
+	{
+		return $this->expired;
+	}
+
+
+	public function isExpiringSoon(): bool
+	{
+		return $this->expiringSoon;
+	}
+
+}

--- a/site/app/Tls/CertificateFactory.php
+++ b/site/app/Tls/CertificateFactory.php
@@ -1,0 +1,91 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use MichalSpacekCz\DateTime\DateTime;
+use MichalSpacekCz\DateTime\DateTimeParser;
+use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+use MichalSpacekCz\Tls\Exceptions\CertificateException;
+use MichalSpacekCz\Tls\Exceptions\OpenSslException;
+use Nette\Database\Row;
+use OpenSSLCertificate;
+
+class CertificateFactory
+{
+
+	public function __construct(
+		private int $expiringThreshold,
+	) {
+	}
+
+
+	/**
+	 * @throws CertificateException
+	 */
+	public function fromDatabaseRow(Row $row): Certificate
+	{
+		return new Certificate(
+			$row->cn,
+			$row->ext,
+			DateTimeImmutable::createFromInterface($row->notBefore),
+			DateTimeImmutable::createFromInterface($row->notAfter),
+			$this->expiringThreshold,
+			null,
+		);
+	}
+
+
+	/**
+	 * @throws OpenSslException
+	 * @throws CannotParseDateTimeException
+	 * @throws CertificateException
+	 */
+	public function fromObject(OpenSSLCertificate $certificate): Certificate
+	{
+		$details = OpenSsl::x509parse($certificate);
+		return new Certificate(
+			$details['subject']['commonName'],
+			null,
+			DateTimeParser::createFromFormat('U', (string)$details['validFrom_time_t']),
+			DateTimeParser::createFromFormat('U', (string)$details['validTo_time_t']),
+			$this->expiringThreshold,
+			$details['serialNumberHex'],
+		);
+	}
+
+
+	/**
+	 * @param array{commonName:string, commonNameExt:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string} $details
+	 * @return Certificate
+	 * @throws CannotParseDateTimeException
+	 * @throws CertificateException
+	 */
+	public function fromArray(array $details): Certificate
+	{
+		return new Certificate(
+			$details['commonName'],
+			$details['commonNameExt'],
+			$this->createDateTimeImmutable($details['notBefore'], $details['notBeforeTz']),
+			$this->createDateTimeImmutable($details['notAfter'], $details['notAfterTz']),
+			$details['expiringThreshold'],
+			$details['serialNumber'],
+			$this->createDateTimeImmutable($details['now'], $details['nowTz']),
+		);
+	}
+
+
+	/**
+	 * @param string $time
+	 * @param string $timeZone
+	 * @return DateTimeImmutable
+	 * @throws CannotParseDateTimeException
+	 */
+	private function createDateTimeImmutable(string $time, string $timeZone): DateTimeImmutable
+	{
+		return DateTimeParser::createFromFormat(DateTime::DATE_RFC3339_MICROSECONDS, $time)->setTimezone(new DateTimeZone($timeZone));
+	}
+
+}

--- a/site/app/Tls/CertificateGatherer.php
+++ b/site/app/Tls/CertificateGatherer.php
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+use MichalSpacekCz\Http\HttpStreamContext;
+use MichalSpacekCz\Tls\Exceptions\CertificateException;
+use MichalSpacekCz\Tls\Exceptions\OpenSslException;
+
+class CertificateGatherer
+{
+
+	public function __construct(
+		private CertificateFactory $certificateFactory,
+		private HttpStreamContext $httpStreamContext,
+	) {
+	}
+
+
+	/**
+	 * @throws OpenSslException
+	 * @throws CertificateException
+	 * @throws CannotParseDateTimeException
+	 */
+	public function fetchCertificate(string $hostname): Certificate
+	{
+		$url = "https://{$hostname}/";
+		$fp = fopen($url, 'r', context: $this->httpStreamContext->create(
+			__METHOD__,
+			[
+				'method' => 'HEAD',
+				'follow_location' => 0,
+			],
+			[
+				'capture_peer_cert' => true,
+			],
+		));
+		if (!$fp) {
+			throw new CertificateException("Unable to open {$url}");
+		}
+		$options = stream_context_get_options($fp);
+		fclose($fp);
+		return $this->certificateFactory->fromObject($options['ssl']['peer_certificate']);
+	}
+
+}

--- a/site/app/Tls/CertificateMonitor.php
+++ b/site/app/Tls/CertificateMonitor.php
@@ -1,0 +1,118 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use JakubOnderka\PhpConsoleColor\ConsoleColor;
+
+class CertificateMonitor
+{
+
+	private bool $hasErrors = false;
+
+
+	public function __construct(
+		private CertificateGatherer $certificateGatherer,
+		private CertificatesApiClient $certificatesApiClient,
+		private ConsoleColor $color,
+	) {
+	}
+
+
+	public function run(): never
+	{
+		// Not running in parallel because those sites are hosted on just a few tiny servers
+		foreach ($this->certificatesApiClient->getLoggedCertificates() as $loggedCertificate) {
+			$this->compareCertificates($loggedCertificate, $this->certificateGatherer->fetchCertificate($loggedCertificate->getCommonName()));
+		}
+		exit($this->hasErrors ? 1 : 0);
+	}
+
+
+	private function compareCertificates(Certificate $loggedCertificate, Certificate $serverCertificate): void
+	{
+		$error = false;
+		if ($loggedCertificate->getNotAfter()->getTimestamp() !== $serverCertificate->getNotAfter()->getTimestamp()) {
+			$error = true;
+			$this->error($serverCertificate, sprintf(
+				"Logged certificate's notAfter (%s, %s) doesn't match server certificate's notAfter (%s, %s)",
+				$loggedCertificate->getNotAfter()->format(DATE_RFC3339),
+				$this->getExpiryDays($loggedCertificate),
+				$serverCertificate->getNotAfter()->format(DATE_RFC3339),
+				$this->getExpiryDays($serverCertificate),
+			));
+		}
+		if ($serverCertificate->isExpiringSoon()) {
+			$error = true;
+			$this->error($serverCertificate, sprintf(
+				'Server certificate expires soon (notAfter: %s, %s)',
+				$serverCertificate->getNotAfter()->format(DATE_RFC3339),
+				$this->getExpiryDays($serverCertificate),
+			));
+		}
+		if ($serverCertificate->isExpired()) {
+			$error = true;
+			$this->error($serverCertificate, sprintf(
+				'Server certificate expired (notAfter: %s, %s)',
+				$serverCertificate->getNotAfter()->format(DATE_RFC3339),
+				$this->getExpiryDays($serverCertificate),
+			));
+		}
+		if ($error) {
+			$this->hasErrors = true;
+		} else {
+			$this->info($loggedCertificate, sprintf(
+				"Logged certificate's notAfter matches server certificate's notAfter (%s, %s)",
+				$loggedCertificate->getNotAfter()->format(DATE_RFC3339),
+				$this->getExpiryDays($loggedCertificate),
+			));
+		}
+	}
+
+
+	private function getExpiryDays(Certificate $certificate): string
+	{
+		$days = '';
+		if (!$certificate->isExpired()) {
+			$days .= 'in ';
+		}
+		$days .= $certificate->getExpiryDays() . ' ';
+		$days .= $certificate->getExpiryDays() === 1 ? 'day' : 'days';
+		if ($certificate->isExpired()) {
+			$days .= ' ago';
+		}
+		return $days;
+	}
+
+
+	private function error(Certificate $certificate, string $message): void
+	{
+		$this->message(
+			$certificate,
+			$this->color->apply('dark_gray', '%s') . ' ' . $this->color->apply(['light_red', 'bold'], '%s') . ' ' . $this->color->apply('light_red', 'ERROR:') . ' %s',
+			$message,
+		);
+	}
+
+
+	private function info(Certificate $certificate, string $message): void
+	{
+		$this->message(
+			$certificate,
+			$this->color->apply('dark_gray', '%s') . ' ' . $this->color->apply(['light_green', 'bold'], '%s') . ' ' . $this->color->apply('light_green', 'INFO:') . ' %s',
+			$message,
+		);
+	}
+
+
+	private function message(Certificate $certificate, string $format, string $message): void
+	{
+		printf(
+			$format . "\n",
+			date(DATE_RFC3339),
+			$certificate->getCommonName(),
+			$message,
+		);
+	}
+
+}

--- a/site/app/Tls/Certificates.php
+++ b/site/app/Tls/Certificates.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\Http;
+namespace MichalSpacekCz\Tls;
 
 use DateTime;
 use MichalSpacekCz\User\Manager;

--- a/site/app/Tls/Certificates.php
+++ b/site/app/Tls/Certificates.php
@@ -3,11 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Tls;
 
-use DateTime;
+use DateTimeImmutable;
+use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\User\Manager;
 use Nette\Database\DriverException;
 use Nette\Database\Explorer;
-use Nette\Database\Row;
 use Nette\Security\AuthenticationException;
 use Nette\Utils\DateTime as NetteDateTime;
 use RuntimeException;
@@ -85,12 +85,11 @@ class Certificates
 	/**
 	 * Get newest certificates.
 	 *
-	 * @return Row[]
+	 * @return array<int, Certificate>
+	 * @throws CertificateException
 	 */
 	public function getNewest(): array
 	{
-		$now = new DateTime();
-
 		$query = 'SELECT
 			cr.cn,
 			cr.ext,
@@ -101,18 +100,14 @@ class Certificates
 			WHERE NOT c.hidden
 			GROUP BY cr.cn, cr.ext
 			ORDER BY cr.cn, cr.ext';
-		$certificates = $this->database->fetchAll($query);
-
-		foreach ($certificates as $key => $certificate) {
-			$certificate->validDays = $certificate->notBefore->diff($now)->days;
-			$certificate->expired = $certificate->notAfter < $now;
-			$certificate->expiryDays = $certificate->notAfter->diff($now)->days;
-			$certificate->expiringSoon = !$certificate->expired && $certificate->expiryDays < $this->expiringThreshold;
-			if ($certificate->expired && $certificate->expiryDays > $this->hideExpiredAfter) {
-				unset($certificates[$key]);
+		$certificates = [];
+		foreach ($this->database->fetchAll($query) as $data) {
+			$certificate = new Certificate($data->cn, $data->ext, DateTimeImmutable::createFromInterface($data->notBefore), DateTimeImmutable::createFromInterface($data->notAfter), $this->expiringThreshold);
+			if ($certificate->isExpired() && $certificate->getExpiryDays() > $this->hideExpiredAfter) {
+				continue;
 			}
+			$certificates[] = $certificate;
 		}
-
 		return $certificates;
 	}
 
@@ -176,7 +171,7 @@ class Certificates
 		$this->database->query('INSERT INTO certificate_requests', array(
 			'cn' => $cn,
 			'ext' => (empty($ext) ? null : $ext),
-			'time' => new DateTime(),
+			'time' => new DateTimeImmutable(),
 			'success' => $success,
 		));
 		return (int)$this->database->getInsertId();

--- a/site/app/Tls/CertificatesApiClient.php
+++ b/site/app/Tls/CertificatesApiClient.php
@@ -1,0 +1,69 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+use MichalSpacekCz\Http\HttpStreamContext;
+use MichalSpacekCz\Tls\Exceptions\CertificatesApiException;
+use Nette\Application\LinkGenerator;
+use Nette\Application\UI\InvalidLinkException;
+use Nette\Utils\Helpers;
+use Nette\Utils\Json;
+use Nette\Utils\JsonException;
+
+class CertificatesApiClient
+{
+
+	public function __construct(
+		private LinkGenerator $linkGenerator,
+		private CertificateFactory $certificateFactory,
+		private HttpStreamContext $httpStreamContext,
+	) {
+	}
+
+
+	/**
+	 * @return array<int, Certificate>
+	 * @throws Exceptions\CertificateException
+	 * @throws CannotParseDateTimeException
+	 * @throws InvalidLinkException
+	 * @throws JsonException
+	 * @throws CertificatesApiException
+	 */
+	public function getLoggedCertificates(): array
+	{
+		$url = $this->linkGenerator->link('Api:Certificates:');
+		$json = @file_get_contents($url, context: $this->httpStreamContext->create(  // intentionally @, warning converted to exception
+			__METHOD__,
+			[
+				'method' => 'POST',
+				'header'  => 'Content-type: application/x-www-form-urlencoded',
+				'content' => $this->getPostData(),
+			],
+		));
+		if (!$json) {
+			throw new CertificatesApiException(sprintf('Failure getting data from %s: %s', $url, Helpers::getLastError()));
+		}
+		$certificates = [];
+		$decoded = Json::decode($json, Json::FORCE_ARRAY);
+		if (!is_array($decoded)) {
+			throw new CertificatesApiException(sprintf('Decoded response type from %s is %s (`%s`) not array', $url, gettype($decoded), $json));
+		}
+		foreach ($decoded as $details) {
+			$certificates[] = $this->certificateFactory->fromArray($details);
+		}
+		return $certificates;
+	}
+
+
+	private function getPostData(): string
+	{
+		$postData = [
+			'user' => $_SERVER['CERTMONITOR_USER'],
+			'key' => $_SERVER['CERTMONITOR_KEY'],
+		];
+		return http_build_query($postData);
+	}
+
+}

--- a/site/app/Tls/Exceptions/CertificateException.php
+++ b/site/app/Tls/Exceptions/CertificateException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls\Exceptions;
+
+use Exception;
+
+class CertificateException extends Exception
+{
+}

--- a/site/app/Tls/Exceptions/CertificatesApiException.php
+++ b/site/app/Tls/Exceptions/CertificatesApiException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls\Exceptions;
+
+use Exception;
+
+class CertificatesApiException extends Exception
+{
+}

--- a/site/app/Tls/Exceptions/OpenSslException.php
+++ b/site/app/Tls/Exceptions/OpenSslException.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls\Exceptions;
+
+use Exception;
+use Throwable;
+
+class OpenSslException extends Exception
+{
+
+	public function __construct(Throwable $previous = null)
+	{
+		$messages = [];
+		while ($message = openssl_error_string()) {
+			$messages[] = $message;
+		}
+		parent::__construct(implode('; ', $messages), 0, $previous);
+	}
+
+}

--- a/site/app/Tls/OpenSsl.php
+++ b/site/app/Tls/OpenSsl.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use MichalSpacekCz\Tls\Exceptions\OpenSslException;
+use OpenSSLCertificate;
+
+class OpenSsl
+{
+
+	/**
+	 * @param OpenSSLCertificate|string $certificate An OpenSSLCertificate instance or PEM-encoded certificate content
+	 * @return array<string, mixed>
+	 * @throws OpenSslException
+	 */
+	public static function x509parse(OpenSSLCertificate|string $certificate): array
+	{
+		$info = @openssl_x509_parse($certificate, false);  // intentionally @, warning converted to exception
+		if ($info === false) {
+			throw new OpenSslException();
+		}
+		return $info;
+	}
+
+}

--- a/site/bin/certmonitor.php
+++ b/site/bin/certmonitor.php
@@ -1,0 +1,18 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Bin;
+
+use MichalSpacekCz\Application\Bootstrap;
+use MichalSpacekCz\Tls\CertificateMonitor;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$siteDir = realpath(__DIR__ . '/..');
+require $siteDir . '/vendor/autoload.php';
+
+$bootstrap = new Bootstrap($siteDir);
+/** @var CertificateMonitor $certificateMonitor */
+$certificateMonitor = $bootstrap->bootCli()->getByType(CertificateMonitor::class);
+$certificateMonitor->run();

--- a/site/composer.json
+++ b/site/composer.json
@@ -10,6 +10,7 @@
 		"ext-intl": "*",
 		"ext-libxml": "*",
 		"ext-mbstring": "*",
+		"ext-openssl": "*",
 		"ext-pdo": "*",
 		"ext-simplexml": "*",
 		"contributte/translation": "^0.9.0",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6a0f9f49f46e6d65ef8e9de80da1cd11",
+    "content-hash": "1932cf0fff1158ab8168fb3f74e2aa1c",
     "packages": [
         {
             "name": "contributte/translation",
@@ -3862,6 +3862,7 @@
         "ext-intl": "*",
         "ext-libxml": "*",
         "ext-mbstring": "*",
+        "ext-openssl": "*",
         "ext-pdo": "*",
         "ext-simplexml": "*"
     },

--- a/site/config/extra-cli-debug.neon
+++ b/site/config/extra-cli-debug.neon
@@ -1,0 +1,2 @@
+includes:
+	- extra-michalspacek.cz.test.neon

--- a/site/config/extra-cli.neon
+++ b/site/config/extra-cli.neon
@@ -1,0 +1,2 @@
+includes:
+	- extra-michalspacek.cz.neon

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -1,4 +1,6 @@
 services:
+	webApplication: MichalSpacekCz\Application\WebApplication(fqdn: %domain.fqdn%)
+	application: Nette\Application\Application
 	routerFactory:
 		factory: MichalSpacekCz\Application\RouterFactory
 		setup:

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -108,7 +108,7 @@ services:
 	blogPostLoader: MichalSpacekCz\Post\Loader
 	blogPostLocaleUrls: MichalSpacekCz\Post\LocaleUrls
 	certificatesApi:
-		factory: MichalSpacekCz\Http\Certificates
+		factory: MichalSpacekCz\Tls\Certificates
 		setup:
 			- setUsers(%certificatesApi.users%)
 			- setExpiringThreshold(%certificatesApi.expiringThreshold%)

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -18,6 +18,7 @@ services:
 			- setLocationRoot(%domain.locationRoot%)
 	latte.templateFactory: MichalSpacekCz\Templating\TemplateFactory
 	redirections: MichalSpacekCz\Http\Redirections
+	httpStreamContext: MichalSpacekCz\Http\HttpStreamContext
 	articles: MichalSpacekCz\Articles\Articles
 	talks:
 		factory: MichalSpacekCz\Talks\Talks
@@ -113,8 +114,11 @@ services:
 		factory: MichalSpacekCz\Tls\Certificates
 		setup:
 			- setUsers(%certificatesApi.users%)
-			- setExpiringThreshold(%certificatesApi.expiringThreshold%)
 			- setHideExpiredAfter(%certificatesApi.hideExpiredAfter%)
+	certificatesApiClient: MichalSpacekCz\Tls\CertificatesApiClient
+	certificateGatherer: MichalSpacekCz\Tls\CertificateGatherer
+	certificateMonitor: MichalSpacekCz\Tls\CertificateMonitor
+	certificateFactory: MichalSpacekCz\Tls\CertificateFactory(expiringThreshold: %certificatesApi.expiringThreshold%)
 	exports: MichalSpacekCz\Feed\Exports
 	strings: MichalSpacekCz\Utils\Strings
 	error: MichalSpacekCz\Application\Error
@@ -126,6 +130,7 @@ services:
 	netteCve202015227: MichalSpacekCz\EasterEgg\NetteCve202015227
 	formSpam: MichalSpacekCz\Training\FormSpam
 	formDataLogger: MichalSpacekCz\Training\FormDataLogger
+	consoleColor: JakubOnderka\PhpConsoleColor\ConsoleColor
 
 	- MichalSpacekCz\Form\FormFactory
 	- MichalSpacekCz\Form\UnprotectedFormFactory

--- a/site/public/www.michalspacek.cz/app.php
+++ b/site/public/www.michalspacek.cz/app.php
@@ -2,6 +2,7 @@
 declare(strict_types = 1);
 
 use MichalSpacekCz\Application\Bootstrap;
+use MichalSpacekCz\Application\WebApplication;
 
 if (file_exists('./maintenance.php')) {
 	require 'maintenance.php';
@@ -9,11 +10,6 @@ if (file_exists('./maintenance.php')) {
 
 $siteDir = realpath(__DIR__ . '/../..');
 require $siteDir . '/vendor/autoload.php';
-require $siteDir . '/app/Application/Bootstrap.php';
 
-$logDir = $siteDir . '/log';
-$tempDir = $siteDir . '/temp';
-$environment = (isset($_SERVER['ENVIRONMENT']) ? $_SERVER['ENVIRONMENT'] : null);
-
-$bootstrap = new Bootstrap($siteDir, $logDir, $tempDir, $environment, 'Europe/Prague');
-$bootstrap->run();
+$bootstrap = new Bootstrap($siteDir);
+$bootstrap->boot()->getByType(WebApplication::class)->run();

--- a/site/tests/Tls/CertificateFactoryTest.phpt
+++ b/site/tests/Tls/CertificateFactoryTest.phpt
@@ -1,0 +1,43 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Tls;
+
+use DateTimeImmutable;
+use Nette\Utils\Json;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class CertificateFactoryTest extends TestCase
+{
+
+	private CertificateFactory $certificateFactory;
+
+
+	public function setUp()
+	{
+		$this->certificateFactory = new CertificateFactory(3);
+	}
+
+
+	public function testFromArray(): void
+	{
+		$certificate = new Certificate(
+			'cn',
+			'cn-ext',
+			new DateTimeImmutable('-2 weeks'),
+			new DateTimeImmutable('+3 weeks'),
+			3,
+			'CafeCe37',
+		);
+		$array = Json::decode(Json::encode($certificate), Json::FORCE_ARRAY);
+		Assert::equal($certificate, $this->certificateFactory->fromArray($array));
+	}
+
+}
+
+(new CertificateFactoryTest())->run();

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => '86e1c9bb65b7456dfef9779eccdb9eecc86c34f9',
+        'reference' => 'cf9be21e9dedcd1537709b6b0c43e5d663f1281b',
         'name' => 'spaze/michalspacek.cz',
         'dev' => true,
     ),
@@ -393,7 +393,7 @@
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => '86e1c9bb65b7456dfef9779eccdb9eecc86c34f9',
+            'reference' => 'cf9be21e9dedcd1537709b6b0c43e5d663f1281b',
             'dev_requirement' => false,
         ),
         'spaze/mysql-session-handler' => array(


### PR DESCRIPTION
Will fetch a list of hostnames/certificates previously logged by [letsgetacert](https://github.com/spaze/letsgetacert)'s hook
- and fetch certificates from these hosts
- and check expiration dates
- and fail if any of the certs expires soon
- or the expiration date doesn't match the date of the logged cert
- which would indicate the certificate wasn't deployed, only issued

The `bin/certmonitor.php` script is intended to be used with GitHub Actions, authenticated by env vars/repo secrets [`CERTMONITOR_USER`](https://github.com/spaze/michalspacek.cz/settings/secrets/actions/CERTMONITOR_USER) & [`CERTMONITOR_KEY`](https://github.com/spaze/michalspacek.cz/settings/secrets/actions/CERTMONITOR_KEY).

Or is it *SSL*?