### PR TITLE
`Makefile`

### DIFF
--- a/.github/workflows/php-latte.yml
+++ b/.github/workflows/php-latte.yml
@@ -25,4 +25,4 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site run-script --timeout=600 phpstan-latte-templates
+    - run: make --directory=site phpstan-latte-templates

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -47,7 +47,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site check-file-patterns
+    - run: make --directory=site check-file-patterns
 
 
   lint:
@@ -62,7 +62,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site lint
+    - run: make --directory=site lint-php
 
   lint-latte:
     runs-on: ubuntu-latest
@@ -76,7 +76,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site lint-latte
+    - run: make --directory=site lint-latte
 
   lint-neon:
     runs-on: ubuntu-latest
@@ -90,13 +90,13 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site lint-neon
+    - run: make --directory=site lint-neon
 
   lint-xml:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: composer --working-dir=site lint-xml -- --auto-install-with-apt-fast
+    - run: make --directory=site lint-xml-auto-install
 
   phpcs:
     runs-on: ubuntu-latest
@@ -117,7 +117,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site phpcs
+    - run: make --directory=site phpcs
 
   phpstan:
     runs-on: ubuntu-latest
@@ -138,7 +138,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site phpstan
+    - run: make --directory=site phpstan
 
   phpstan-vendor:
     runs-on: ubuntu-latest
@@ -159,7 +159,7 @@ jobs:
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site run-script --timeout=600 phpstan-vendor
+    - run: make --directory=site phpstan-vendor
 
   tester:
     runs-on: ubuntu-latest
@@ -173,7 +173,7 @@ jobs:
       with:
         coverage: pcov
         php-version: ${{ matrix.php-version }}
