### PR TITLE
Update packages

### DIFF
--- a/site/composer.lock
+++ b/site/composer.lock
@@ -3343,16 +3343,16 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.2",
+            "version": "1.20.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81"
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/90490bd8fd8530a272043c4950c180b6d0cf5f81",
-                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6c04009f6cae6eda2f040745b6b846080ef069c2",
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2",
                 "shasum": ""
             },
             "require": {
@@ -3382,9 +3382,9 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.3"
             },
-            "time": "2023-04-22T12:59:35+00:00"
+            "time": "2023-04-25T09:01:03+00:00"
         },
         {
             "name": "phpstan/phpstan",
@@ -3564,12 +3564,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1f742625cd069120b577015b3930fefa1e46c8ff"
+                "reference": "5eb9b0587e4625150e4892e569bb223714c86256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1f742625cd069120b577015b3930fefa1e46c8ff",
-                "reference": "1f742625cd069120b577015b3930fefa1e46c8ff",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5eb9b0587e4625150e4892e569bb223714c86256",
+                "reference": "5eb9b0587e4625150e4892e569bb223714c86256",
                 "shasum": ""
             },
             "conflict": {
@@ -3598,7 +3598,7 @@
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "azuracast/azuracast": "<0.18",
-                "backdrop/backdrop": "<=1.23",
+                "backdrop/backdrop": "<1.24.2",
                 "badaso/core": "<2.7",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
@@ -3640,9 +3640,9 @@
                 "concrete5/concrete5": "<=9.1.3|>= 9.0.0RC1, < 9.1.3",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
+                "contao/core-bundle": "<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "craftcms/cms": "<3.7.64|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
@@ -3789,7 +3789,7 @@
                 "krayin/laravel-crm": "<1.2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
-                "laminas/laminas-diactoros": "<2.11.1",
+                "laminas/laminas-diactoros": "<2.18.1|>=2.24,<2.24.2|>=2.25,<2.25.2|= 2.23.0|= 2.22.0|= 2.21.0|= 2.20.0|= 2.19.0",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
                 "laravel/fortify": "<1.11.1",
@@ -3905,7 +3905,7 @@
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.0.1",
+                "prestashop/prestashop": "<8.0.4",
                 "prestashop/productcomments": "<5.0.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
@@ -4161,7 +4161,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-24T21:04:22+00:00"
+            "time": "2023-04-25T20:04:17+00:00"
         },
         {
             "name": "slevomat/coding-standard",
@@ -4278,16 +4278,16 @@
         },
         {
             "name": "spaze/phpstan-disallowed-calls",
-            "version": "v2.13.0",
+            "version": "v2.14.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/phpstan-disallowed-calls.git",
-                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83"
+                "reference": "b991392c0904fdb3320c978e812da872c768e518"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/ad3a6d043463c441e73f1d190c1a4a19890abf83",
-                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83",
+                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/b991392c0904fdb3320c978e812da872c768e518",
+                "reference": "b991392c0904fdb3320c978e812da872c768e518",
                 "shasum": ""
             },
             "require": {
@@ -4332,7 +4332,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spaze/phpstan-disallowed-calls/issues",
-                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.13.0"
+                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.14.1"
             },
             "funding": [
                 {
@@ -4340,7 +4340,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2023-04-24T00:48:17+00:00"
+            "time": "2023-04-26T01:51:29+00:00"
         },
         {
             "name": "spaze/phpstan-disallowed-calls-nette",

--- a/site/vendor/composer/installed.json
+++ b/site/vendor/composer/installed.json
@@ -1974,17 +1974,17 @@
         },
         {
             "name": "phpstan/phpdoc-parser",
-            "version": "1.20.2",
-            "version_normalized": "1.20.2.0",
+            "version": "1.20.3",
+            "version_normalized": "1.20.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpdoc-parser.git",
-                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81"
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/90490bd8fd8530a272043c4950c180b6d0cf5f81",
-                "reference": "90490bd8fd8530a272043c4950c180b6d0cf5f81",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/6c04009f6cae6eda2f040745b6b846080ef069c2",
+                "reference": "6c04009f6cae6eda2f040745b6b846080ef069c2",
                 "shasum": ""
             },
             "require": {
@@ -1999,7 +1999,7 @@
                 "phpunit/phpunit": "^9.5",
                 "symfony/process": "^5.2"
             },
-            "time": "2023-04-22T12:59:35+00:00",
+            "time": "2023-04-25T09:01:03+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -2016,7 +2016,7 @@
             "description": "PHPDoc parser with support for nullable, intersection and generic types",
             "support": {
                 "issues": "https://github.com/phpstan/phpdoc-parser/issues",
-                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.2"
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.20.3"
             },
             "install-path": "../phpstan/phpdoc-parser"
         },
