### PR TITLE
Use v3 of Symfony Security Checker

### DIFF
--- a/.github/workflows/composer-vulns.yml
+++ b/.github/workflows/composer-vulns.yml
@@ -15,7 +15,7 @@ jobs:
       with:
           path: ~/.symfony/cache
           key: db
-    - uses: symfonycorp/security-checker-action@v2
+    - uses: symfonycorp/security-checker-action@v3
       with:
           lock: site/composer.lock
 


### PR DESCRIPTION
There's a v3 tag not a release (only v2 release) and so the GitHub Actions page offers v2 only and I noticed only now

- The tag: https://github.com/symfonycorp/security-checker-action/releases/tag/v3
- Symfony issue https://github.com/symfonycorp/security-checker-action/issues/6

v2 [stopped working](https://github.com/spaze/michalspacek.cz/runs/8140472020?check_suite_focus=true) due to

> Error response from daemon: pull access denied for symfonycorp/cli, repository does not exist or may require 'docker login': denied: requested access to the resource is denied