### PR TITLE
GitHub Actions actions upgrade

### DIFF
--- a/.github/workflows/composer-vulns.yml
+++ b/.github/workflows/composer-vulns.yml
@@ -9,8 +9,8 @@ jobs:
   composer-vulnz:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/cache@v2
+    - uses: actions/checkout@v3
+    - uses: actions/cache@v3
       id: cache-db
       with:
           path: ~/.symfony/cache
@@ -22,5 +22,5 @@ jobs:
   composer-audit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: composer --working-dir=site audit

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -84,7 +84,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get PHP_CodeSniffer cache file pattern
       id: phpcs-cache
-      run: echo "::set-output name=file::$(php -r "echo sys_get_temp_dir() . '/phpcs.*';")"
+      run: echo "file=$(php -r "echo sys_get_temp_dir() . '/phpcs.*';")" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       with:
         path: ${{ steps.phpcs-cache.outputs.file }}
@@ -102,7 +102,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get PHPStan result cache directory
       id: phpstan-cache
-      run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
+      run: echo "dir=$(php -r "echo sys_get_temp_dir() . '/phpstan';")" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}
@@ -120,7 +120,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Get PHPStan result cache directory
       id: phpstan-cache
-      run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
+      run: echo "dir=$(php -r "echo sys_get_temp_dir() . '/phpstan';")" >> $GITHUB_OUTPUT
     - uses: actions/cache@v3
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -25,7 +25,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Validate composer.json and composer.lock
       run: composer --working-dir=site validate
 
@@ -36,7 +36,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - run: composer --working-dir=site check-file-patterns
 
@@ -48,7 +48,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - run: composer --working-dir=site lint
 
@@ -59,7 +59,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - run: composer --working-dir=site lint-latte
 
@@ -70,7 +70,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - run: composer --working-dir=site lint-neon
 
@@ -81,11 +81,11 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get PHP_CodeSniffer cache file pattern
       id: phpcs-cache
       run: echo "::set-output name=file::$(php -r "echo sys_get_temp_dir() . '/phpcs.*';")"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ${{ steps.phpcs-cache.outputs.file }}
         key: phpcs-cache-php${{ matrix.php-version }}
@@ -99,11 +99,11 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get PHPStan result cache directory
       id: phpstan-cache
       run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}
         key: phpstan-cache-php${{ matrix.php-version }}
@@ -117,11 +117,11 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Get PHPStan result cache directory
       id: phpstan-cache
       run: echo "::set-output name=dir::$(php -r "echo sys_get_temp_dir() . '/phpstan';")"
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}
         key: phpstan-vendor-cache-php${{ matrix.php-version }}
@@ -135,14 +135,14 @@ jobs:
         php-version:
           - "8.1"
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
     - run: composer --working-dir=site tester
     - name: Failed test output, if any
       if: failure()
       run: for i in $(find ./site/tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
     - name: Upload test code coverage
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       if: success()
       with:
         name: Test code coverage (PHP ${{ matrix.php-version }})

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -52,7 +52,7 @@ jobs:
         php-version:
           - "8.1"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
       - run: php site/bin/certmonitor.php --colors --no-ipv6
         env:


### PR DESCRIPTION
1. Upgrade to `@v3` actions to use Node.js 16 and remove deprecation warnings about Node.js 12, see [docs](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/).
2. Replace `::set-output` in `phpstan` and `phpcs` jobs with environment file, see [docs](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/).

Fix #37