### PR TITLE
Add well-known URL for changing passwords in admin

### DIFF
--- a/conf/nginx/common-_.michalspacek.cz.conf
+++ b/conf/nginx/common-_.michalspacek.cz.conf
@@ -39,11 +39,5 @@ location ~ (\.php|\.html?) {
 }
 
 location / {
-    include /srv/www/michalspacek.cz/conf/nginx/common-methods.conf;
-    error_page 404 /app.php;
-
-    # Strip trailing punctuation
-    rewrite (.*?)[,.]+$ $1 permanent;
-
-    rewrite .* /app.php last;
+	include /srv/www/michalspacek.cz/conf/nginx/common-app.conf;
 }

--- a/conf/nginx/common-admin.michalspacek.cz.conf
+++ b/conf/nginx/common-admin.michalspacek.cz.conf
@@ -2,3 +2,7 @@ root /srv/www/michalspacek.cz/site/public/admin;
 client_max_body_size 2m;
 client_body_buffer_size 2m;
 include /srv/www/michalspacek.cz/conf/nginx/common-_.michalspacek.cz.conf;
+
+location = /.well-known/change-password {
+	include /srv/www/michalspacek.cz/conf/nginx/common-app.conf;
+}

--- a/conf/nginx/common-app.conf
+++ b/conf/nginx/common-app.conf
@@ -1,0 +1,7 @@
+include /srv/www/michalspacek.cz/conf/nginx/common-methods.conf;
+error_page 404 /app.php;
+
+# Strip trailing punctuation
+rewrite (.*?)[,.]+$ $1 permanent;
+
+rewrite .* /app.php last;

--- a/site/app/Admin/Presenters/WellKnownPresenter.php
+++ b/site/app/Admin/Presenters/WellKnownPresenter.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Admin\Presenters;
+
+class WellKnownPresenter extends BasePresenter
+{
+
+	public function actionChangePassword(): never
+	{
+		$this->redirect('User:changePassword');
+	}
+
+}

--- a/site/app/Application/RouterFactory.php
+++ b/site/app/Application/RouterFactory.php
@@ -125,6 +125,7 @@ class RouterFactory
 		$this->router->withModule('EasterEgg')->addRoute('/nette.micro', 'Nette:micro');
 
 		$this->initRouterLists(self::MODULE_ADMIN);
+		$this->addRoute('.well-known[/<action>]', 'WellKnown', 'default');
 		$this->addRoute('[<presenter>][/<action>][/<param>]', 'Homepage', 'default');
 
 		$this->initRouterLists(self::MODULE_HEARTBLEED);


### PR DESCRIPTION
`<admin>/.well-known/change-password` will now redirect to the page where you, or actually just I, can change my password. This is for a nicer integration with 1Password.

The redirect is done in Nette so that I can redirect to `presenter:action` and not a URL. If the redirect would be done in server config, then it's one more place to change if the URL changes. Also not added as a one-way route to Nette because the redirection should be a temporary redirect while the one-way route redirect is a permanent one.

See the spec here https://www.w3.org/TR/change-password-url/