@@ -2369,12 +2369,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Roave/SecurityAdvisories.git",
-                "reference": "1f742625cd069120b577015b3930fefa1e46c8ff"
+                "reference": "5eb9b0587e4625150e4892e569bb223714c86256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/1f742625cd069120b577015b3930fefa1e46c8ff",
-                "reference": "1f742625cd069120b577015b3930fefa1e46c8ff",
+                "url": "https://api.github.com/repos/Roave/SecurityAdvisories/zipball/5eb9b0587e4625150e4892e569bb223714c86256",
+                "reference": "5eb9b0587e4625150e4892e569bb223714c86256",
                 "shasum": ""
             },
             "conflict": {
@@ -2403,7 +2403,7 @@
                 "awesome-support/awesome-support": "<=6.0.7",
                 "aws/aws-sdk-php": ">=3,<3.2.1",
                 "azuracast/azuracast": "<0.18",
-                "backdrop/backdrop": "<=1.23",
+                "backdrop/backdrop": "<1.24.2",
                 "badaso/core": "<2.7",
                 "bagisto/bagisto": "<0.1.5",
                 "barrelstrength/sprout-base-email": "<1.2.7",
@@ -2445,9 +2445,9 @@
                 "concrete5/concrete5": "<=9.1.3|>= 9.0.0RC1, < 9.1.3",
                 "concrete5/core": "<8.5.8|>=9,<9.1",
                 "contao-components/mediaelement": ">=2.14.2,<2.21.1",
-                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3",
+                "contao/contao": ">=4,<4.4.56|>=4.5,<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4",
                 "contao/core": ">=2,<3.5.39",
-                "contao/core-bundle": "<4.9.18|>=4.10,<4.11.7|>=4.13,<4.13.3|= 4.10.0",
+                "contao/core-bundle": "<4.9.40|>=4.10,<4.11.7|>=4.13,<4.13.21|>=5.1,<5.1.4|= 4.10.0",
                 "contao/listing-bundle": ">=4,<4.4.8",
                 "contao/managed-edition": "<=1.5",
                 "craftcms/cms": "<3.7.64|>= 4.0.0-RC1, < 4.3.7|>= 4.0.0-RC1, < 4.2.1",
@@ -2594,7 +2594,7 @@
                 "krayin/laravel-crm": "<1.2.2",
                 "kreait/firebase-php": ">=3.2,<3.8.1",
                 "la-haute-societe/tcpdf": "<6.2.22",
-                "laminas/laminas-diactoros": "<2.11.1",
+                "laminas/laminas-diactoros": "<2.18.1|>=2.24,<2.24.2|>=2.25,<2.25.2|= 2.23.0|= 2.22.0|= 2.21.0|= 2.20.0|= 2.19.0",
                 "laminas/laminas-form": "<2.17.1|>=3,<3.0.2|>=3.1,<3.1.1",
                 "laminas/laminas-http": "<2.14.2",
                 "laravel/fortify": "<1.11.1",
@@ -2710,7 +2710,7 @@
                 "prestashop/blockwishlist": ">=2,<2.1.1",
                 "prestashop/contactform": ">=1.0.1,<4.3",
                 "prestashop/gamification": "<2.3.2",
-                "prestashop/prestashop": "<8.0.1",
+                "prestashop/prestashop": "<8.0.4",
                 "prestashop/productcomments": "<5.0.2",
                 "prestashop/ps_emailsubscription": "<2.6.1",
                 "prestashop/ps_facetedsearch": "<3.4.1",
@@ -2930,7 +2930,7 @@
                 "zfr/zfr-oauth2-server-module": "<0.1.2",
                 "zoujingli/thinkadmin": "<6.0.22"
             },
-            "time": "2023-04-24T21:04:22+00:00",
+            "time": "2023-04-25T20:04:17+00:00",
             "default-branch": true,
             "type": "metapackage",
             "notification-url": "https://packagist.org/downloads/",
@@ -3427,17 +3427,17 @@
         },
         {
             "name": "spaze/phpstan-disallowed-calls",
-            "version": "v2.13.0",
-            "version_normalized": "2.13.0.0",
+            "version": "v2.14.1",
+            "version_normalized": "2.14.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/phpstan-disallowed-calls.git",
-                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83"
+                "reference": "b991392c0904fdb3320c978e812da872c768e518"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/ad3a6d043463c441e73f1d190c1a4a19890abf83",
-                "reference": "ad3a6d043463c441e73f1d190c1a4a19890abf83",
+                "url": "https://api.github.com/repos/spaze/phpstan-disallowed-calls/zipball/b991392c0904fdb3320c978e812da872c768e518",
+                "reference": "b991392c0904fdb3320c978e812da872c768e518",
                 "shasum": ""
             },
             "require": {
@@ -3452,7 +3452,7 @@
                 "phpunit/phpunit": "^8.5 || ^10.1",
                 "spaze/coding-standard": "^1.6"
             },
