### PR TITLE
Don't gzip HTTP 304s, they have no response bodies anyway

### DIFF
--- a/site/app/Www/Presenters/BasePresenter.php
+++ b/site/app/Www/Presenters/BasePresenter.php
@@ -138,4 +138,15 @@ abstract class BasePresenter extends Presenter
 		$this->redirectPermanent('this');
 	}
 
+
+	/** @inheritDoc */
+	public function lastModified($lastModified, string $etag = null, string $expire = null): void
+	{
+		$compression = ini_get('zlib.output_compression');
+		ini_set('zlib.output_compression', false);
+		parent::lastModified($lastModified, $etag, $expire);
+		// If the response was HTTP 304 then the following line won't be reached and 304s won't be compressed
+		ini_set('zlib.output_compression', $compression);
+	}
+
 }

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -2,6 +2,11 @@ parameters:
 	paths:
 		- app
 	level: 7
+	ignoreErrors:
+		- # https://github.com/phpstan/phpstan-src/pull/898
+			message: '#^Parameter \#2 \$value of function ini_set expects string,#'
+			path: app/Www/Presenters/BasePresenter.php
+			count: 2
 
 includes:
 	- vendor/phpstan/phpstan-nette/extension.neon


### PR DESCRIPTION
But compressing all responses including 304s, makes nginx log "upstream sent more data than specified in "Content-Length" header while reading upstream". Compression is re-enabled only if the AbortException wasn't thrown in \Nette\Application\UI\Presenter::lastModified.

Fix #16 (this feels like the best fix because to me it seems like an nginx issue though I may be wrong)