### PR TITLE
Trying to move_uploaded_file under my WSL (files in Windows) says "Unable to move" even when the file is actually moved

### DIFF
--- a/site/app/Application/WindowsSubsystemForLinux.php
+++ b/site/app/Application/WindowsSubsystemForLinux.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+class WindowsSubsystemForLinux
+{
+
+	public function isWsl(): bool
+	{
+		return str_ends_with(php_uname('r'), 'microsoft-standard-WSL2');
+	}
+
+}

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -5,6 +5,7 @@ services:
 	- @MichalSpacekCz\Application\RouterFactory::createRouter
 	- MichalSpacekCz\Application\Theme
 	- MichalSpacekCz\Application\WebApplication(fqdn: %domain.fqdn%)
+	- MichalSpacekCz\Application\WindowsSubsystemForLinux
 	- MichalSpacekCz\Articles\Articles
 	- MichalSpacekCz\CompanyInfo\Ares(url: %ares.url%)
 	- MichalSpacekCz\CompanyInfo\Info(loadCompanyDataVisible: %loadCompanyDataVisible%)


### PR DESCRIPTION
Let's ignore the exception when running on WSL then. `tmpName` will not be updated in `$replace->move` because the exception will be thrown before, so have to `getImageSize()` before moving it.

It's very weird and I don't like this but if it's stupid and it works, it's not stupid.