### PR TITLE
Proper support `link-en_US:` links in Texy with explicitly specified locale

### DIFF
--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -42,7 +42,7 @@ class Bootstrap
 
 	public static function bootTest(): Container
 	{
-		$configurator = self::createConfigurator(true, self::SITE_DIR . '/config/tests.neon');
+		$configurator = self::createConfigurator(true, finalConfig: self::SITE_DIR . '/config/tests.neon');
 		$configurator->addStaticParameters([
 			'wwwDir' => self::SITE_DIR . '/tests',
 		]);
@@ -53,9 +53,9 @@ class Bootstrap
 
 
 	/**
-	 * @return string[]
+	 * @return non-empty-array<int, string|null>
 	 */
-	private static function getConfigurationFiles(string $extraConfig): array
+	private static function getConfigurationFiles(?string $extraConfig = null, ?string $finalConfig = null): array
 	{
 		return array_unique([
 			self::SITE_DIR . '/config/extensions.neon',
@@ -67,11 +67,12 @@ class Bootstrap
 			self::SITE_DIR . '/config/routes.neon',
 			$extraConfig,
 			self::SITE_DIR . '/config/local.neon',
+			$finalConfig,
 		]);
 	}
 
 
-	private static function createConfigurator(bool $debugMode, string $extraConfig): Configurator
+	private static function createConfigurator(bool $debugMode, ?string $extraConfig = null, ?string $finalConfig = null): Configurator
 	{
 		$configurator = new Configurator();
 		$configurator->addStaticParameters(['siteDir' => self::SITE_DIR]);
@@ -81,8 +82,8 @@ class Bootstrap
 		$configurator->setTimeZone('Europe/Prague');
 		$configurator->setTempDirectory($_SERVER['TEMP_DIR'] ?? self::SITE_DIR . '/temp');
 
-		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig), function ($path) {
-			return is_file($path);
+		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig, $finalConfig), function (?string $path) {
+			return $path && is_file($path);
 		});
 		foreach ($existingFiles as $filename) {
 			$configurator->addConfig($filename);

--- a/site/app/Application/LocaleLinkGenerator.php
+++ b/site/app/Application/LocaleLinkGenerator.php
@@ -7,6 +7,7 @@ use Contributte\Translation\Translator;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\LinkGenerator;
 use Nette\Application\Routers\RouteList;
+use Nette\Application\UI\InvalidLinkException;
 use Nette\Http\IRequest;
 
 /**
@@ -35,6 +36,7 @@ class LocaleLinkGenerator implements LocaleLinkGeneratorInterface
 	 * @param string $destination destination in format "[[[module:]presenter:]action] [#fragment]"
 	 * @param array<string, array<string, string|null>> $params of locale => [name => value]
 	 * @return array<string, string> of locale => URL
+	 * @throws InvalidLinkException
 	 */
 	public function links(string $destination, array $params = []): array
 	{
@@ -86,9 +88,14 @@ class LocaleLinkGenerator implements LocaleLinkGeneratorInterface
 	public function allLinks(string $destination, array $params = []): array
 	{
 		$locale = (string)$this->translator->getDefaultLocale();
+		try {
+			$links = $this->links($destination, $params);
+		} catch (InvalidLinkException) {
+			$links = [];
+		}
 		return array_merge(
 			[$locale => $this->linkGenerator->link($destination, $this->getParams($params, $locale))],
-			$this->links($destination, $params),
+			$links,
 		);
 	}
 

--- a/site/app/Test/NoOpTranslator.php
+++ b/site/app/Test/NoOpTranslator.php
@@ -9,7 +9,11 @@ use Contributte\Translation\Translator;
 class NoOpTranslator extends Translator
 {
 
+	/**
+	 * @param list<string> $availableLocales
+	 */
 	public function __construct(
+		private readonly array $availableLocales,
 		private readonly string $defaultLocale,
 	) {
 	}
@@ -33,12 +37,14 @@ class NoOpTranslator extends Translator
 	}
 
 
-	/**
-	 * @return string[]
-	 */
 	public function getAvailableLocales(): array
 	{
-		return [];
+		return $this->availableLocales;
+	}
+
+
+	public function setFallbackLocales(array $locales): void
+	{
 	}
 
 }

--- a/site/config/tests.neon
+++ b/site/config/tests.neon
@@ -3,6 +3,11 @@ parameters:
 		root: domain.example
 		fqdn: www.%domain.root%
 		contentSecurityPolicySelf: "'self'"
+	locales:
+		rootDomainMapping:
+			cz: rizek.test
+			com: burger.test
+
 
 services:
 	localeLinkGenerator: MichalSpacekCz\Test\Application\LocaleLinkGenerator

--- a/site/config/tests.neon
+++ b/site/config/tests.neon
@@ -11,7 +11,7 @@ services:
 	http.request: MichalSpacekCz\Test\Http\Request
 	http.response: MichalSpacekCz\Test\Http\Response
 	- MichalSpacekCz\Test\Http\SecurityHeadersFactory
-	- MichalSpacekCz\Test\NoOpTranslator(defaultLocale: cs_CZ)
+	translation.translator: MichalSpacekCz\Test\NoOpTranslator(availableLocales: [cs_CZ, en_US], defaultLocale: cs_CZ)
 	tracy.logger: MichalSpacekCz\Test\NullLogger
 	- MichalSpacekCz\Test\TestCaseRunner
 	cache.storage: Nette\Caching\Storages\DevNullStorage

--- a/site/tests/Application/LocaleLinkGeneratorTest.phpt
+++ b/site/tests/Application/LocaleLinkGeneratorTest.phpt
@@ -1,0 +1,114 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
+/** @noinspection PhpDocRedundantThrowsInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use MichalSpacekCz\Test\NoOpTranslator;
+use Nette\Application\IPresenterFactory;
+use Nette\Application\LinkGenerator;
+use Nette\Http\IRequest;
+use Tester\Assert;
+use Tester\TestCase;
+
+$runner = require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class LocaleLinkGeneratorTest extends TestCase
+{
+
+	private LocaleLinkGenerator $localeLinkGenerator;
+
+
+	public function __construct(
+		private readonly RouterFactory $routerFactory,
+		private readonly IRequest $httpRequest,
+		private readonly IPresenterFactory $presenterFactory,
+		private readonly LinkGenerator $linkGenerator,
+		private readonly NoOpTranslator $translator,
+	) {
+	}
+
+
+	protected function setUp(): void
+	{
+		$this->localeLinkGenerator = new LocaleLinkGenerator($this->routerFactory, $this->httpRequest, $this->presenterFactory, $this->linkGenerator, $this->translator);
+	}
+
+
+	public function testLinks(): void
+	{
+		$params = [
+			'en_US' => ['name' => 'foo'],
+			'cs_CZ' => ['name' => 'fuu'],
+		];
+		$links = $this->localeLinkGenerator->links('Www:Talks:talk', $params);
+		Assert::same('cs_CZ', $this->translator->getDefaultLocale());
+		Assert::same(['en_US' => 'https://www.burger.test/talks/foo'], $links);
+	}
+
+
+	/**
+	 * @throws \Nette\Application\UI\InvalidLinkException No route for Pulse:PasswordsStorages:site(param=foo)
+	 */
+	public function testLinksNoRoute(): void
+	{
+		$params = [
+			'en_US' => ['param' => 'foo'],
+			'cs_CZ' => ['param' => 'fuu'],
+		];
+		$this->localeLinkGenerator->links('Pulse:PasswordsStorages:site', $params);
+	}
+
+
+	/**
+	 * @throws \Nette\Application\UI\InvalidLinkException Cannot load presenter 'Does:Not', class 'MichalSpacekCz\Does\Presenters\NotPresenter' was not found.
+	 */
+	public function testLinksUnknownRoute(): void
+	{
+		$this->localeLinkGenerator->links('Does:Not:exist');
+	}
+
+
+	public function testAllLinks(): void
+	{
+		$params = [
+			'en_US' => ['name' => 'foo'],
+			'cs_CZ' => ['name' => 'fuu'],
+		];
+		$links = $this->localeLinkGenerator->allLinks('Www:Talks:talk', $params);
+		Assert::same('cs_CZ', $this->translator->getDefaultLocale());
+		$expected = [
+			'cs_CZ' => 'https://www.rizek.test/prednasky/fuu',
+			'en_US' => 'https://www.burger.test/talks/foo',
+		];
+		Assert::same($expected, $links);
+	}
+
+
+	public function testAllLinksNoRoute(): void
+	{
+		$params = [
+			'en_US' => ['param' => 'foo'],
+			'cs_CZ' => ['param' => 'fuu'],
+		];
+		$expected = [
+			'cs_CZ' => 'https://pulse.rizek.test/passwords/storages/site/fuu',
+		];
+		Assert::same($expected, $this->localeLinkGenerator->allLinks('Pulse:PasswordsStorages:site', $params));
+	}
+
+
+	/**
+	 * @throws \Nette\Application\UI\InvalidLinkException Cannot load presenter 'Exist:Does', class 'MichalSpacekCz\Exist\Presenters\DoesPresenter' was not found.
+	 */
+	public function testAllLinksUnknownRoute(): void
+	{
+		$this->localeLinkGenerator->allLinks('Exist:Does:not');
+	}
+
+}
+
+$runner->run(LocaleLinkGeneratorTest::class);


### PR DESCRIPTION
Previous incarnation in e9cc329 didn't really work as the `$locale` parameter was used only for training URLs/actions, not generally.