### PR TITLE
No IPv6 for old men (and for Cert monitor_

### DIFF
--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
-      - run: php site/bin/certmonitor.php --colors
+      - run: php site/bin/certmonitor.php --colors --no-ipv6
         env:
           CERTMONITOR_USER: ${{ secrets.CERTMONITOR_USER }}
           CERTMONITOR_KEY: ${{ secrets.CERTMONITOR_KEY }}

--- a/site/app/Tls/CertificateGatherer.php
+++ b/site/app/Tls/CertificateGatherer.php
@@ -23,16 +23,17 @@ class CertificateGatherer
 
 	/**
 	 * @param string $hostname
+	 * @param bool $includeIpv6
 	 * @return array<string, Certificate>
 	 * @throws CannotParseDateTimeException
 	 * @throws CertificateException
 	 * @throws OpenSslException
 	 * @throws DnsGetRecordException
 	 */
-	public function fetchCertificates(string $hostname): array
+	public function fetchCertificates(string $hostname, bool $includeIpv6): array
 	{
 		$certificates = [];
-		$records = $this->dnsResolver->getRecords($hostname, DNS_A | DNS_AAAA);
+		$records = $this->dnsResolver->getRecords($hostname, $includeIpv6 ? DNS_A | DNS_AAAA : DNS_A);
 		foreach ($records as $record) {
 			$certificates[$record->getIpv6() ?? $record->getIp()] = $this->fetchCertificate($hostname, $record->getIp() ?? null, $record->getIpv6() ?? null);
 		}

--- a/site/app/Tls/CertificateMonitor.php
+++ b/site/app/Tls/CertificateMonitor.php
@@ -20,12 +20,12 @@ class CertificateMonitor
 	}
 
 
-	public function run(): never
+	public function run(bool $includeIpv6): never
 	{
 		try {
 			// Not running in parallel because those sites are hosted on just a few tiny servers
 			foreach ($this->certificatesApiClient->getLoggedCertificates() as $loggedCertificate) {
-				$this->compareCertificates($loggedCertificate, $this->certificateGatherer->fetchCertificates($loggedCertificate->getCommonName()));
+				$this->compareCertificates($loggedCertificate, $this->certificateGatherer->fetchCertificates($loggedCertificate->getCommonName(), $includeIpv6));
 			}
 			exit($this->hasErrors ? 1 : 0);
 		} catch (Exception $e) {

--- a/site/bin/certmonitor.php
+++ b/site/bin/certmonitor.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Bin;
 
 use MichalSpacekCz\Application\Bootstrap;
 use MichalSpacekCz\Tls\CertificateMonitor;
+use Nette\Utils\Arrays;
 
 require __DIR__ . '/../vendor/autoload.php';
 
@@ -15,4 +16,4 @@ require $siteDir . '/vendor/autoload.php';
 $bootstrap = new Bootstrap($siteDir);
 /** @var CertificateMonitor $certificateMonitor */
 $certificateMonitor = $bootstrap->bootCli()->getByType(CertificateMonitor::class);
-$certificateMonitor->run();
+$certificateMonitor->run(!Arrays::contains($_SERVER['argv'], '--no-ipv6'));


### PR DESCRIPTION
Don't certmonitor IPv6 addresses . Because it seems GitHub Actions don't support IPv6 actions/virtual-environments#668

But that's fine because although my sites run on IPv6 too, they all run the same TLS config on both IPv4 and IPv6.

Ref #12