### PR TITLE
Use pcov for code coverage for tester

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -164,7 +164,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: shivammathur/setup-php@v2
       with:
-        coverage: none
+        coverage: pcov
         php-version: ${{ matrix.php-version }}
     - run: composer --working-dir=site tester
     - name: Failed test output, if any


### PR DESCRIPTION
This [option](https://github.com/shivammathur/setup-php/#signal_strength-coverage-support) might not be intended for Tester directly but indirectly it may work by installing the pcov extension.

Follow-up to #49