-    - run: composer --working-dir=site tester
+    - run: make --directory=site tester
     - name: Failed test output, if any
       if: failure()
       run: for i in $(find ./site/tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -63,7 +63,7 @@ jobs:
         php-version: ${{ matrix.php-version }}
     - run: make --directory=site check-makefile
 
-  lint:
+  lint-php:
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -49,6 +49,19 @@ jobs:
         php-version: ${{ matrix.php-version }}
     - run: make --directory=site check-file-patterns
 
+  check-makefile:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.2"
+    steps:
+    - uses: actions/checkout@v3
+    - uses: shivammathur/setup-php@v2
+      with:
+        coverage: none
+        php-version: ${{ matrix.php-version }}
+    - run: make --directory=site check-makefile
 
   lint:
     runs-on: ubuntu-latest

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,0 +1,39 @@
+.PHONY: test audit cs-fix check-file-patterns lint-php lint-latte lint-neon lint-xml phpcs phpstan phpstan-latte-templates phpstan-vendor tester
+
+test: audit check-file-patterns lint-php lint-latte lint-neon lint-xml phpcs phpstan tester phpstan-vendor
+
+audit:
+	composer audit
+
+cs-fix:
+	vendor/squizlabs/php_codesniffer/bin/phpcbf app/ public/ tests/
+
+check-file-patterns:
+	bin/check-file-patterns.sh
+
+lint-php:
+	vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors app/ public/ tests/
+
+lint-latte:
+	bin/latte-lint.php app/
+
+lint-neon:
+	vendor/nette/neon/bin/neon-lint app/
+
+lint-xml:
+	bin/xmllint.sh
+
+phpcs:
+	vendor/squizlabs/php_codesniffer/bin/phpcs app/ public/ tests/
+
+phpstan:
+	vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon
+
+phpstan-latte-templates:
+	vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-latte-templates.neon
+
+phpstan-vendor:
+	vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-vendor.neon
+
+tester:
+	vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,6 +1,6 @@
-.PHONY: test audit cs-fix check-file-patterns lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor tester
+.PHONY: test audit cs-fix check-file-patterns check-makefile lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor tester
 
-test: audit check-file-patterns lint-php lint-latte lint-neon lint-xml phpcs phpstan tester phpstan-vendor
+test: audit check-file-patterns check-makefile lint-php lint-latte lint-neon lint-xml phpcs phpstan tester phpstan-vendor
 
 audit:
 	composer audit
@@ -10,6 +10,9 @@ cs-fix:
 
 check-file-patterns:
 	bin/check-file-patterns.sh
+
+check-makefile:
+	bin/check-makefile.php
 
 lint-php:
 	vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors app/ public/ tests/

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test audit cs-fix check-file-patterns lint-php lint-latte lint-neon lint-xml phpcs phpstan phpstan-latte-templates phpstan-vendor tester
+.PHONY: test audit cs-fix check-file-patterns lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor tester
 
 test: audit check-file-patterns lint-php lint-latte lint-neon lint-xml phpcs phpstan tester phpstan-vendor
 
@@ -22,6 +22,9 @@ lint-neon:
 
 lint-xml:
 	bin/xmllint.sh
+
+lint-xml-auto-install:
+	bin/xmllint.sh --auto-install-with-apt-fast
 
 phpcs:
 	vendor/squizlabs/php_codesniffer/bin/phpcs app/ public/ tests/

--- a/site/app/Makefile/Exceptions/MakefileContainsRealTargetsException.php
+++ b/site/app/Makefile/Exceptions/MakefileContainsRealTargetsException.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Makefile\Exceptions;
+
+use Throwable;
+
+class MakefileContainsRealTargetsException extends MakefileException
+{
+
+	/**
+	 * @param array<string, non-empty-list<int>> $notPhonyTargets
+	 */
+	public function __construct(private readonly array $notPhonyTargets, ?Throwable $previous = null)
+	{
+		$multipleTargets = count($this->notPhonyTargets) > 1;
+		$message = 'Makefile contains ' . ($multipleTargets ? 'real targets' : 'a real target') . ":\n";
+		foreach ($this->notPhonyTargets as $target => $lines) {
+			$message .= sprintf("- `%s` defined on %s %s\n", $target, count($lines) > 1 ? 'lines' : 'line', implode(', ', $lines));
+		}
+		$message .= "Add " . ($multipleTargets ? 'them' : 'it') . " to a .PHONY target!";
+		parent::__construct($message, previous: $previous);
+	}
+
+}

--- a/site/app/Makefile/Exceptions/MakefileException.php
+++ b/site/app/Makefile/Exceptions/MakefileException.php
@@ -1,0 +1,10 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Makefile\Exceptions;
+
+use Exception;
+
+abstract class MakefileException extends Exception
+{
+}

--- a/site/app/Makefile/Exceptions/MakefileNotFoundException.php
+++ b/site/app/Makefile/Exceptions/MakefileNotFoundException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Makefile\Exceptions;
+
+use Throwable;
+
+class MakefileNotFoundException extends MakefileException
+{
+
+	public function __construct(string $file, ?Throwable $previous = null)
+	{
+		parent::__construct("Makefile '{$file}' not found", previous: $previous);
+	}
+
+}

--- a/site/app/Makefile/Makefile.php
+++ b/site/app/Makefile/Makefile.php
@@ -1,0 +1,83 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Makefile;
+
+use MichalSpacekCz\Makefile\Exceptions\MakefileContainsRealTargetsException;
+use MichalSpacekCz\Makefile\Exceptions\MakefileNotFoundException;
+use Nette\IOException;
+use Nette\Utils\FileSystem;
+
+class Makefile
+{
+
+	private const PHONY_TARGET = '.PHONY';
+
+	/** @var array<string, non-empty-list<int>> target => lines */
+	private array $targetDefinitions = [];
+
+
+	/**
+	 * @return array<string, list<string>> target => prerequisites
+	 * @throws MakefileNotFoundException
+	 */
+	private function getPrerequisites(string $file): array
+	{
+		$this->targetDefinitions = [];
+		$prerequisites = [
+			self::PHONY_TARGET => [],
+		];
+		try {
+			$lines = FileSystem::readLines($file);
+		} catch (IOException $e) {
+			throw new MakefileNotFoundException($file, $e);
+		}
+		foreach ($lines as $index => $line) {
+			if (str_starts_with($line, "\t")) {
+				continue;
+			}
+			$parts = explode('#', $line, 2);
+			$line = trim($parts[0]);
+			$parts = explode(':', $line, 2);
+			$targets = array_filter(explode(' ', $parts[0]));
+			$targetPrerequisites = array_filter(explode(' ', $parts[1] ?? ''));
+			foreach ($targets as $target) {
+				if (!isset($this->targetDefinitions[$target])) {
+					$this->targetDefinitions[$target] = [$index + 1];
+				} else {
+					$this->targetDefinitions[$target][] = $index + 1;
+				}
+				if (!isset($prerequisites[$target])) {
+					$prerequisites[$target] = [];
+				}
+				foreach ($targetPrerequisites as $prerequisite) {
+					$prerequisites[$target][] = $prerequisite;
+				}
+			}
+		}
+		return $prerequisites;
+	}
+
+
+	/**
+	 * @throws MakefileContainsRealTargetsException
+	 * @throws MakefileNotFoundException
+	 */
+	public function checkAllTargetsArePhony(string $file): void
+	{
+		$notPhonyTargets = [];
+		$prerequisites = $this->getPrerequisites($file);
+		foreach ($prerequisites as $target => $prerequisite) {
+			if ($target === self::PHONY_TARGET) {
+				continue;
+			}
+			if (!in_array($target, $prerequisites[self::PHONY_TARGET])) {
+				$notPhonyTargets[$target] = $this->targetDefinitions[$target];
+			}
+		}
+		if ($notPhonyTargets) {
+			throw new MakefileContainsRealTargetsException($notPhonyTargets);
+		}
+	}
+
+}

--- a/site/bin/check-makefile.php
+++ b/site/bin/check-makefile.php
@@ -1,0 +1,21 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Bin;
+
+use MichalSpacekCz\Application\Bootstrap;
+use MichalSpacekCz\Makefile\Exceptions\MakefileException;
+use MichalSpacekCz\Makefile\Makefile;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$makefile = Bootstrap::bootCli()->getByType(Makefile::class);
+try {
+	$makefile->checkAllTargetsArePhony(__DIR__ . '/../Makefile');
+	echo "[Cajk] All Makefile targets are phony\n";
+	exit(0);
+} catch (MakefileException $e) {
+	echo "[Error] {$e->getMessage()}\n";
+	exit(1);
+}

--- a/site/composer.json
+++ b/site/composer.json
@@ -74,30 +74,5 @@
 		"psr-4": {
 			"MichalSpacekCz\\": "app/"
 		}
-	},
-	"scripts": {
-		"cs-fix": "vendor/squizlabs/php_codesniffer/bin/phpcbf app/ public/ tests/",
-		"check-file-patterns": "bin/check-file-patterns.sh",
-		"lint": "vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors app/ public/ tests/",
-		"lint-latte": "bin/latte-lint.php app/",
-		"lint-neon": "vendor/nette/neon/bin/neon-lint app/",
-		"lint-xml": "bin/xmllint.sh",
-		"phpcs": "vendor/squizlabs/php_codesniffer/bin/phpcs app/ public/ tests/",
-		"phpstan": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan.neon",
-		"phpstan-latte-templates": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-latte-templates.neon",
-		"phpstan-vendor": "vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-vendor.neon",
-		"test": [
-			"composer audit",
-			"@check-file-patterns",
-			"@lint",
-			"@lint-latte",
-			"@lint-neon",
-			"@lint-xml",
-			"@phpcs",
-			"@phpstan",
-			"@tester",
-			"@phpstan-vendor"
-		],
-		"tester": "vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/"
 	}
 }

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -52,6 +52,7 @@ services:
 	- MichalSpacekCz\Http\Redirections
 	- MichalSpacekCz\Http\SecurityHeaders(permissionsPolicy: %permissionsPolicy%)
 	- MichalSpacekCz\Interviews\Interviews
