### PR TITLE
Remove indirect/"second row" dev dependencies from `composer.json`

### DIFF
--- a/site/composer.json
+++ b/site/composer.json
@@ -49,19 +49,16 @@
 		"symfony/polyfill-php81": "*"
 	},
 	"require-dev": {
-		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
 		"nette/tester": "^2.0",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.2",
-		"phpstan/phpdoc-parser": "^1.2",
 		"phpstan/phpstan": "^1.0",
 		"phpstan/phpstan-deprecation-rules": "^1.0",
 		"phpstan/phpstan-nette": "^1.0",
 		"roave/security-advisories": "dev-latest",
 		"spaze/coding-standard": "^1.1",
 		"spaze/phpstan-disallowed-calls": "^2.0",
-		"spaze/phpstan-disallowed-calls-nette": "^2.0",
-		"squizlabs/php_codesniffer": "^3.5"
+		"spaze/phpstan-disallowed-calls-nette": "^2.0"
 	},
 	"config": {
 		"sort-packages": true,

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2ff454915478e2bfc94f443e1a8f39d2",
+    "content-hash": "ac9b6c05446e36f891cd332779f4f0c7",
     "packages": [
         {
             "name": "contributte/translation",

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-master',
         'version' => 'dev-master',
-        'reference' => '80113413e709bdd39fd21cdd81a08d6ded34f1ce',
+        'reference' => 'e84ac86aa45060cd5c64a120f3efdd43bf47d23d',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -390,7 +390,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-master',
             'version' => 'dev-master',
-            'reference' => '80113413e709bdd39fd21cdd81a08d6ded34f1ce',
+            'reference' => 'e84ac86aa45060cd5c64a120f3efdd43bf47d23d',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Reverts part of #4, the dev dependencies would be deleted based on their presence in `installed.php`. not `composer.json`, by https://github.com/spaze/stupid-git-deploy/pull/2