### PR TITLE
CSPRO Trusted Types for `www` only

### DIFF
--- a/site/config/contentsecuritypolicy.neon
+++ b/site/config/contentsecuritypolicy.neon
@@ -66,3 +66,8 @@ contentSecurityPolicy:
 			@extends: www.*.*
 		upckeys.*.*:
 			@extends: www.*.*
+	policiesReportOnly:
+		www.*.*:
+			require-trusted-types-for: "'script'"
+			report-uri: %reporting.contentSecurityPolicy%
+			report-to: default


### PR DESCRIPTION
Previously, I've enabled Trusted Types for the whole site (#8) and had to roll back (#10) but since then have removed jQuery from www scripts (#57) so this should be fine.

For #56