### PR TITLE
php-console-color required

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -27,6 +27,7 @@
 		"nette/security": "~3.1.4",
 		"nette/utils": "~3.0",
 		"paragonie/halite": "^4",
+		"php-parallel-lint/php-console-color": "^0.3",
 		"spaze/csp-config": "^2.1",
 		"spaze/encryption": "^0.4",
 		"spaze/feed-exports": "~0.2",
@@ -49,7 +50,6 @@
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"nette/tester": "^2.0",
-		"php-parallel-lint/php-console-color": "^0.3",
 		"php-parallel-lint/php-console-highlighter": "^0.5.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
 		"phpstan/phpdoc-parser": "^1.2",

--- a/site/composer.json
+++ b/site/composer.json
@@ -64,7 +64,10 @@
 		"squizlabs/php_codesniffer": "^3.5"
 	},
 	"config": {
-		"sort-packages": true
+		"sort-packages": true,
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	},
 	"autoload": {
 		"psr-4": {

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1932cf0fff1158ab8168fb3f74e2aa1c",
+    "content-hash": "035c04fbcb67c5536523f1e164b489e8",
     "packages": [
         {
             "name": "contributte/translation",
@@ -1674,6 +1674,55 @@
             "time": "2020-12-06T15:07:44+00:00"
         },
         {
+            "name": "php-parallel-lint/php-console-color",
+            "version": "v0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-parallel-lint/PHP-Console-Color.git",
+                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/b6af326b2088f1ad3b264696c9fd590ec395b49e",
+                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4.0"
+            },
+            "replace": {
+                "jakub-onderka/php-console-color": "*"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-code-style": "1.0",
+                "php-parallel-lint/php-parallel-lint": "1.0",
+                "php-parallel-lint/php-var-dump-check": "0.*",
+                "phpunit/phpunit": "~4.3",
+                "squizlabs/php_codesniffer": "1.*"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "JakubOnderka\\PhpConsoleColor\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Jakub Onderka",
+                    "email": "jakub.onderka@gmail.com"
+                }
+            ],
+            "support": {
+                "issues": "https://github.com/php-parallel-lint/PHP-Console-Color/issues",
+                "source": "https://github.com/php-parallel-lint/PHP-Console-Color/tree/master"
+            },
+            "time": "2020-05-14T05:47:14+00:00"
+        },
+        {
             "name": "phpstan/phpdoc-parser",
             "version": "1.2.0",
             "source": {
@@ -2984,55 +3033,6 @@
             "time": "2021-08-24T14:13:00+00:00"
         },
         {
-            "name": "php-parallel-lint/php-console-color",
-            "version": "v0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-parallel-lint/PHP-Console-Color.git",
-                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-parallel-lint/PHP-Console-Color/zipball/b6af326b2088f1ad3b264696c9fd590ec395b49e",
-                "reference": "b6af326b2088f1ad3b264696c9fd590ec395b49e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4.0"
-            },
-            "replace": {
-                "jakub-onderka/php-console-color": "*"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-code-style": "1.0",
-                "php-parallel-lint/php-parallel-lint": "1.0",
-                "php-parallel-lint/php-var-dump-check": "0.*",
-                "phpunit/phpunit": "~4.3",
-                "squizlabs/php_codesniffer": "1.*"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "JakubOnderka\\PhpConsoleColor\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-2-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Jakub Onderka",
-                    "email": "jakub.onderka@gmail.com"
-                }
-            ],
-            "support": {
-                "issues": "https://github.com/php-parallel-lint/PHP-Console-Color/issues",
-                "source": "https://github.com/php-parallel-lint/PHP-Console-Color/tree/master"
-            },
-            "time": "2020-05-14T05:47:14+00:00"
-        },
-        {
             "name": "php-parallel-lint/php-console-highlighter",
             "version": "v0.5",
             "source": {
@@ -3867,5 +3867,5 @@
         "ext-simplexml": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/site/vendor/composer/ClassLoader.php
+++ b/site/vendor/composer/ClassLoader.php
@@ -149,7 +149,7 @@ class ClassLoader
 
     /**
      * @return string[] Array of classname => path
-     * @psalm-var array<string, string>
+     * @psalm-return array<string, string>
      */
     public function getClassMap()
     {

--- a/site/vendor/composer/autoload_real.php
+++ b/site/vendor/composer/autoload_real.php
@@ -65,11 +65,16 @@ class ComposerAutoloaderInit247de957f14f643f393d210a332dd05b
     }
 }
 
+/**
+ * @param string $fileIdentifier
+ * @param string $file
+ * @return void
+ */
 function composerRequire247de957f14f643f393d210a332dd05b($fileIdentifier, $file)
 {
     if (empty($GLOBALS['__composer_autoload_files'][$fileIdentifier])) {
-        require $file;
-
         $GLOBALS['__composer_autoload_files'][$fileIdentifier] = true;
+
+        require $file;
     }
 }

--- a/site/vendor/composer/installed.json
+++ b/site/vendor/composer/installed.json
@@ -3968,7 +3968,6 @@
     "dev": true,
     "dev-package-names": [
         "nette/tester",
-        "php-parallel-lint/php-console-color",
         "php-parallel-lint/php-console-highlighter",
         "php-parallel-lint/php-parallel-lint",
         "phpstan/phpstan",

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -5,7 +5,7 @@
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
-        'reference' => 'cf9be21e9dedcd1537709b6b0c43e5d663f1281b',
+        'reference' => '4580d1115948b321d81e86f3866021b822e5cb09',
         'name' => 'spaze/michalspacek.cz',
         'dev' => true,
     ),
@@ -41,7 +41,7 @@
             ),
         ),
         'jakub-onderka/php-console-color' => array(
-            'dev_requirement' => true,
+            'dev_requirement' => false,
             'replaced' => array(
                 0 => '*',
             ),
@@ -275,7 +275,7 @@
             'install_path' => __DIR__ . '/../php-parallel-lint/php-console-color',
             'aliases' => array(),
             'reference' => 'b6af326b2088f1ad3b264696c9fd590ec395b49e',
-            'dev_requirement' => true,
+            'dev_requirement' => false,
         ),
         'php-parallel-lint/php-console-highlighter' => array(
             'pretty_version' => 'v0.5',
@@ -393,7 +393,7 @@
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
-            'reference' => 'cf9be21e9dedcd1537709b6b0c43e5d663f1281b',
+            'reference' => '4580d1115948b321d81e86f3866021b822e5cb09',
             'dev_requirement' => false,
         ),
         'spaze/mysql-session-handler' => array(


### PR DESCRIPTION
Required by #12 for normal non-dev operations too and must be in `require`, not in `require-dev` otherwise it gets deleted by [stupid-git-deploy](https://github.com/spaze/stupid-git-deploy).