### PR TITLE
spaze/security-txt got IPv6 support, unlike GitHub Actions

### DIFF
--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -33,4 +33,5 @@ jobs:
         ${{ matrix.host }} \
         10 \
         --colors \
+        --no-ipv6 \
         --strict


### PR DESCRIPTION
The IPv6 support https://github.com/spaze/security-txt/issues/2
Had to do something similar for certmonitor in 5c9cbcddeb12a2acf21bce0e779c5cc96af469aa