### PR TITLE
Remove PHPStan Latte legacy config

### DIFF
--- a/site/app/PhpStan/presenterFactory.php
+++ b/site/app/PhpStan/presenterFactory.php
@@ -1,0 +1,9 @@
+<?php
+declare(strict_types = 1);
+
+# Used by efabrica/phpstan-latte – PHPStan Latte extension
+
+use MichalSpacekCz\Application\Bootstrap;
+use Nette\Application\IPresenterFactory;
+
+return Bootstrap::bootCli()->getByType(IPresenterFactory::class);

--- a/site/phpstan-latte-templates.neon
+++ b/site/phpstan-latte-templates.neon
@@ -6,10 +6,6 @@ parameters:
 	latte:
 		engineBootstrap: app/PhpStan/latteEngine.php
 		presenterFactoryBootstrap: app/PhpStan/presenterFactory.php
-	earlyTerminatingMethodCalls:
-		Nette\Application\UI\Component:
-			# https://github.com/efabrica-team/phpstan-latte/issues/261
-			- redirectPermanent
 	ignoreErrors:
 		- '#^Form field with name "0" probably does not exist#'  # https://github.com/efabrica-team/phpstan-latte/issues/106
 

--- a/site/phpstan-latte-templates.neon
+++ b/site/phpstan-latte-templates.neon
@@ -5,8 +5,7 @@ parameters:
 	level: 0
 	latte:
 		engineBootstrap: app/PhpStan/latteEngine.php
-		applicationMapping:  # Copy of mapping from common.neon until https://github.com/efabrica-team/phpstan-latte/issues/27 is resolved somehow
-			*: MichalSpacekCz\*\Presenters\*Presenter
+		presenterFactoryBootstrap: app/PhpStan/presenterFactory.php
 	earlyTerminatingMethodCalls:
 		Nette\Application\UI\Component:
 			# https://github.com/efabrica-team/phpstan-latte/issues/261


### PR DESCRIPTION
- Use presenter factory instead of app mapping config
Close #81
- Early terminating calls like redirectPermanent should now be detected automatically