### PR TITLE
Enable Trusted Types

### DIFF
--- a/site/config/contentsecuritypolicy.neon
+++ b/site/config/contentsecuritypolicy.neon
@@ -7,6 +7,7 @@ contentSecurityPolicy:
 		*.*:
 			default-src: "'none'"
 			form-action: "'none'"
+			require-trusted-types-for: "'script'"
 			report-uri: %reporting.contentSecurityPolicy%
 			report-to: default
 		*.*.*:
@@ -67,8 +68,3 @@ contentSecurityPolicy:
 			@extends: www.*.*
 		upckeys.*.*:
 			@extends: www.*.*
-	policiesReportOnly:
-		*.*.*:
-			require-trusted-types-for: "'script'"
-			report-uri: %reporting.contentSecurityPolicy%
-			report-to: default

--- a/site/config/contentsecuritypolicy.neon
+++ b/site/config/contentsecuritypolicy.neon
@@ -8,6 +8,7 @@ contentSecurityPolicy:
 			default-src: "'none'"
 			form-action: "'none'"
 			require-trusted-types-for: "'script'"
+			trusted-types:
 			report-uri: %reporting.contentSecurityPolicy%
 			report-to: default
 		*.*.*:


### PR DESCRIPTION
Require Trusted Types using an enforcing CSP, not report-only & disallows creating any Trusted Type policy.

Close #56