-            "time": "2023-04-24T00:48:17+00:00",
+            "time": "2023-04-26T01:51:29+00:00",
             "type": "phpstan-extension",
             "extra": {
                 "phpstan": {
@@ -3484,7 +3484,7 @@
             ],
             "support": {
                 "issues": "https://github.com/spaze/phpstan-disallowed-calls/issues",
-                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.13.0"
+                "source": "https://github.com/spaze/phpstan-disallowed-calls/tree/v2.14.1"
             },
             "funding": [
                 {

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => 'c63a12678469a86913d2095781b2ece69806f0a1',
+        'reference' => 'c089447e6d0c1d4e3d93a906c7a79043c268ca6d',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -302,9 +302,9 @@
             'dev_requirement' => true,
         ),
         'phpstan/phpdoc-parser' => array(
-            'pretty_version' => '1.20.2',
-            'version' => '1.20.2.0',
-            'reference' => '90490bd8fd8530a272043c4950c180b6d0cf5f81',
+            'pretty_version' => '1.20.3',
+            'version' => '1.20.3.0',
+            'reference' => '6c04009f6cae6eda2f040745b6b846080ef069c2',
             'type' => 'library',
             'install_path' => __DIR__ . '/../phpstan/phpdoc-parser',
             'aliases' => array(),
@@ -379,7 +379,7 @@
         'roave/security-advisories' => array(
             'pretty_version' => 'dev-latest',
             'version' => 'dev-latest',
-            'reference' => '1f742625cd069120b577015b3930fefa1e46c8ff',
+            'reference' => '5eb9b0587e4625150e4892e569bb223714c86256',
             'type' => 'metapackage',
             'install_path' => NULL,
             'aliases' => array(
@@ -435,7 +435,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'c63a12678469a86913d2095781b2ece69806f0a1',
+            'reference' => 'c089447e6d0c1d4e3d93a906c7a79043c268ca6d',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
@@ -469,9 +469,9 @@
             'dev_requirement' => false,
         ),
         'spaze/phpstan-disallowed-calls' => array(
-            'pretty_version' => 'v2.13.0',
-            'version' => '2.13.0.0',
-            'reference' => 'ad3a6d043463c441e73f1d190c1a4a19890abf83',
+            'pretty_version' => 'v2.14.1',
+            'version' => '2.14.1.0',
+            'reference' => 'b991392c0904fdb3320c978e812da872c768e518',
             'type' => 'phpstan-extension',
             'install_path' => __DIR__ . '/../spaze/phpstan-disallowed-calls',
             'aliases' => array(),

--- a/site/vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php
+++ b/site/vendor/phpstan/phpdoc-parser/src/Parser/PhpDocParser.php
@@ -86,13 +86,22 @@ class PhpDocParser
 				}
 			}
 
-			$tokens->forwardToTheEnd();
-			$tag = new Ast\PhpDoc\PhpDocTagNode($name, new Ast\PhpDoc\InvalidTagValueNode($e->getMessage(), $e));
+			$tag = new Ast\PhpDoc\PhpDocTagNode(
+				$name,
+				$this->enrichWithAttributes(
+					$tokens,
+					new Ast\PhpDoc\InvalidTagValueNode($e->getMessage(), $e),
+					$startLine,
+					$startIndex
+				)
+			);
 
-			return new Ast\PhpDoc\PhpDocNode([$this->enrichWithAttributes($tokens, $tag, $startLine, $startIndex)]);
+			$tokens->forwardToTheEnd();
+
+			return $this->enrichWithAttributes($tokens, new Ast\PhpDoc\PhpDocNode([$this->enrichWithAttributes($tokens, $tag, $startLine, $startIndex)]), 1, 0);
 		}
 
-		return new Ast\PhpDoc\PhpDocNode(array_values($children));
+		return $this->enrichWithAttributes($tokens, new Ast\PhpDoc\PhpDocNode(array_values($children)), 1, 0);
 	}
 
 
@@ -133,6 +142,8 @@ class PhpDocParser
 				if ($tokensArray[$endIndex][Lexer::TYPE_OFFSET] === Lexer::TOKEN_HORIZONTAL_WS) {
 					$endIndex--;
 				}
+			} elseif ($tokensArray[$endIndex][Lexer::TYPE_OFFSET] === Lexer::TOKEN_PHPDOC_EOL) {
+				$endIndex--;
 			}
 
 			$tag->setAttribute(Ast\Attribute::START_INDEX, $startIndex);
@@ -394,6 +405,8 @@ class PhpDocParser
 	private function parseMethodTagValue(TokenIterator $tokens): Ast\PhpDoc\MethodTagValueNode
 	{
 		$isStatic = $tokens->tryConsumeTokenValue('static');
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		$returnTypeOrMethodName = $this->typeParser->parse($tokens);
 
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_IDENTIFIER)) {
@@ -402,7 +415,9 @@ class PhpDocParser
 			$tokens->next();
 
 		} elseif ($returnTypeOrMethodName instanceof Ast\Type\IdentifierTypeNode) {
-			$returnType = $isStatic ? new Ast\Type\IdentifierTypeNode('static') : null;
+			$returnType = $isStatic
+				? $this->typeParser->enrichWithAttributes($tokens, new Ast\Type\IdentifierTypeNode('static'), $startLine, $startIndex)
+				: null;
 			$methodName = $returnTypeOrMethodName->name;
 			$isStatic = false;
 
@@ -412,9 +427,12 @@ class PhpDocParser
 		}
 
 		$templateTypes = [];
+
 		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
 			do {
-				$templateTypes[] = $this->parseTemplateTagValue($tokens, false);
+				$startLine = $tokens->currentTokenLine();
+				$startIndex = $tokens->currentTokenIndex();
+				$templateTypes[] = $this->enrichWithAttributes($tokens, $this->parseTemplateTagValue($tokens, false), $startLine, $startIndex);
 			} while ($tokens->tryConsumeTokenType(Lexer::TOKEN_COMMA));
 			$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_ANGLE_BRACKET);
 		}
@@ -435,6 +453,9 @@ class PhpDocParser
 
 	private function parseMethodTagValueParameter(TokenIterator $tokens): Ast\PhpDoc\MethodTagValueParameterNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
+
 		switch ($tokens->currentTokenType()) {
 			case Lexer::TOKEN_IDENTIFIER:
 			case Lexer::TOKEN_OPEN_PARENTHESES:
@@ -459,7 +480,12 @@ class PhpDocParser
 			$defaultValue = null;
 		}
 
