### PR TITLE
JS `cloneNode` to copy event handlers too

### DIFF
--- a/site/public/www.michalspacek.cz/i/js/admin.js
+++ b/site/public/www.michalspacek.cz/i/js/admin.js
@@ -180,11 +180,11 @@ App.ready(document, function () {
 		tbody.after(slide);
 		let newTbody = tbody;
 		while (newTbody.nextElementSibling) {
+			newTbody = newTbody.nextElementSibling;
 			const slideNr = newTbody.querySelector('.slide-nr');
 			if (slideNr) {
 				++slideNr.value;
 			}
-			newTbody = newTbody.nextElementSibling;
 		}
 		for (const slide of tbody.parentElement.querySelectorAll('.new-slide')) {
 			for (const input of slide.querySelectorAll('input, textarea')) {

--- a/site/public/www.michalspacek.cz/i/js/admin.js
+++ b/site/public/www.michalspacek.cz/i/js/admin.js
@@ -32,7 +32,7 @@ App.ready(document, function () {
 			item.classList.remove('hidden');
 		}
 		const tr = this.parentElement.parentElement;
-		tr.after(tr.cloneNode(true));
+		tr.after(App.clone(tr));
 		let index = 0;
 		for (const child of tr.parentElement.children) {
 			if (child instanceof HTMLTableRowElement) {
@@ -158,7 +158,7 @@ App.ready(document, function () {
 
 	App.onClick('#frm-slides .add-after', function () {
 		const tbody = this.parentElement.parentElement.parentElement;
-		const slide = tbody.cloneNode(true);
+		const slide = App.clone(tbody);
 		let index = 0;
 		slide.classList.add('new-slide', 'changed');
 		for (const input of slide.querySelectorAll('input:not(.slide-nr), textarea')) {

--- a/site/public/www.michalspacek.cz/i/js/app.js
+++ b/site/public/www.michalspacek.cz/i/js/app.js
@@ -6,9 +6,19 @@ App.ready = function (element, handler) {
 		element.addEventListener('DOMContentLoaded', handler);
 	}
 }
+App.storeEventListener = function (element, type, listener) {
+	if (!Array.isArray(element.eventListeners)) {
+		element.eventListeners = [];
+	}
+	if (!Array.isArray(element.eventListeners[type])) {
+		element.eventListeners[type] = [];
+	}
+	element.eventListeners[type].push(listener);
+}
 App.on = function (type, selector, listener) {
 	document.querySelectorAll(selector).forEach(function (item) {
 		item.addEventListener(type, listener);
+		App.storeEventListener(item, type, listener);
 	});
 }
 App.onClick = function (selector, listener) {
@@ -19,4 +29,18 @@ App.onChange = function (selector, listener) {
 }
 App.onLoad = function (selector, listener) {
 	App.on('load', selector, listener);
+}
+App.clone = function (element) {
+	const cloned = element.cloneNode(true);
+	const sourceElements = element.getElementsByTagName('*');
+	const clonedElements = cloned.getElementsByTagName('*');
+	for (let i = 0; i < sourceElements.length; i++) {
+		for (const type in sourceElements[i].eventListeners) {
+			for (const listener of sourceElements[i].eventListeners[type]) {
+				clonedElements[i].addEventListener(type, listener)
+				App.storeEventListener(clonedElements[i], type, listener);
+			}
+		}
+	}
+	return cloned;
 }


### PR DESCRIPTION
When the listener is added to an element, it is stored into a property (array) on the element so it can be read later when cloning and added to the cloned element.

As inspired by jQuery's clone itself
https://github.com/jquery/jquery/blob/89ef81f86f8f371154e9fd3173be5fb57cb72d5e/src/manipulation.js#L38
https://github.com/jquery/jquery/blob/89ef81f86f8f371154e9fd3173be5fb57cb72d5e/src/manipulation.js#L96