### PR TITLE
Setup PHP 8.2 with the setup-php action

### DIFF
--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -17,8 +17,10 @@ jobs:
           - www.michalspacek.com
           - upcwifikeys.com
     steps:
-    - name: Set PHP version
-      run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+    - uses: shivammathur/setup-php@v2
+      with:
+        coverage: none
+        php-version: ${{ matrix.php-version }}
     - name: Install ext-gnupg
       run: |
         sudo add-apt-repository ppa:ondrej/php

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -53,7 +53,10 @@ jobs:
           - "8.2"
     steps:
       - uses: actions/checkout@v3
-      - run: sudo update-alternatives --set php /usr/bin/php${{ matrix.php-version }}
+      - uses: shivammathur/setup-php@v2
+        with:
+          coverage: none
+          php-version: ${{ matrix.php-version }}
       - run: php site/bin/certmonitor.php --colors --no-ipv6
         env:
           CERTMONITOR_USER: ${{ secrets.CERTMONITOR_USER }}


### PR DESCRIPTION
PHP 8.2 is not available in Ubuntu (yet, not even sure whether and if it will ever be in `ubuntu-latest`) so can't be setup with `update-alternatives`.

Followup to #58
For #53