-		return new Ast\PhpDoc\MethodTagValueParameterNode($parameterType, $isReference, $isVariadic, $parameterName, $defaultValue);
+		return $this->enrichWithAttributes(
+			$tokens,
+			new Ast\PhpDoc\MethodTagValueParameterNode($parameterType, $isReference, $isVariadic, $parameterName, $defaultValue),
+			$startLine,
+			$startIndex
+		);
 	}
 
 	private function parseTemplateTagValue(TokenIterator $tokens, bool $parseDescription): Ast\PhpDoc\TemplateTagValueNode
@@ -491,10 +517,15 @@ class PhpDocParser
 
 	private function parseExtendsTagValue(string $tagName, TokenIterator $tokens): Ast\PhpDoc\PhpDocTagValueNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		$baseType = new IdentifierTypeNode($tokens->currentTokenValue());
 		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
-		$type = $this->typeParser->parseGeneric($tokens, $baseType);
+		$type = $this->typeParser->parseGeneric(
+			$tokens,
+			$this->typeParser->enrichWithAttributes($tokens, $baseType, $startLine, $startIndex)
+		);
 
 		$description = $this->parseOptionalDescription($tokens);
 
@@ -519,6 +550,8 @@ class PhpDocParser
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL);
 
 		if ($this->preserveTypeAliasesWithInvalidTypes) {
+			$startLine = $tokens->currentTokenLine();
+			$startIndex = $tokens->currentTokenIndex();
 			try {
 				$type = $this->typeParser->parse($tokens);
 				if (!$tokens->isCurrentTokenType(Lexer::TOKEN_CLOSE_PHPDOC)) {
@@ -537,7 +570,10 @@ class PhpDocParser
 				return new Ast\PhpDoc\TypeAliasTagValueNode($alias, $type);
 			} catch (ParserException $e) {
 				$this->parseOptionalDescription($tokens);
-				return new Ast\PhpDoc\TypeAliasTagValueNode($alias, new Ast\Type\InvalidTypeNode($e));
+				return new Ast\PhpDoc\TypeAliasTagValueNode(
+					$alias,
+					$this->enrichWithAttributes($tokens, new Ast\Type\InvalidTypeNode($e), $startLine, $startIndex)
+				);
 			}
 		}
 
@@ -553,8 +589,16 @@ class PhpDocParser
 
 		$tokens->consumeTokenValue(Lexer::TOKEN_IDENTIFIER, 'from');
 
+		$identifierStartLine = $tokens->currentTokenLine();
+		$identifierStartIndex = $tokens->currentTokenIndex();
 		$importedFrom = $tokens->currentTokenValue();
 		$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
+		$importedFromType = $this->enrichWithAttributes(
+			$tokens,
+			new IdentifierTypeNode($importedFrom),
+			$identifierStartLine,
+			$identifierStartIndex
+		);
 
 		$importedAs = null;
 		if ($tokens->tryConsumeTokenValue('as')) {
@@ -562,7 +606,7 @@ class PhpDocParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 		}
 
-		return new Ast\PhpDoc\TypeAliasImportTagValueNode($importedAlias, new IdentifierTypeNode($importedFrom), $importedAs);
+		return new Ast\PhpDoc\TypeAliasImportTagValueNode($importedAlias, $importedFromType, $importedAs);
 	}
 
 	/**

--- a/site/vendor/phpstan/phpdoc-parser/src/Parser/TypeParser.php
+++ b/site/vendor/phpstan/phpdoc-parser/src/Parser/TypeParser.php
@@ -61,7 +61,13 @@ class TypeParser
 		return $this->enrichWithAttributes($tokens, $type, $startLine, $startIndex);
 	}
 
-	private function enrichWithAttributes(TokenIterator $tokens, Ast\Type\TypeNode $type, int $startLine, int $startIndex): Ast\Type\TypeNode
+	/**
+	 * @internal
+	 * @template T of Ast\Node
+	 * @param T $type
+	 * @return T
+	 */
+	public function enrichWithAttributes(TokenIterator $tokens, Ast\Node $type, int $startLine, int $startIndex): Ast\Node
 	{
 		$endLine = $tokens->currentTokenLine();
 		$endIndex = $tokens->currentTokenIndex();
@@ -139,7 +145,7 @@ class TypeParser
 		}
 
 		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_THIS_VARIABLE)) {
-			$type = new Ast\Type\ThisTypeNode();
+			$type = $this->enrichWithAttributes($tokens, new Ast\Type\ThisTypeNode(), $startLine, $startIndex);
 
 			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
 				$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
@@ -151,7 +157,7 @@ class TypeParser
 		$currentTokenValue = $tokens->currentTokenValue();
 		$tokens->pushSavePoint(); // because of ConstFetchNode
 		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_IDENTIFIER)) {
-			$type = new Ast\Type\IdentifierTypeNode($currentTokenValue);
+			$type = $this->enrichWithAttributes($tokens, new Ast\Type\IdentifierTypeNode($currentTokenValue), $startLine, $startIndex);
 
 			if (!$tokens->isCurrentTokenType(Lexer::TOKEN_DOUBLE_COLON)) {
 				$tokens->dropSavePoint(); // because of ConstFetchNode
@@ -161,7 +167,7 @@ class TypeParser
 					$isHtml = $this->isHtml($tokens);
 					$tokens->rollback();
 					if ($isHtml) {
-						return $this->enrichWithAttributes($tokens, $type, $startLine, $startIndex);
+						return $type;
 					}
 
 					$type = $this->parseGeneric($tokens, $type);
@@ -183,7 +189,10 @@ class TypeParser
 					}
 
 					if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
-						$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
+						$type = $this->tryParseArrayOrOffsetAccess(
+							$tokens,
+							$this->enrichWithAttributes($tokens, $type, $startLine, $startIndex)
+						);
 					}
 				}
 
