### PR TITLE
Don't run the security.txt check on PHP 8.3, ext-gnupg is not yet available

### DIFF
--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -13,7 +13,6 @@ jobs:
       matrix:
         php-version:
           - "8.2"
-          - "8.3"
         host:
           - www.michalspacek.cz
           - www.michalspacek.com


### PR DESCRIPTION
Added in #161
For #159

The setup-php log:
```
Run shivammathur/setup-php@v2
  with:
    coverage: none
    php-version: 8.3
    extensions: gnupg
    ini-file: production
/usr/bin/bash /home/runner/work/_actions/shivammathur/setup-php/v2/src/scripts/run.sh

==> Setup PHP
✓ PHP Installed PHP 8.3.0-dev (78d98e50c4c051de0aa1af8da51b552135dc569d)

==> Setup Extensions
✗ gnupg Could not install gnupg on PHP 8.3.0-dev
```