### PR TITLE
WSL for local dev

### DIFF
--- a/conf/nginx/dev-php.conf
+++ b/conf/nginx/dev-php.conf
@@ -1,3 +1,4 @@
 internal;
 fastcgi_param ENVIRONMENT development;
+fastcgi_param TEMP_DIR /tmp/michalspacek.cz;
 include /srv/www/michalspacek.cz/conf/nginx/common-php.conf;

--- a/conf/php/dev-michalspacek.cz.conf
+++ b/conf/php/dev-michalspacek.cz.conf
@@ -15,7 +15,7 @@ pm.max_spare_servers = 3
 
 chdir = /
 
-php_admin_value[open_basedir] = /media/snafu-htdocs/private/michalspacek.cz/site/:/media/snafu-htdocs/private/michalspacek.cz/uploads/:/tmp/michalspacek.cz/
+php_admin_value[open_basedir] = /mnt/c/Users/spaze/htdocs/private/michalspacek.cz/site/:/mnt/c/Users/spaze/htdocs/private/michalspacek.cz/uploads/:/tmp/michalspacek.cz/
 php_admin_value[session.save_path] = /srv/www/michalspacek.cz/sessions/
 php_admin_value[upload_tmp_dir] = /srv/www/michalspacek.cz/uploads/
 php_admin_value[user_ini.filename] = ""

--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -79,7 +79,7 @@ class Bootstrap
 		$configurator->setDebugMode($debugMode);
 		$configurator->enableTracy(self::SITE_DIR . '/log');
 		$configurator->setTimeZone('Europe/Prague');
-		$configurator->setTempDirectory(self::SITE_DIR . '/temp');
+		$configurator->setTempDirectory($_SERVER['TEMP_DIR'] ?? self::SITE_DIR . '/temp');
 
 		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig), function ($path) {
 			return is_file($path);


### PR DESCRIPTION
Start using WSL for local dev.

But using `/mnt/c/` is veeeeeeeeeery, veeeeeeeeeeeeeeeeery slooooooow. To partially speed things up (so nginx won't timeout, the bar is really low), the temp dir is moved to WSL filesystem.

This brings only a very, very <sub>small</sub> performance improvement, but at least something.
See microsoft/WSL#9412 for some good news which should hopefully be soon available in WSL.

`/tmp/michalspacek.cz` is managed by `tmpfiles.d`:
```
$ cat /etc/tmpfiles.d/tmp-michalspacek.cz.conf
# My site's file-based SQLiteJournal for Nette cache, see note in michalspacek.cz/site/config/local.template.neon
# Symlink this file to /etc/tmpfiles.d/
d /tmp/michalspacek.cz 0777 www-data www-data -
```