### PR TITLE
Certmonitor, correct JSON field, always colors

### DIFF
--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -55,7 +55,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
-      - run: php site/bin/certmonitor.php
+      - run: php site/bin/certmonitor.php --colors
         env:
           CERTMONITOR_USER: ${{ secrets.CERTMONITOR_USER }}
           CERTMONITOR_KEY: ${{ secrets.CERTMONITOR_KEY }}

--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application;
 
+use JakubOnderka\PhpConsoleColor\ConsoleColor;
 use Nette\Bootstrap\Configurator;
 use Nette\DI\Container;
 use Nette\Utils\Arrays;
@@ -32,10 +33,14 @@ class Bootstrap
 	{
 		$_SERVER['HTTPS'] = 'on';
 		$debugMode = ($_SERVER['PHP_CLI_ENVIRONMENT'] ?? null) === self::MODE_DEVELOPMENT || Arrays::contains($_SERVER['argv'], '--debug');
-		return $this->createConfigurator(
+		$container = $this->createConfigurator(
 			$debugMode,
 			$this->siteDir . '/config/' . ($debugMode ? 'extra-cli-debug.neon' : 'extra-cli.neon'),
 		)->createContainer();
+		if (Arrays::contains($_SERVER['argv'], '--colors')) {
+			$container->getByType(ConsoleColor::class)->setForceStyle(true);
+		}
+		return $container;
 	}
 
 

--- a/site/app/Tls/CertificatesApiClient.php
+++ b/site/app/Tls/CertificatesApiClient.php
@@ -59,7 +59,10 @@ class CertificatesApiClient
 		if (!isset($decoded['certificates'])) {
 			throw new CertificatesApiException(sprintf('Decoded response from %s (`%s`) has no field `certificates`', $url, $json));
 		}
-		foreach ($decoded as $details) {
+		if (!is_array($decoded['certificates'])) {
+			throw new CertificatesApiException(sprintf("Response from %s (`%s`) has `certificates` but it's not an array", $url, $json));
+		}
+		foreach ($decoded['certificates'] as $details) {
 			$certificates[] = $this->certificateFactory->fromArray($details);
 		}
 		return $certificates;


### PR DESCRIPTION
- Certs are in `certificates` field in the API response  (#14 commit 2b0c36fc47b1f554ae27a5995ee87e76a17000fb)
- Force colors when running in GitHub Actions

Required for #12.