### PR TITLE
Download fresh package information before installing `xmllint`

### DIFF
--- a/site/bin/xmllint.sh
+++ b/site/bin/xmllint.sh
@@ -2,6 +2,11 @@
 
 OPT_AUTO_INSTALL_WITH_APT_FAST="--auto-install-with-apt-fast"
 
+function install() {
+	apt-fast --yes --no-install-recommends install libxml2-utils
+}
+
+
 if ! hash xmllint 2>/dev/null; then
 	if [ $# -eq 0 ]; then
 		echo "xmllint is required but it's not installed, install it with e.g. apt install libxml2-utils, or run $0 $OPT_AUTO_INSTALL_WITH_APT_FAST"
@@ -9,7 +14,12 @@ if ! hash xmllint 2>/dev/null; then
 	else
 		if [ "$1" = "$OPT_AUTO_INSTALL_WITH_APT_FAST" ]; then
 			echo "xmllint is required, will be installed automatically"
-			apt-fast --yes --no-install-recommends install libxml2-utils
+			install
+			if ! install; then
+				echo "Possible stale package info, updating the info and retrying the install"
+				sudo apt update
+				install
+			fi
 		fi
 	fi
 fi


### PR DESCRIPTION
But not always, only when the installation has already failed, to save some time.

Because linter job has been failing due to 404:
```
04/24 15:17:09 [NOTICE] Downloading 1 item(s)

04/24 15:17:09 [ERROR] CUID#7 - Download aborted. URI=http://azure.archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.13%2bdfsg-1ubuntu0.2_amd64.deb
Exception: [AbstractCommand.cc:351] errorCode=3 URI=http://azure.archive.ubuntu.com/ubuntu/pool/main/libx/libxml2/libxml2-utils_2.9.13%2bdfsg-1ubuntu0.2_amd64.deb
  -> [HttpSkipResponseCommand.cc:218] errorCode=3 Resource not found

04/24 15:17:09 [NOTICE] Download GID#95494fc88056d070 not complete: /var/cache/apt/apt-fast/libxml2-utils_2.9.13+dfsg-1ubuntu0.2_amd64.deb
```
([source](https://github.com/spaze/michalspacek.cz/actions/runs/4788050621/jobs/8514121835))