### PR TITLE
Use the latest Gitleaks version in the action

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,3 +17,4 @@ jobs:
       - uses: gitleaks/gitleaks-action@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Used to comment on PRs
+          GITLEAKS_VERSION: latest


### PR DESCRIPTION
See the source for the "latest" version logic https://github.com/gitleaks/gitleaks-action/blob/1f2d10fb689bc07a5f56f48d6db61f5bbbe772fa/src/index.js#L134-L135

See this PR that hard-codes the version for reasons why https://github.com/gitleaks/gitleaks-action/pull/78

This PR adds the missing documentation https://github.com/gitleaks/gitleaks-action/pull/109