@@ -393,7 +402,14 @@ class TypeParser
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 			if ($tokens->tryConsumeTokenType(Lexer::TOKEN_CLOSE_ANGLE_BRACKET)) {
 				// trailing comma case
-				return new Ast\Type\GenericTypeNode($baseType, $genericTypes, $variances);
+				$type = new Ast\Type\GenericTypeNode($baseType, $genericTypes, $variances);
+				$startLine = $baseType->getAttribute(Ast\Attribute::START_LINE);
+				$startIndex = $baseType->getAttribute(Ast\Attribute::START_INDEX);
+				if ($startLine !== null && $startIndex !== null) {
+					$type = $this->enrichWithAttributes($tokens, $type, $startLine, $startIndex);
+				}
+
+				return $type;
 			}
 			[$genericTypes[], $variances[]] = $this->parseGenericTypeArgument($tokens);
 			$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
@@ -402,7 +418,14 @@ class TypeParser
 		$tokens->tryConsumeTokenType(Lexer::TOKEN_PHPDOC_EOL);
 		$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_ANGLE_BRACKET);
 
-		return new Ast\Type\GenericTypeNode($baseType, $genericTypes, $variances);
+		$type = new Ast\Type\GenericTypeNode($baseType, $genericTypes, $variances);
+		$startLine = $baseType->getAttribute(Ast\Attribute::START_LINE);
+		$startIndex = $baseType->getAttribute(Ast\Attribute::START_INDEX);
+		if ($startLine !== null && $startIndex !== null) {
+			$type = $this->enrichWithAttributes($tokens, $type, $startLine, $startIndex);
+		}
+
+		return $type;
 	}
 
 
@@ -412,9 +435,11 @@ class TypeParser
 	 */
 	public function parseGenericTypeArgument(TokenIterator $tokens): array
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		if ($tokens->tryConsumeTokenType(Lexer::TOKEN_WILDCARD)) {
 			return [
-				new Ast\Type\IdentifierTypeNode('mixed'),
+				$this->enrichWithAttributes($tokens, new Ast\Type\IdentifierTypeNode('mixed'), $startLine, $startIndex),
 				Ast\Type\GenericTypeNode::VARIANCE_BIVARIANT,
 			];
 		}
@@ -454,7 +479,10 @@ class TypeParser
 
 		$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_PARENTHESES);
 		$tokens->consumeTokenType(Lexer::TOKEN_COLON);
-		$returnType = $this->parseCallableReturnType($tokens);
+
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
+		$returnType = $this->enrichWithAttributes($tokens, $this->parseCallableReturnType($tokens), $startLine, $startIndex);
 
 		return new Ast\Type\CallableTypeNode($identifier, $parameters, $returnType);
 	}
@@ -463,6 +491,8 @@ class TypeParser
 	/** @phpstan-impure */
 	private function parseCallableParameter(TokenIterator $tokens): Ast\Type\CallableTypeParameterNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		$type = $this->parse($tokens);
 		$isReference = $tokens->tryConsumeTokenType(Lexer::TOKEN_REFERENCE);
 		$isVariadic = $tokens->tryConsumeTokenType(Lexer::TOKEN_VARIADIC);
@@ -476,13 +506,20 @@ class TypeParser
 		}
 
 		$isOptional = $tokens->tryConsumeTokenType(Lexer::TOKEN_EQUAL);
-		return new Ast\Type\CallableTypeParameterNode($type, $isReference, $isVariadic, $parameterName, $isOptional);
+		return $this->enrichWithAttributes(
+			$tokens,
+			new Ast\Type\CallableTypeParameterNode($type, $isReference, $isVariadic, $parameterName, $isOptional),
+			$startLine,
+			$startIndex
+		);
 	}
 
 
 	/** @phpstan-impure */
 	private function parseCallableReturnType(TokenIterator $tokens): Ast\Type\TypeNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_NULLABLE)) {
 			$type = $this->parseNullable($tokens);
 
@@ -495,15 +532,33 @@ class TypeParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 
 			if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_ANGLE_BRACKET)) {
-				$type = $this->parseGeneric($tokens, $type);
+				$type = $this->parseGeneric(
+					$tokens,
+					$this->enrichWithAttributes(
+						$tokens,
+						$type,
+						$startLine,
+						$startIndex
+					)
+				);
 
 			} elseif (in_array($type->name, ['array', 'list'], true) && $tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_CURLY_BRACKET) && !$tokens->isPrecededByHorizontalWhitespace()) {
-				$type = $this->parseArrayShape($tokens, $type, $type->name);
+				$type = $this->parseArrayShape($tokens, $this->enrichWithAttributes(
+					$tokens,
+					$type,
+					$startLine,
+					$startIndex
+				), $type->name);
 			}
 		}
 
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
-			$type = $this->tryParseArrayOrOffsetAccess($tokens, $type);
+			$type = $this->tryParseArrayOrOffsetAccess($tokens, $this->enrichWithAttributes(
+				$tokens,
+				$type,
+				$startLine,
+				$startIndex
+			));
 		}
 
 		return $type;
