### PR TITLE
Test the DI container is built correctly in Bootstrap

### DIFF
--- a/site/tests/Application/BootstrapTest.phpt
+++ b/site/tests/Application/BootstrapTest.phpt
@@ -1,0 +1,72 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use Nette\DI\Container;
+use Tester\Assert;
+use Tester\TestCase;
+use Tracy\ILogger;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class BootstrapTest extends TestCase
+{
+
+	private const SITE_DIR = __DIR__ . '/../..';
+	private const EXCEPTION_LOG = self::SITE_DIR . '/log/' . ILogger::EXCEPTION . '.log';
+	private ?string $tempLog = null;
+
+
+	public function __construct()
+	{
+		if (file_exists(self::EXCEPTION_LOG)) {
+			$this->tempLog = self::EXCEPTION_LOG . '.' . uniqid(more_entropy: true);
+			rename(self::EXCEPTION_LOG, $this->tempLog);
+		}
+		$_SERVER['SERVER_NAME'] = 'michalspacek.cz';
+	}
+
+
+	public function __destruct()
+	{
+		if (file_exists(self::EXCEPTION_LOG)) {
+			echo file_get_contents(self::EXCEPTION_LOG);
+			unlink(self::EXCEPTION_LOG);
+		}
+		if ($this->tempLog && file_exists($this->tempLog)) {
+			rename($this->tempLog, self::EXCEPTION_LOG);
+		}
+	}
+
+
+	public function getBootEnvironments(): array
+	{
+		return [
+			'production' => [
+				'environment' => null,
+			],
+			'development' => [
+				'environment' => 'development',
+			],
+		];
+	}
+
+
+	/** @dataProvider getBootEnvironments */
+	public function testBoot(?string $environment): void
+	{
+		if ($environment !== null) {
+			$_SERVER['ENVIRONMENT'] = $environment;
+		}
+		Assert::noError(function () use (&$container): void {
+			$container = (new Bootstrap(self::SITE_DIR))->boot();
+		});
+		Assert::type(Container::class, $container);
+	}
+
+}
+
+(new BootstrapTest())->run();

--- a/site/tests/php-unix.ini
+++ b/site/tests/php-unix.ini
@@ -2,7 +2,9 @@
 extension=ctype.so
 extension=iconv.so
 extension=intl.so
+extension=mbstring.so
 extension=pcov.so
+extension=pdo.so
 extension=simplexml.so
 extension=tokenizer.so
 extension=xmlwriter.so


### PR DESCRIPTION
I'm still not fully convinced whether this is a good idea or whether the test makes sense and/or is written correctly, but let's see.

This is an [example of a failing test](https://github.com/spaze/michalspacek.cz/runs/7660844853?check_suite_focus=true):

```
Run composer --working-dir=site tester
> vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/
 _____ ___  ___ _____ ___  ___
|_   _/ __)( __/_   _/ __)| _ )
  |_| \___ /___) |_| \___ |_|_\  v2.4.2

Code coverage by PCOV: /home/runner/work/michalspacek.cz/michalspacek.cz/site/temp/coverage.html
PHP 8.1.8 (cli) | php -n -c /home/runner/work/michalspacek.cz/michalspacek.cz/site/tests/php-unix.ini -d pcov.directory=/home/runner/work/michalspacek.cz/michalspacek.cz/site/app | 8 threads

.................................F

-- FAILED: Application/BootstrapTest.phpt
   Exited with error code 255 (expected 0)
   [2022-08-03 22-57-50] Nette\InvalidArgumentException: Missing parameter 'loadCompanyDataVisible'. in /home/runner/work/michalspacek.cz/michalspacek.cz/site/vendor/nette/di/src/DI/Helpers.php:80  @  CLI (PID: 1620): /home/runner/work/michalspacek.cz/michalspacek.cz/site/tests/Application/BootstrapTest.phpt  @@  exception--2022-08-03--22-57--2df17101b5.html


FAILURES! (34 tests, 1 failure, 0.7 seconds)
Generating code coverage report... 11% covered
Script vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/ handling the tester event returned with error code 1
Error: Process completed with exit code 1.
```