### PR TITLE
Remove `Expect-CT` header

### DIFF
--- a/docs/nginx/common-https.conf
+++ b/docs/nginx/common-https.conf
@@ -3,4 +3,3 @@ include /etc/common-config/nginx/https.conf;
 server_tokens off;
 
 add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
-add_header Expect-CT 'max-age=0, report-uri="https://plz.report-uri.com/r/d/ct/reportOnly"' always;


### PR DESCRIPTION
Chrome was the only browser that has supported the header, and it has dropped its support now in 107:
- https://chromestatus.com/feature/6244547273687040
- https://chromium.googlesource.com/devtools/devtools-frontend.git/+/c7b92aac4dcb53c59d056711e75b80a6949ae87e%5E%21/

Close #33