### PR TITLE
I think I can just stop using nette/robot-loader and use Composer autoloader only

### DIFF
--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -81,10 +81,6 @@ class Bootstrap
 		$configurator->setTimeZone('Europe/Prague');
 		$configurator->setTempDirectory(self::SITE_DIR . '/temp');
 
-		$configurator->createRobotLoader()
-			->addDirectory(self::SITE_DIR . '/app')
-			->register();
-
 		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig), function ($path) {
 			return is_file($path);
 		});

--- a/site/composer.json
+++ b/site/composer.json
@@ -25,7 +25,6 @@
 		"nette/http": "^3.1.6",
 		"nette/mail": "^3.1.8",
 		"nette/neon": "^3.3.3",
-		"nette/robot-loader": "^3.4.1",
 		"nette/security": "~3.1.4",
 		"nette/utils": "^3.2.8",
 		"paragonie/halite": "^5.1",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d1dde5c2d3bab602fce0e77f97501dd1",
+    "content-hash": "5607fe752c617ed77e6f2011baf19e8a",
     "packages": [
         {
             "name": "contributte/translation",

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'b2bd78cdf20007c6cd61846bcff9f8321a4a6bf4',
+        'reference' => '9c28fa13aa887bda6d362194707ed77cd53759e5',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -429,7 +429,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'b2bd78cdf20007c6cd61846bcff9f8321a4a6bf4',
+            'reference' => '9c28fa13aa887bda6d362194707ed77cd53759e5',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Removing it mostly because of https://github.com/efabrica-team/phpstan-latte/issues/229 (and because I don't need it, of course). It's still required by nette/di so the package itself stays.