### PR TITLE
Serve *a* `/etc/passwd` if requested

### DIFF
--- a/site/app/EasterEgg/FourOhFourButFound.php
+++ b/site/app/EasterEgg/FourOhFourButFound.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\EasterEgg;
+
+use Nette\Application\Responses\TextResponse;
+use Nette\Application\UI\Presenter;
+use Nette\Http\IRequest;
+
+class FourOhFourButFound
+{
+
+	private const TEMPLATES = [
+		'/etc/passwd' => __DIR__ . '/templates/etcPasswd.html',
+	];
+
+
+	public function __construct(
+		private readonly IRequest $httpRequest,
+	) {
+	}
+
+
+	public function sendItMaybe(Presenter $presenter): void
+	{
+		$url = $this->httpRequest->getUrl();
+		foreach (self::TEMPLATES as $request => $template) {
+			if (str_contains($url->getPath(), $request)) {
+				$this->sendIt($presenter, $template);
+			} else {
+				$query = $url->getQuery();
+				if ($query && str_contains(urldecode($query), $request)) {
+					$this->sendIt($presenter, $template);
+				}
+			}
+		}
+	}
+
+
+	private function sendIt(Presenter $presenter, string $template): never
+	{
+		$presenter->sendResponse(new TextResponse(file_get_contents($template)));
+	}
+
+}

--- a/site/app/EasterEgg/templates/etcPasswd.html
+++ b/site/app/EasterEgg/templates/etcPasswd.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="utf-8">
+	<meta name="robots" content="noindex, nofollow">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<title>/etc/passwd</title>
+</head>
+<body>
+<pre>
+root:x:0:0:root:/root:/bin/bash
+daemon:x:1:1:daemon:/usr/sbin:/usr/sbin/nologin
+bin:x:2:2:bin:/bin:/usr/sbin/nologin
+sys:x:3:3:sys:/dev:/usr/sbin/nologin
+sync:x:4:65534:sync:/bin:/bin/sync
+games:x:5:60:games:/usr/games:/usr/sbin/nologin
+man:x:6:12:man:/var/cache/man:/usr/sbin/nologin
+lp:x:7:7:lp:/var/spool/lpd:/usr/sbin/nologin
+mail:x:8:8:mail:/var/mail:/usr/sbin/nologin
+news:x:9:9:news:/var/spool/news:/usr/sbin/nologin
+uucp:x:10:10:uucp:/var/spool/uucp:/usr/sbin/nologin
+proxy:x:13:13:proxy:/bin:/usr/sbin/nologin
+www-data:x:33:33:www-data:/var/www:/usr/sbin/nologin
+backup:x:34:34:backup:/var/backups:/usr/sbin/nologin
+list:x:38:38:Mailing List Manager:/var/list:/usr/sbin/nologin
+icq:x:39:39:icqd:/run/icqd:/usr/sbin/nologin
+gnats:x:41:41:Gnats Bug-Reporting System (admin):/var/lib/gnats:/usr/sbin/nologin
+nobody:x:65534:65534:nobody:/nonexistent:/usr/sbin/nologin
+systemd-network:x:100:102:systemd Network Management,,,:/run/systemd:/usr/sbin/nologin
+systemd-resolve:x:101:103:systemd Resolver,,,:/run/systemd:/usr/sbin/nologin
+messagebus:x:102:105:🚌:/nonexistent:/usr/sbin/nologin
+systemd-timesync:x:103:106:systemd Time Synchronization,,,:/run/systemd:/usr/sbin/nologin
+syslog:x:104:111::/home/syslog:/usr/sbin/nologin
+_apt:x:105:65534::/nonexistent:/usr/sbin/nologin
+uuidd:x:106:112::/run/uuidd:/usr/sbin/nologin
+tcpdump:x:107:113::/nonexistent:/usr/sbin/nologin
+rick:x:1337:1337:Astley,Rolls Royce bldg.,,:/home/youtube/dQw4w9WgXcQ:/bin/bash
+npc:x:109:116::/home/npc:/bin/false
+memcache:x:110:118:Memcached,,,:/nonexistent:/bin/false
+clamav:x:111:119::/var/lib/clamav:/bin/false
+redis:x:112:120:Or Not,Here I come,,:/home/youtube/aIXyKmElvv8:/bin/false
+opendkim:x:113:121::/var/run/opendkim:/bin/false
+</pre>
+</body>
+</html>

--- a/site/app/Test/Http/Request.php
+++ b/site/app/Test/Http/Request.php
@@ -30,7 +30,7 @@ class Request implements IRequest
 
 	private bool $sameSite;
 
-	private readonly UrlScript $url;
+	private UrlScript $url;
 
 
 	public function __construct()
@@ -42,6 +42,12 @@ class Request implements IRequest
 	public function getUrl(): UrlScript
 	{
 		return $this->url;
+	}
+
+
+	public function setUrl(UrlScript $url): void
+	{
+		$this->url = $url;
 	}
 
 

--- a/site/app/Www/Presenters/ErrorPresenter.php
+++ b/site/app/Www/Presenters/ErrorPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Www\Presenters;
 
 use MichalSpacekCz\Application\LocaleLinkGeneratorInterface;
