### PR TITLE
Set `wwwDir` param for tests, too

### DIFF
--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -42,7 +42,11 @@ class Bootstrap
 
 	public static function bootTest(): Container
 	{
-		$container = self::createConfigurator(true, self::SITE_DIR . '/config/tests.neon')->createContainer();
+		$configurator = self::createConfigurator(true, self::SITE_DIR . '/config/tests.neon');
+		$configurator->addStaticParameters([
+			'wwwDir' => self::SITE_DIR . '/tests',
+		]);
+		$container = $configurator->createContainer();
 		Environment::setup();
 		return $container;
 	}


### PR DESCRIPTION
If not set, the default is used and the default is calculated as a directory in which the executed test file is stored. So the `wwwDir` is different for each test file executed which results in many containers (one per dir) being created when running the full test suite which slows it down.

Follow-up to #27