@@ -530,6 +585,8 @@ class TypeParser
 	/** @phpstan-impure */
 	private function tryParseArrayOrOffsetAccess(TokenIterator $tokens, Ast\Type\TypeNode $type): Ast\Type\TypeNode
 	{
+		$startLine = $type->getAttribute(Ast\Attribute::START_LINE);
+		$startIndex = $type->getAttribute(Ast\Attribute::START_INDEX);
 		try {
 			while ($tokens->isCurrentTokenType(Lexer::TOKEN_OPEN_SQUARE_BRACKET)) {
 				$tokens->pushSavePoint();
@@ -542,10 +599,28 @@ class TypeParser
 					$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_SQUARE_BRACKET);
 					$tokens->dropSavePoint();
 					$type = new Ast\Type\OffsetAccessTypeNode($type, $offset);
+
+					if ($startLine !== null && $startIndex !== null) {
+						$type = $this->enrichWithAttributes(
+							$tokens,
+							$type,
+							$startLine,
+							$startIndex
+						);
+					}
 				} else {
 					$tokens->consumeTokenType(Lexer::TOKEN_CLOSE_SQUARE_BRACKET);
 					$tokens->dropSavePoint();
 					$type = new Ast\Type\ArrayTypeNode($type);
+
+					if ($startLine !== null && $startIndex !== null) {
+						$type = $this->enrichWithAttributes(
+							$tokens,
+							$type,
+							$startLine,
+							$startIndex
+						);
+					}
 				}
 			}
 
@@ -596,6 +671,8 @@ class TypeParser
 	/** @phpstan-impure */
 	private function parseArrayShapeItem(TokenIterator $tokens): Ast\Type\ArrayShapeItemNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
 		try {
 			$tokens->pushSavePoint();
 			$key = $this->parseArrayShapeKey($tokens);
@@ -604,12 +681,22 @@ class TypeParser
 			$value = $this->parse($tokens);
 			$tokens->dropSavePoint();
 
-			return new Ast\Type\ArrayShapeItemNode($key, $optional, $value);
+			return $this->enrichWithAttributes(
+				$tokens,
+				new Ast\Type\ArrayShapeItemNode($key, $optional, $value),
+				$startLine,
+				$startIndex
+			);
 		} catch (ParserException $e) {
 			$tokens->rollback();
 			$value = $this->parse($tokens);
 
-			return new Ast\Type\ArrayShapeItemNode(null, false, $value);
+			return $this->enrichWithAttributes(
+				$tokens,
+				new Ast\Type\ArrayShapeItemNode(null, false, $value),
+				$startLine,
+				$startIndex
+			);
 		}
 	}
 
@@ -619,6 +706,9 @@ class TypeParser
 	 */
 	private function parseArrayShapeKey(TokenIterator $tokens)
 	{
+		$startIndex = $tokens->currentTokenIndex();
+		$startLine = $tokens->currentTokenLine();
+
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_INTEGER)) {
 			$key = new Ast\ConstExpr\ConstExprIntegerNode($tokens->currentTokenValue());
 			$tokens->next();
@@ -645,7 +735,12 @@ class TypeParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 		}
 
-		return $key;
+		return $this->enrichWithAttributes(
+			$tokens,
+			$key,
+			$startLine,
+			$startIndex
+		);
 	}
 
 	/**
@@ -678,12 +773,15 @@ class TypeParser
 	/** @phpstan-impure */
 	private function parseObjectShapeItem(TokenIterator $tokens): Ast\Type\ObjectShapeItemNode
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
+
 		$key = $this->parseObjectShapeKey($tokens);
 		$optional = $tokens->tryConsumeTokenType(Lexer::TOKEN_NULLABLE);
 		$tokens->consumeTokenType(Lexer::TOKEN_COLON);
 		$value = $this->parse($tokens);
 
