### PR TITLE
`getAction()` is defined on `Ui\Presenter` only but generic error presenters do not extend it

### DIFF
--- a/site/app/Http/SecurityHeaders.php
+++ b/site/app/Http/SecurityHeaders.php
@@ -71,9 +71,8 @@ class SecurityHeaders
 
 	public function sendHeaders(CspValues $cspValues = CspValues::Specific): void
 	{
-		if ($cspValues === CspValues::Specific) {
-			/** @var Presenter $presenter */
-			$presenter = $this->application->getPresenter();
+		$presenter = $this->application->getPresenter();
+		if ($cspValues === CspValues::Specific && $presenter instanceof Presenter) {
 			$actionName = $presenter->getAction(true);
 		} else {
 			$actionName = $this->contentSecurityPolicy->getDefaultKey();


### PR DESCRIPTION
Extending it turned out to be a bit more difficult so `ErrorGenericPresenter`s get a default CSP config even if it should be a specific config, which seems fine.