### PR TITLE
Add Gitleaks config

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,43 @@
+[extend]
+useDefault = true  # The default config file is https://github.com/zricethezav/gitleaks/blob/master/config/gitleaks.toml
+
+[[rules]]
+# This is the same as the "Generic API Key" rule from the default config file except
+# it has a lower entropy and adds a few more keywords to both the "regex" and "keywords" fields
+description = "Generic API Key, with extra keywords and lower entropy"
+id = "generic-api-key-extra-keywords"
+regex = '''(?i)(?:key|api|token|secret|client|passwd|password|auth|access|dev|prod)(?:[0-9a-z\-_\t .]{0,20})(?:[\s|']|[\s|"]){0,3}(?:=|>|:=|\|\|:|<=|=>|:)(?:'|\"|\s|=|\x60){0,5}([0-9a-z\-_.=]{10,150})(?:['|\"|\n|\r|\s|\x60|;]|$)'''
+secretGroup = 1
+entropy = 3
+keywords = [
+  "key",
+  "api",
+  "token",
+  "secret",
+  "client",
+  "passwd",
+  "password",
+  "auth",
+  "access",
+  "dev",
+  "prod",
+]
+
+[rules.allowlist]
+stopwords = [
+  # Database column names
+  '''_talk''',
+  '''_status''',
+  '''_training''',
+]
+
+[allowlist]
+paths = [
+  '''js/openpgp\.min\.js''',
+  # Paths otherwise .gitignored should be listed here if you want to run with --no-git
+  '''i/build/''',
+  '''site/config/local.*\.neon''',
+  '''site/config/remote.*\.neon''',
+  '''site/temp/cache/''',
+]
+

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,7 @@
+1f0e722ad88cdb93a7e575ffa71ddcc8b96ec15b:app/config/config.neon:generic-api-key-extra-keywords:45
+27ed639a3be060b650357bad58c675925d00adeb:site/app/config/config.local.template.neon:generic-api-key-extra-keywords:26
+4eea8b8b4a748558fc9d148e870c046e70f02e93:site/app/config/config.local.template.neon:generic-api-key-extra-keywords:69
+4eea8b8b4a748558fc9d148e870c046e70f02e93:site/app/config/config.local.template.neon:generic-api-key-extra-keywords:71
+4eea8b8b4a748558fc9d148e870c046e70f02e93:site/app/config/config.local.template.neon:generic-api-key-extra-keywords:73
+8e2f5d8924f633825fdd9e83431ac83166fb2ba4:site/app/config/config.local.template.neon:generic-api-key-extra-keywords:80
+bcedeb91aedc5501ee37ef6e71e0abe5ec5f8622:app/config/config.neon:generic-api-key-extra-keywords:37


### PR DESCRIPTION
This adds custom config for the Gitleaks action added in #73. Currently, the action uses slightly older version of Gitleaks so there might be some differences in what it detects.

The new "generic-api-key-extra-keywords" rule is the same as the "Generic API Key" rule from the default config file except it has a lower entropy and adds a few more keywords ("dev", "prod") to both the "regex" and "keywords" fields.

`.gitleaksignore` ignores items that have either been rotated or are just examples