-		return new Ast\Type\ObjectShapeItemNode($key, $optional, $value);
+		return $this->enrichWithAttributes($tokens, new Ast\Type\ObjectShapeItemNode($key, $optional, $value), $startLine, $startIndex);
 	}
 
 	/**
@@ -692,6 +790,9 @@ class TypeParser
 	 */
 	private function parseObjectShapeKey(TokenIterator $tokens)
 	{
+		$startLine = $tokens->currentTokenLine();
+		$startIndex = $tokens->currentTokenIndex();
+
 		if ($tokens->isCurrentTokenType(Lexer::TOKEN_SINGLE_QUOTED_STRING)) {
 			if ($this->quoteAwareConstExprString) {
 				$key = new Ast\ConstExpr\QuoteAwareConstExprStringNode(StringUnescaper::unescapeString($tokens->currentTokenValue()), Ast\ConstExpr\QuoteAwareConstExprStringNode::SINGLE_QUOTED);
@@ -713,7 +814,7 @@ class TypeParser
 			$tokens->consumeTokenType(Lexer::TOKEN_IDENTIFIER);
 		}
 
-		return $key;
+		return $this->enrichWithAttributes($tokens, $key, $startLine, $startIndex);
 	}
 
 }

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedAttribute.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedAttribute.php
@@ -36,7 +36,7 @@ class DisallowedAttribute implements DisallowedWithParams
 		?string $errorIdentifier,
 		?string $errorTip
 	) {
-		$this->attribute = ltrim($attribute, '\\');
+		$this->attribute = $attribute;
 		$this->message = $message;
 		$this->allowedConfig = $allowedConfig;
 		$this->errorIdentifier = $errorIdentifier;

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedAttributeFactory.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedAttributeFactory.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use Spaze\PHPStan\Rules\Disallowed\Exceptions\UnsupportedParamTypeInConfigException;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class DisallowedAttributeFactory
 {
@@ -11,10 +12,14 @@ class DisallowedAttributeFactory
 	/** @var Allowed */
 	private $allowed;
 
+	/** @var Normalizer */
+	private $normalizer;
 
-	public function __construct(Allowed $allowed)
+
+	public function __construct(Allowed $allowed, Normalizer $normalizer)
 	{
 		$this->allowed = $allowed;
+		$this->normalizer = $normalizer;
 	}
 
 
@@ -31,7 +36,7 @@ class DisallowedAttributeFactory
 			$attributes = $disallowed['attribute'];
 			foreach ((array)$attributes as $attribute) {
 				$disallowedAttribute = new DisallowedAttribute(
-					$attribute,
+					$this->normalizer->normalizeNamespace($attribute),
 					$disallowed['message'] ?? null,
 					$this->allowed->getConfig($disallowed),
 					$disallowed['errorIdentifier'] ?? null,

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedConstant.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedConstant.php
@@ -43,7 +43,7 @@ class DisallowedConstant implements Disallowed
 		?string $errorIdentifier,
 		?string $errorTip
 	) {
-		$this->constant = ltrim($constant, '\\');
+		$this->constant = $constant;
 		$this->message = $message;
 		$this->allowIn = $allowIn;
 		$this->allowExceptIn = $allowExceptIn;

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedConstantFactory.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedConstantFactory.php
@@ -4,9 +4,20 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class DisallowedConstantFactory
 {
+
+	/** @var Normalizer */
+	private $normalizer;
+
+
+	public function __construct(Normalizer $normalizer)
+	{
+		$this->normalizer = $normalizer;
+	}
+
 
 	/**
 	 * @param array<array{class?:string, constant?:string, message?:string, allowIn?:string[], allowExceptIn?:string[], disallowIn?:string[], errorIdentifier?:string, errorTip?:string}> $config
@@ -25,7 +36,7 @@ class DisallowedConstantFactory
 			foreach ((array)$constants as $constant) {
 				$class = $disallowed['class'] ?? null;
 				$disallowedConstant = new DisallowedConstant(
-					$class ? "{$class}::{$constant}" : $constant,
+					$this->normalizer->normalizeNamespace($class ? "{$class}::{$constant}" : $constant),
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
 					$disallowed['allowExceptIn'] ?? $disallowed['disallowIn'] ?? [],

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedNamespace.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedNamespace.php
@@ -43,7 +43,7 @@ class DisallowedNamespace implements Disallowed
 		?string $errorIdentifier,
 		?string $errorTip
 	) {
-		$this->namespace = ltrim($namespace, '\\');
+		$this->namespace = $namespace;
 		$this->message = $message;
 		$this->allowIn = $allowIn;
 		$this->allowExceptIn = $allowExceptIn;

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedNamespaceFactory.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/DisallowedNamespaceFactory.php
@@ -4,9 +4,20 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed;
 
 use PHPStan\ShouldNotHappenException;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class DisallowedNamespaceFactory
 {
+
+	/** @var Normalizer */
+	private $normalizer;
+
+
+	public function __construct(Normalizer $normalizer)
+	{
+		$this->normalizer = $normalizer;
+	}
+
 
 	/**
 	 * @param array<array{namespace?:string, class?:string, message?:string, allowIn?:string[], allowExceptIn?:string[], disallowIn?:string[], errorIdentifier?:string, errorTip?:string}> $config
@@ -23,7 +34,7 @@ class DisallowedNamespaceFactory
 			}
 			foreach ((array)$namespaces as $namespace) {
 				$disallowedNamespace = new DisallowedNamespace(
-					$namespace,
+					$this->normalizer->normalizeNamespace($namespace),
 					$disallowed['message'] ?? null,
 					$disallowed['allowIn'] ?? [],
 					$disallowed['allowExceptIn'] ?? $disallowed['disallowIn'] ?? [],

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/Formatter/Formatter.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/Formatter/Formatter.php
@@ -4,9 +4,20 @@ declare(strict_types = 1);
 namespace Spaze\PHPStan\Rules\Disallowed\Formatter;
 
 use PHPStan\Reflection\MethodReflection;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 
 class Formatter
 {
+
+	/** @var Normalizer */
+	private $normalizer;
+
+
+	public function __construct(Normalizer $normalizer)
+	{
+		$this->normalizer = $normalizer;
+	}
+
 
 	public function getFullyQualified(string $class, MethodReflection $method): string
 	{
@@ -20,7 +31,14 @@ class Formatter
 	 */
 	public function formatIdentifier(array $identifiers): string
 	{
-		return count($identifiers) === 1 ? $identifiers[0] : '{' . implode(',', $identifiers) . '}';
+		if (count($identifiers) === 1) {
+			return $this->normalizer->normalizeNamespace($identifiers[0]);
+		} else {
+			array_walk($identifiers, function (string &$identifier): void {
+				$identifier = $this->normalizer->normalizeNamespace($identifier);
+			});
+			return '{' . implode(',', $identifiers) . '}';
+		}
 	}
 
 }

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/Normalizer/Normalizer.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/Normalizer/Normalizer.php
@@ -9,7 +9,13 @@ class Normalizer
 	public function normalizeCall(string $call): string
 	{
 		$call = substr($call, -2) === '()' ? substr($call, 0, -2) : $call;
-		return ltrim($call, '\\');
+		return $this->normalizeNamespace($call);
+	}
+
+
+	public function normalizeNamespace(string $namespace): string
+	{
+		return ltrim($namespace, '\\');
 	}
 
 }

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/Usages/ClassConstantUsages.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/Usages/ClassConstantUsages.php
@@ -84,7 +84,8 @@ class ClassConstantUsages implements Rule
 			throw new ShouldNotHappenException(sprintf('$node->name should be %s but is %s', Identifier::class, get_class($node->name)));
 		}
 		$constant = (string)$node->name;
-		$usedOnType = $this->typeResolver->getType($node->class, $scope);
+		$type = $this->typeResolver->getType($node->class, $scope);
+		$usedOnType = $type->getObjectTypeOrClassStringObjectType();
 
 		if (strtolower($constant) === 'class') {
 			return [];
@@ -94,21 +95,23 @@ class ClassConstantUsages implements Rule
 		if ($usedOnType->getConstantStrings()) {
 			$classNames = array_map(
 				function (ConstantStringType $constantString): string {
-					return ltrim($constantString->getValue(), '\\');
+					return $constantString->getValue();
 				},
 				$usedOnType->getConstantStrings()
 			);
 		} else {
-			if ($usedOnType->hasConstant($constant)->no()) {
+			if ($usedOnType->hasConstant($constant)->yes()) {
+				$classNames = [$usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName()];
+			} elseif ($type->hasConstant($constant)->no()) {
 				return [
 					RuleErrorBuilder::message(sprintf(
 						'Cannot access constant %s on %s',
 						$constant,
-						$usedOnType->describe(VerbosityLevel::getRecommendedLevelByType($usedOnType))
+						$type->describe(VerbosityLevel::getRecommendedLevelByType($type))
 					))->build(),
 				];
 			} else {
-				$classNames = [$usedOnType->getConstant($constant)->getDeclaringClass()->getDisplayName()];
+				return [];
 			}
 		}
 		return $this->disallowedConstantRuleErrors->get($this->getFullyQualified($classNames, $constant), $scope, $displayName, $this->disallowedConstants);

--- a/site/vendor/spaze/phpstan-disallowed-calls/src/Usages/NamespaceUsages.php
+++ b/site/vendor/spaze/phpstan-disallowed-calls/src/Usages/NamespaceUsages.php
@@ -20,6 +20,7 @@ use PHPStan\Rules\Rule;
 use PHPStan\Rules\RuleError;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespace;
 use Spaze\PHPStan\Rules\Disallowed\DisallowedNamespaceFactory;
+use Spaze\PHPStan\Rules\Disallowed\Normalizer\Normalizer;
 use Spaze\PHPStan\Rules\Disallowed\RuleErrors\DisallowedNamespaceRuleErrors;
 
 /**
@@ -34,16 +35,25 @@ class NamespaceUsages implements Rule
 	/** @var DisallowedNamespace[] */
 	private $disallowedNamespace;
 
+	/** @var Normalizer */
+	private $normalizer;
+
 
 	/**
 	 * @param DisallowedNamespaceRuleErrors $disallowedNamespaceRuleErrors
 	 * @param DisallowedNamespaceFactory $disallowNamespaceFactory
+	 * @param Normalizer $normalizer
 	 * @param array<array{namespace:string, message?:string, allowIn?:string[]}> $forbiddenNamespaces
 	 */
-	public function __construct(DisallowedNamespaceRuleErrors $disallowedNamespaceRuleErrors, DisallowedNamespaceFactory $disallowNamespaceFactory, array $forbiddenNamespaces)
-	{
+	public function __construct(
+		DisallowedNamespaceRuleErrors $disallowedNamespaceRuleErrors,
+		DisallowedNamespaceFactory $disallowNamespaceFactory,
+		Normalizer $normalizer,
+		array $forbiddenNamespaces
+	) {
 		$this->disallowedNamespaceRuleErrors = $disallowedNamespaceRuleErrors;
 		$this->disallowedNamespace = $disallowNamespaceFactory->createFromConfig($forbiddenNamespaces);
+		$this->normalizer = $normalizer;
 	}
 
 
@@ -108,7 +118,7 @@ class NamespaceUsages implements Rule
 		foreach ($namespaces as $namespace) {
 			$errors = array_merge(
 				$errors,
-				$this->disallowedNamespaceRuleErrors->getDisallowedMessage(ltrim($namespace, '\\'), $description ?? 'Namespace', $scope, $this->disallowedNamespace)
+				$this->disallowedNamespaceRuleErrors->getDisallowedMessage($this->normalizer->normalizeNamespace($namespace), $description ?? 'Namespace', $scope, $this->disallowedNamespace)
 			);
 		}
 


### PR DESCRIPTION
 - phpstan/phpdoc-parser updated from 1.20.2 to 1.20.3 patch
   See changes: https://github.com/phpstan/phpdoc-parser/compare/1.20.2...1.20.3
   Release notes: https://github.com/phpstan/phpdoc-parser/releases/tag/1.20.3

 - roave/security-advisories updated from dev-latest@1f74262 to dev-latest@5eb9b05
   See changes: https://github.com/Roave/SecurityAdvisories/compare/1f74262...5eb9b05

 - spaze/phpstan-disallowed-calls updated from v2.13.0 to v2.14.1 minor
   See changes: https://github.com/spaze/phpstan-disallowed-calls/compare/v2.13.0...v2.14.1
   Release notes: https://github.com/spaze/phpstan-disallowed-calls/releases/tag/v2.14.1
