### PR TITLE
Password forms improvements

### DIFF
--- a/site/app/Form/ChangePasswordFormFactory.php
+++ b/site/app/Form/ChangePasswordFormFactory.php
@@ -27,11 +27,14 @@ class ChangePasswordFormFactory
 	{
 		$form = $this->factory->create();
 		$form->addPassword('password', 'Současné heslo:')
+			->setHtmlAttribute('autocomplete', 'current-password')
 			->setRequired('Zadejte prosím současné heslo');
 		$newPassword = $form->addPassword('newPassword', 'Nové heslo:')
+			->setHtmlAttribute('autocomplete', 'new-password')
 			->setRequired('Zadejte prosím nové heslo')
 			->addRule($form::MIN_LENGTH, 'Nové heslo musí mít alespoň %d znaků', 15);
 		$form->addPassword('newPasswordVerify', 'Nové heslo pro kontrolu:')
+			->setHtmlAttribute('autocomplete', 'new-password')
 			->setRequired('Zadejte prosím nové heslo pro kontrolu')
 			->addRule($form::EQUAL, 'Hesla se neshodují', $newPassword);
 		$form->addSubmit('save', 'Uložit');

--- a/site/app/Form/ChangePasswordFormFactory.php
+++ b/site/app/Form/ChangePasswordFormFactory.php
@@ -30,7 +30,7 @@ class ChangePasswordFormFactory
 			->setRequired('Zadejte prosím současné heslo');
 		$newPassword = $form->addPassword('newPassword', 'Nové heslo:')
 			->setRequired('Zadejte prosím nové heslo')
-			->addRule($form::MIN_LENGTH, 'Nové heslo musí mít alespoň %d znaků', 6);
+			->addRule($form::MIN_LENGTH, 'Nové heslo musí mít alespoň %d znaků', 15);
 		$form->addPassword('newPasswordVerify', 'Nové heslo pro kontrolu:')
 			->setRequired('Zadejte prosím nové heslo pro kontrolu')
 			->addRule($form::EQUAL, 'Hesla se neshodují', $newPassword);

--- a/site/app/Form/ChangePasswordFormFactory.php
+++ b/site/app/Form/ChangePasswordFormFactory.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Form;
 
+use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use MichalSpacekCz\User\Manager;
 use Nette\Application\UI\Form;
 use Nette\Security\User;
@@ -22,10 +23,15 @@ class ChangePasswordFormFactory
 	/**
 	 * @param callable(): void $onSuccess
 	 * @return Form
+	 * @throws IdentityNotSimpleIdentityException
 	 */
 	public function create(callable $onSuccess): Form
 	{
 		$form = $this->factory->create();
+		$form->addText('username')
+			->setDefaultValue($this->authenticator->getIdentityByUser($this->user)->username)
+			->setHtmlAttribute('autocomplete', 'username')
+			->setHtmlAttribute('class', 'hidden');
 		$form->addPassword('password', 'Současné heslo:')
 			->setHtmlAttribute('autocomplete', 'current-password')
 			->setRequired('Zadejte prosím současné heslo');

--- a/site/app/Form/ChangePasswordFormFactory.php
+++ b/site/app/Form/ChangePasswordFormFactory.php
@@ -30,6 +30,7 @@ class ChangePasswordFormFactory
 		$form = $this->factory->create();
 		$form->addText('username')
 			->setDefaultValue($this->authenticator->getIdentityByUser($this->user)->username)
+			->setHtmlAttribute('passwordrules', 'minlength: 42; required: lower; required: upper; required: digit; required: [ !#$%&*+,./:;=?@_~];')
 			->setHtmlAttribute('autocomplete', 'username')
 			->setHtmlAttribute('class', 'hidden');
 		$form->addPassword('password', 'Současné heslo:')

--- a/site/app/Form/Controls/FormControlsFactory.php
+++ b/site/app/Form/Controls/FormControlsFactory.php
@@ -11,8 +11,10 @@ class FormControlsFactory
 	public function addSignIn(Container $container): void
 	{
 		$container->addText('username', 'Uživatel:')
+			->setHtmlAttribute('autocomplete', 'username')
 			->setRequired('Zadejte prosím uživatele');
 		$container->addPassword('password', 'Heslo:')
+			->setHtmlAttribute('autocomplete', 'current-password')
 			->setRequired('Zadejte prosím heslo');
 		$container->addCheckbox('remember', 'Zůstat přihlášen');
 		$container->addSubmit('signin', 'Přihlásit');

--- a/site/app/User/Exceptions/IdentityNotSimpleIdentityException.php
+++ b/site/app/User/Exceptions/IdentityNotSimpleIdentityException.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\Exceptions;
+
+use Exception;
+use Nette\Security\IIdentity;
+use Nette\Security\SimpleIdentity;
+use Throwable;
+
+class IdentityNotSimpleIdentityException extends Exception
+{
+
+	public function __construct(?IIdentity $identity, ?Throwable $previous = null)
+	{
+		parent::__construct(
+			sprintf('Identity is of class %s but should be %s', $identity === null ? '<null>' : $identity::class, SimpleIdentity::class),
+			previous: $previous,
+		);
+	}
+
+}

--- a/site/app/User/Manager.php
+++ b/site/app/User/Manager.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\User;
 
 use DateTimeInterface;
 use Exception;
+use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use Nette\Application\LinkGenerator;
 use Nette\Database\Explorer;
 use Nette\Database\Row;
@@ -80,6 +81,19 @@ class Manager implements Authenticator
 
 
 	/**
+	 * @throws IdentityNotSimpleIdentityException
+	 */
+	public function getIdentityByUser(User $user): SimpleIdentity
+	{
+		$identity = $user->getIdentity();
+		if (!$identity instanceof SimpleIdentity) {
+			throw new IdentityNotSimpleIdentityException($identity);
+		}
+		return $identity;
+	}
+
+
+	/**
 	 * @param string $username
 	 * @param string $password
 	 * @return int User id
@@ -123,12 +137,11 @@ class Manager implements Authenticator
 	 * @param string $newPassword
 	 * @throws AuthenticationException
 	 * @throws HaliteAlert
+	 * @throws IdentityNotSimpleIdentityException
 	 */
 	public function changePassword(User $user, string $password, string $newPassword): void
 	{
-		/** @var SimpleIdentity $identity */
-		$identity = $user->getIdentity();
-		$this->verifyPassword($identity->username, $password);
+		$this->verifyPassword($this->getIdentityByUser($user)->username, $password);
 		$this->updatePassword($user->getId(), $newPassword);
 		$this->clearPermanentLogin($user);
 	}


### PR DESCRIPTION
Well, I'm the only one using the login forms on this site but still wanted to try these.

- Raise min length to 15 chars
- Help password managers understand the form fields
- Indicate which account is the password being changed for
- Tell 1Password to generate a bit longer+stronger password by default

TIL the `passwordrules` attribute thanks to this great @scotthelme's blog post https://scotthelme.co.uk/boosting-account-security-pwned-passwords-and-zxcvbn/

Here are some helpful links:
- [Design your website to work best with 1Password](https://developer.1password.com/docs/web/compatible-website-design/)
- [Password Rules Validation Tool](https://developer.apple.com/password-rules/) by Apple, apparently supported in Safari [since 2018 (Safari 12)](https://webkit.org/blog/8327/safari-technology-preview-58-with-safari-12-features-is-now-available/)
- https://github.com/whatwg/html/issues/3518

_This is a companion to #89._