+use MichalSpacekCz\EasterEgg\FourOhFourButFound;
 use MichalSpacekCz\ShouldNotHappenException;
 use Nette\Application\BadRequestException;
 use Nette\Application\UI\InvalidLinkException;
@@ -25,6 +26,7 @@ class ErrorPresenter extends BaseErrorPresenter
 
 	public function __construct(
 		private readonly LocaleLinkGeneratorInterface $localeLinkGenerator,
+		private readonly FourOhFourButFound $fourOhFourButFound,
 	) {
 		parent::__construct();
 	}
@@ -32,6 +34,7 @@ class ErrorPresenter extends BaseErrorPresenter
 
 	public function actionDefault(BadRequestException $exception): void
 	{
+		$this->fourOhFourButFound->sendItMaybe($this);
 		$code = (in_array($exception->getCode(), $this->statuses) ? $exception->getCode() : IResponse::S400_BadRequest);
 		$this->template->errorCode = $code;
 		$this->template->pageTitle = $this->translator->translate("messages.title.error{$code}");

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -10,6 +10,7 @@ services:
 	- MichalSpacekCz\CompanyInfo\Info(loadCompanyDataVisible: %loadCompanyDataVisible%)
 	- MichalSpacekCz\CompanyInfo\RegisterUz(rootUrl: %registerUz.rootUrl%)
 	- MichalSpacekCz\DateTime\DateTimeFormatter(@translation.translator::getDefaultLocale())
+	- MichalSpacekCz\EasterEgg\FourOhFourButFound
 	- MichalSpacekCz\EasterEgg\NetteCve202015227
 	- MichalSpacekCz\EasterEgg\WinterIsComing
 	- MichalSpacekCz\Feed\Exports

--- a/site/tests/EasterEgg/FourOhFourButFoundTest.phpt
+++ b/site/tests/EasterEgg/FourOhFourButFoundTest.phpt
@@ -1,0 +1,93 @@
+<?php
+/** @noinspection PhpMissingParentConstructorInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\EasterEgg;
+
+use MichalSpacekCz\Test\Http\Request;
+use Nette\Application\AbortException;
+use Nette\Application\Response;
+use Nette\Application\Responses\TextResponse;
+use Nette\Application\UI\Presenter;
+use Nette\Http\UrlScript;
+use stdClass;
+use Tester\Assert;
+use Tester\TestCase;
+
+$runner = require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class FourOhFourButFoundTest extends TestCase
+{
+
+	private stdClass $resultObject;
+
+	private Presenter $presenter;
+
+
+	public function __construct(
+		private readonly FourOhFourButFound $fourOhFourButFound,
+		private readonly Request $request,
+	) {
+	}
+
+
+	protected function setUp(): void
+	{
+		$this->resultObject = new stdClass();
+		$this->resultObject->response = null;
+		$this->presenter = new class ($this->resultObject) extends Presenter {
+
+			public function __construct(
+				private readonly stdClass $resultObject,
+			) {
+			}
+
+
+			public function sendResponse(Response $response): never
+			{
+				$this->resultObject->response = $response;
+				$this->terminate();
+			}
+
+		};
+	}
+
+
+	/**
+	 * @return non-empty-list<array{0:string, 1:string|null}>
+	 */
+	public function getUrlContains(): array
+	{
+		return [
+			['/', null],
+			['/etc/foo', null],
+			['/etc/passwd', 'rick:x:1337:1337:Astley'],
+			['/etc/passwd/foo/bar', 'rick:x:1337:1337:Astley'],
+			['/etc/foo?file=../../../etc/passwd', 'rick:x:1337:1337:Astley'],
+			['/etc/foo?file=..%2F..%2F..%2Fetc%2Fpasswd', 'rick:x:1337:1337:Astley'],
+			['/etc/foo?file=../../../etc/passwd&foo/bar', 'rick:x:1337:1337:Astley'],
+			['/etc/foo?file=..%2F..%2F..%2Fetc%2Fpasswd&foo/bar', 'rick:x:1337:1337:Astley'],
+		];
+	}
+
+
+	/** @dataProvider getUrlContains */
+	public function testSendItMaybe(string $url, ?string $contains): void
+	{
+		$this->request->setUrl(new UrlScript($url));
+		if ($contains === null) {
+			$this->fourOhFourButFound->sendItMaybe($this->presenter);
+			Assert::null($this->resultObject->response);
+		} else {
+			Assert::throws(function (): void {
+				$this->fourOhFourButFound->sendItMaybe($this->presenter);
+			}, AbortException::class);
+			Assert::type(TextResponse::class, $this->resultObject->response);
+			Assert::contains($contains, $this->resultObject->response->getSource());
+		}
+	}
+
+}
+
+$runner->run(FourOhFourButFoundTest::class);


### PR DESCRIPTION
This is to satisfy some scanners looking for one. I mean, it's Easter, after all.

The `FourOhFourButFound` class could be marked as `readonly` but the code sniffer doesn't yet support readonly classes, see squizlabs/PHP_CodeSniffer#3727.