+	- MichalSpacekCz\Makefile\Makefile
 	interviewMediaResources: MichalSpacekCz\Media\Resources\InterviewMediaResources(imagesRoot: %domain.imagesRoot%, staticRoot: %domain.sharedStaticRoot%, locationRoot: %domain.locationRoot%)
 	talkMediaResources: MichalSpacekCz\Media\Resources\TalkMediaResources(imagesRoot: %domain.imagesRoot%, staticRoot: %domain.sharedStaticRoot%, locationRoot: %domain.locationRoot%)
 	- MichalSpacekCz\Media\SupportedImageFileFormats

--- a/site/tests/Makefile/MakefileTest.phpt
+++ b/site/tests/Makefile/MakefileTest.phpt
@@ -1,0 +1,71 @@
+<?php
+/** @noinspection PhpFullyQualifiedNameUsageInspection */
+/** @noinspection PhpDocMissingThrowsInspection */
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Makefile;
+
+use MichalSpacekCz\Makefile\Exceptions\MakefileContainsRealTargetsException;
+use Tester\Assert;
+use Tester\FileMock;
+use Tester\TestCase;
+
+$runner = require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class MakefileTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Makefile $makefile,
+	) {
+	}
+
+
+	/**
+	 * @throws \MichalSpacekCz\Makefile\Exceptions\MakefileNotFoundException Makefile 'Fake it till you makefile it.jpg' not found
+	 */
+	public function testCheckAllTargetsArePhonyNoFile(): void
+	{
+		$this->makefile->checkAllTargetsArePhony('Fake it till you makefile it.jpg');
+	}
+
+
+	public function testCheckAllTargetsArePhonyEmptyFile(): void
+	{
+		Assert::noError(function (): void {
+			$this->makefile->checkAllTargetsArePhony(FileMock::create());
+		});
+	}
+
+
+	public function testCheckAllTargetsArePhony(): void
+	{
+		Assert::noError(function (): void {
+			$makefile = FileMock::create(" foo bar   baz:\n\twaldo\n # comment: ignored\n.PHONY: foo\n.PHONY: bar baz");
+			$this->makefile->checkAllTargetsArePhony($makefile);
+		});
+	}
+
+
+	public function testCheckAllTargetsArePhonyOneIsNot(): void
+	{
+		Assert::throws(function (): void {
+			$makefile = FileMock::create("foo:\nbar:\n.PHONY:foo");
+			$this->makefile->checkAllTargetsArePhony($makefile);
+		}, MakefileContainsRealTargetsException::class, "Makefile contains a real target:\n- `bar` defined on line 2\nAdd it to a .PHONY target!");
+	}
+
+
+	public function testCheckAllTargetsArePhonyMultipleAreNot(): void
+	{
+		Assert::throws(function (): void {
+			$makefile = FileMock::create(" foo bar   baz:\n\twaldo\n # comment: ignored\n.PHONY: foo\nbaz:\n.PHONY: bar\nquux:");
+			$this->makefile->checkAllTargetsArePhony($makefile);
+		}, MakefileContainsRealTargetsException::class, "Makefile contains real targets:\n- `baz` defined on lines 1, 5\n- `quux` defined on line 7\nAdd them to a .PHONY target!");
+	}
+
+}
+
+$runner->run(MakefileTest::class);

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '141b3ca3af243e25c4139d915782072ae7b31a9b',
+        'reference' => 'e552a20e643b1c9b07e6daca9fdac775d2265616',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -435,7 +435,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '141b3ca3af243e25c4139d915782072ae7b31a9b',
+            'reference' => 'e552a20e643b1c9b07e6daca9fdac775d2265616',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Replace composer scripts with `Makefile`. The execution is marginally faster now, also adding a script doesn't require `composer.json` modifications.

All targets in the `Makefile` are also tested to make sure they're phony (listed in `.PHONY` special target).

A phony target is one that runs its recipe even if a file with the target's name already exists. I want all targets to be phony in case a file of the target's name suddenly appears which would prevent the recipe (and the test the recipe runs) to be executed.

Another option would be to check existing files whether they're not of the same name as the target names. Such check would need to run early enough before all tests.