### PR TITLE
Spaze/certificates add timezone

### DIFF
--- a/site/app/Api/Presenters/CertificatesPresenter.php
+++ b/site/app/Api/Presenters/CertificatesPresenter.php
@@ -7,9 +7,11 @@ use MichalSpacekCz\Http\HttpInput;
 use MichalSpacekCz\Tls\CertificateAttemptFactory;
 use MichalSpacekCz\Tls\CertificateFactory;
 use MichalSpacekCz\Tls\Certificates;
+use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\SomeCertificatesLoggedToFileException;
 use MichalSpacekCz\Www\Presenters\BasePresenter;
 use Nette\Security\AuthenticationException;
+use Tracy\Debugger;
 
 class CertificatesPresenter extends BasePresenter
 {
@@ -43,9 +45,9 @@ class CertificatesPresenter extends BasePresenter
 
 	public function actionLogIssued(): void
 	{
-		$certs = $this->certificateFactory->listFromLogRequest($this->httpInput->getPostArray('certs') ?? []);
-		$failures = $this->certificateAttemptFactory->listFromLogRequest($this->httpInput->getPostArray('failure') ?? []);
 		try {
+			$certs = $this->certificateFactory->listFromLogRequest($this->httpInput->getPostArray('certs') ?? []);
+			$failures = $this->certificateAttemptFactory->listFromLogRequest($this->httpInput->getPostArray('failure') ?? []);
 			$count = $this->certificates->log($certs, $failures);
 			$this->sendJson([
 				'status' => 'ok',
@@ -54,6 +56,9 @@ class CertificatesPresenter extends BasePresenter
 			]);
 		} catch (SomeCertificatesLoggedToFileException) {
 			$this->sendJson(['status' => 'error', 'statusMessage' => 'Some certs logged to file']);
+		} catch (CertificateException $e) {
+			Debugger::log($e);
+			$this->sendJson(['status' => 'error', 'statusMessage' => 'Request logged but certs not']);
 		}
 	}
 

--- a/site/app/DateTime/DateTimeFactory.php
+++ b/site/app/DateTime/DateTimeFactory.php
@@ -4,11 +4,21 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\DateTime;
 
 use DateTimeImmutable;
+use DateTimeInterface;
 use DateTimeZone;
+use Exception;
+use MichalSpacekCz\DateTime\Exceptions\CannotCreateDateTimeObjectException;
 use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
 
 class DateTimeFactory
 {
+
+	public function __construct(
+		private readonly DateTimeZoneFactory $dateTimeZoneFactory,
+	) {
+	}
+
 
 	/**
 	 * Similar to \Nette\Utils\DateTime::createFromFormat() except this method returns \DateTimeImmutable.
@@ -22,6 +32,21 @@ class DateTimeFactory
 			throw new CannotParseDateTimeException($format, $datetime);
 		}
 		return $date;
+	}
+
+
+	/**
+	 * @throws InvalidTimezoneException
+	 * @throws CannotCreateDateTimeObjectException
+	 */
+	public function createFrom(DateTimeInterface $dateTime, ?string $timezoneId = null): DateTimeImmutable
+	{
+		$timezone = $timezoneId ? $this->dateTimeZoneFactory->get($timezoneId) : null;
+		try {
+			return new DateTimeImmutable($dateTime->format('Y-m-d H:i:s.u'), $timezone);
+		} catch (Exception $e) {
+			throw new CannotCreateDateTimeObjectException($e);
+		}
 	}
 
 }

--- a/site/app/DateTime/DateTimeFactory.php
+++ b/site/app/DateTime/DateTimeFactory.php
@@ -7,7 +7,7 @@ use DateTimeImmutable;
 use DateTimeZone;
 use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
 
-class DateTimeParser
+class DateTimeFactory
 {
 
 	/**

--- a/site/app/DateTime/DateTimeFactory.php
+++ b/site/app/DateTime/DateTimeFactory.php
@@ -25,7 +25,7 @@ class DateTimeFactory
 	 *
 	 * @throws CannotParseDateTimeException
 	 */
-	public static function createFromFormat(string $format, string $datetime, DateTimeZone $timezone = null): DateTimeImmutable
+	public function createFromFormat(string $format, string $datetime, ?DateTimeZone $timezone = null): DateTimeImmutable
 	{
 		$date = DateTimeImmutable::createFromFormat($format, $datetime, $timezone);
 		if ($date === false) {

--- a/site/app/DateTime/Exceptions/CannotCreateDateTimeObjectException.php
+++ b/site/app/DateTime/Exceptions/CannotCreateDateTimeObjectException.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime\Exceptions;
+
+use Throwable;
+
+class CannotCreateDateTimeObjectException extends DateTimeException
+{
+
+	public function __construct(?Throwable $previous = null)
+	{
+		parent::__construct('Cannot create a DateTime or DateTimeImmutable object', $previous);
+	}
+
+}

--- a/site/app/DateTime/Exceptions/DateTimeException.php
+++ b/site/app/DateTime/Exceptions/DateTimeException.php
@@ -12,7 +12,10 @@ abstract class DateTimeException extends Exception
 
 	public function __construct(string $message, Throwable $previous = null)
 	{
-		$message .= ' ' . Json::encode(date_get_last_errors());
+		$errors = date_get_last_errors();
+		if ($errors) {
+			$message .= ' ' . Json::encode($errors);
+		}
 		parent::__construct($message, 0, $previous);
 	}
 

--- a/site/app/DateTime/Exceptions/InvalidTimezoneException.php
+++ b/site/app/DateTime/Exceptions/InvalidTimezoneException.php
@@ -3,10 +3,9 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\DateTime\Exceptions;
 
-use Exception;
 use Throwable;
 
-class InvalidTimezoneException extends Exception
+class InvalidTimezoneException extends DateTimeException
 {
 
 	public function __construct(string $timezone, ?Throwable $previous = null)

--- a/site/app/Tls/CertificateFactory.php
+++ b/site/app/Tls/CertificateFactory.php
@@ -12,6 +12,7 @@ use MichalSpacekCz\DateTime\Exceptions\DateTimeException;
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
 use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
+use MichalSpacekCz\Tls\Exceptions\OpenSslX509ParseException;
 use Nette\Database\Row;
 use OpenSSLCertificate;
 
@@ -47,6 +48,7 @@ class CertificateFactory
 	 * @throws OpenSslException
 	 * @throws CannotParseDateTimeException
 	 * @throws CertificateException
+	 * @throws OpenSslX509ParseException
 	 */
 	public function fromObject(OpenSSLCertificate $certificate): Certificate
 	{
@@ -107,6 +109,7 @@ class CertificateFactory
 	/**
 	 * @param array<string|int, mixed> $request
 	 * @return list<Certificate>
+	 * @throws CertificateException
 	 */
 	public function listFromLogRequest(array $request): array
 	{

--- a/site/app/Tls/CertificateFactory.php
+++ b/site/app/Tls/CertificateFactory.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\DateTime\DateTime;
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\DateTime\DateTimeZoneFactory;
 use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
+use MichalSpacekCz\DateTime\Exceptions\DateTimeException;
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
 use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
@@ -19,6 +20,7 @@ class CertificateFactory
 
 	public function __construct(
 		private readonly DateTimeZoneFactory $dateTimeZoneFactory,
+		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly int $expiringThreshold,
 	) {
 	}
@@ -26,14 +28,15 @@ class CertificateFactory
 
 	/**
 	 * @throws CertificateException
+	 * @throws DateTimeException
 	 */
 	public function fromDatabaseRow(Row $row): Certificate
 	{
 		return new Certificate(
 			$row->cn,
 			$row->ext,
-			DateTimeImmutable::createFromInterface($row->notBefore),
-			DateTimeImmutable::createFromInterface($row->notAfter),
+			$this->dateTimeFactory->createFrom($row->notBefore, $row->notBeforeTimezone),
+			$this->dateTimeFactory->createFrom($row->notAfter, $row->notAfterTimezone),
 			$this->expiringThreshold,
 			null,
 		);

--- a/site/app/Tls/CertificateFactory.php
+++ b/site/app/Tls/CertificateFactory.php
@@ -5,7 +5,7 @@ namespace MichalSpacekCz\Tls;
 
 use DateTimeImmutable;
 use MichalSpacekCz\DateTime\DateTime;
-use MichalSpacekCz\DateTime\DateTimeParser;
+use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\DateTime\DateTimeZoneFactory;
 use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
@@ -51,8 +51,8 @@ class CertificateFactory
 		return new Certificate(
 			$details['subject']['commonName'],
 			null,
-			DateTimeParser::createFromFormat('U', (string)$details['validFrom_time_t']),
-			DateTimeParser::createFromFormat('U', (string)$details['validTo_time_t']),
+			DateTimeFactory::createFromFormat('U', (string)$details['validFrom_time_t']),
+			DateTimeFactory::createFromFormat('U', (string)$details['validTo_time_t']),
 			$this->expiringThreshold,
 			$details['serialNumberHex'],
 		);
@@ -97,7 +97,7 @@ class CertificateFactory
 	 */
 	private function createDateTimeImmutable(string $time, string $timeZone): DateTimeImmutable
 	{
-		return DateTimeParser::createFromFormat(DateTime::DATE_RFC3339_MICROSECONDS, $time)->setTimezone($this->dateTimeZoneFactory->get($timeZone));
+		return DateTimeFactory::createFromFormat(DateTime::DATE_RFC3339_MICROSECONDS, $time)->setTimezone($this->dateTimeZoneFactory->get($timeZone));
 	}
 
 

--- a/site/app/Tls/CertificateFactory.php
+++ b/site/app/Tls/CertificateFactory.php
@@ -56,8 +56,8 @@ class CertificateFactory
 		return new Certificate(
 			$details['subject']['commonName'],
 			null,
-			DateTimeFactory::createFromFormat('U', (string)$details['validFrom_time_t']),
-			DateTimeFactory::createFromFormat('U', (string)$details['validTo_time_t']),
+			$this->dateTimeFactory->createFromFormat('U', (string)$details['validFrom_time_t']),
+			$this->dateTimeFactory->createFromFormat('U', (string)$details['validTo_time_t']),
 			$this->expiringThreshold,
 			$details['serialNumberHex'],
 		);
@@ -102,7 +102,7 @@ class CertificateFactory
 	 */
 	private function createDateTimeImmutable(string $time, string $timeZone): DateTimeImmutable
 	{
-		return DateTimeFactory::createFromFormat(DateTime::DATE_RFC3339_MICROSECONDS, $time)->setTimezone($this->dateTimeZoneFactory->get($timeZone));
+		return $this->dateTimeFactory->createFromFormat(DateTime::DATE_RFC3339_MICROSECONDS, $time)->setTimezone($this->dateTimeZoneFactory->get($timeZone));
 	}
 
 

--- a/site/app/Tls/CertificateGatherer.php
+++ b/site/app/Tls/CertificateGatherer.php
@@ -9,6 +9,7 @@ use MichalSpacekCz\Net\DnsResolver;
 use MichalSpacekCz\Net\Exceptions\DnsGetRecordException;
 use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
+use MichalSpacekCz\Tls\Exceptions\OpenSslX509ParseException;
 
 class CertificateGatherer
 {
@@ -29,6 +30,7 @@ class CertificateGatherer
 	 * @throws CertificateException
 	 * @throws OpenSslException
 	 * @throws DnsGetRecordException
+	 * @throws OpenSslX509ParseException
 	 */
 	public function fetchCertificates(string $hostname, bool $includeIpv6): array
 	{
@@ -45,6 +47,7 @@ class CertificateGatherer
 	 * @throws OpenSslException
 	 * @throws CertificateException
 	 * @throws CannotParseDateTimeException
+	 * @throws OpenSslX509ParseException
 	 */
 	private function fetchCertificate(string $hostname, ?string $ipv4, ?string $ipv6): Certificate
 	{

--- a/site/app/Tls/Certificates.php
+++ b/site/app/Tls/Certificates.php
@@ -90,7 +90,9 @@ class Certificates
 				$this->database->query('INSERT INTO certificates', [
 					'key_certificate_request' => $this->logRequest($cert, true),
 					'not_before' => $cert->getNotBefore(),
+					'not_before_timezone' => $cert->getNotBefore()->getTimezone()->getName(),
 					'not_after' => $cert->getNotAfter(),
+					'not_after_timezone' => $cert->getNotAfter()->getTimezone()->getName(),
 				]);
 				$this->database->commit();
 			} catch (DriverException $e) {
@@ -128,10 +130,12 @@ class Certificates
 
 	private function logRequest(Certificate|CertificateAttempt $certificate, bool $success): int
 	{
+		$now = new DateTimeImmutable();
 		$this->database->query('INSERT INTO certificate_requests', [
 			'cn' => $certificate->getCommonName(),
 			'ext' => $certificate->getCommonNameExt(),
-			'time' => new DateTimeImmutable(),
+			'time' => $now,
+			'time_timezone' => $now->getTimezone()->getName(),
 			'success' => $success,
 		]);
 		return (int)$this->database->getInsertId();

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -16,6 +16,7 @@ services:
 	- MichalSpacekCz\CompanyInfo\Ares(url: %ares.url%)
 	- MichalSpacekCz\CompanyInfo\CompanyInfo(loadCompanyDataVisible: %loadCompanyDataVisible%)
 	- MichalSpacekCz\CompanyInfo\RegisterUz(rootUrl: %registerUz.rootUrl%)
+	- MichalSpacekCz\DateTime\DateTimeFactory
 	- MichalSpacekCz\DateTime\DateTimeFormatter(@translation.translator::getDefaultLocale())
 	- MichalSpacekCz\DateTime\DateTimeZoneFactory
 	- MichalSpacekCz\EasterEgg\FourOhFourButFound

--- a/site/tests/DateTime/DateTimeFactoryTest.phpt
+++ b/site/tests/DateTime/DateTimeFactoryTest.phpt
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\DateTime;
 
 use DateTimeImmutable;
+use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
 use Tester\Assert;
 use Tester\TestCase;
@@ -18,6 +19,19 @@ class DateTimeFactoryTest extends TestCase
 	public function __construct(
 		private readonly DateTimeFactory $dateTimeFactory,
 	) {
+	}
+
+
+	public function testCreateFromFormat(): void
+	{
+		$dateTime = $this->dateTimeFactory->createFromFormat('j-M-Y', '15-Feb-2009');
+		Assert::same('2009', $dateTime->format('Y'));
+		Assert::same('02', $dateTime->format('m'));
+		Assert::same('15', $dateTime->format('d'));
+
+		Assert::exception(function (): void {
+			$this->dateTimeFactory->createFromFormat('foo', '15-Feb-2009');
+		}, CannotParseDateTimeException::class, "~^Cannot parse '15-Feb-2009' using format 'foo'~");
 	}
 
 

--- a/site/tests/DateTime/DateTimeFactoryTest.phpt
+++ b/site/tests/DateTime/DateTimeFactoryTest.phpt
@@ -1,0 +1,40 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\DateTime;
+
+use DateTimeImmutable;
+use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
+use Tester\Assert;
+use Tester\TestCase;
+
+$runner = require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class DateTimeFactoryTest extends TestCase
+{
+
+	public function __construct(
+		private readonly DateTimeFactory $dateTimeFactory,
+	) {
+	}
+
+
+	public function testCreateFrom(): void
+	{
+		Assert::exception(function (): void {
+			$this->dateTimeFactory->createFrom(new DateTimeImmutable(), 'Europe/Brno');
+		}, InvalidTimezoneException::class, "Invalid timezone 'Europe/Brno'");
+
+		$niceDate = '2020-10-10 20:30:40';
+		$niceDateTime = new DateTimeImmutable("{$niceDate} UTC");
+		$newDateTime = $this->dateTimeFactory->createFrom($niceDateTime, 'Europe/Prague');
+		Assert::same($niceDate, $newDateTime->format('Y-m-d H:i:s'));
+		Assert::same('Europe/Prague', $newDateTime->getTimezone()->getName());
+		Assert::notSame($niceDateTime->getTimestamp(), $newDateTime->getTimestamp());
+	}
+
+}
+
+$runner->run(DateTimeFactoryTest::class);

--- a/site/tests/Tls/CertificateFactoryTest.phpt
+++ b/site/tests/Tls/CertificateFactoryTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Tls;
 
 use DateTimeImmutable;
 use MichalSpacekCz\DateTime\DateTime;
+use Nette\Database\Row;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tester\TestCase;
@@ -71,6 +72,26 @@ class CertificateFactoryTest extends TestCase
 		Assert::null($certs[1]->getCommonNameExt());
 		Assert::same('2023-05-26T12:14:12.000000+00:00', $certs[0]->getNotBefore()->format(DateTime::DATE_RFC3339_MICROSECONDS));
 		Assert::same('2023-06-25T12:13:58.000000+00:00', $certs[0]->getNotAfter()->format(DateTime::DATE_RFC3339_MICROSECONDS));
+	}
+
+
+	public function testFromDatabaseRow(): void
+	{
+		$data = [
+			'cn' => 'foo.example',
+			'ext' => 'ec',
+			'notBefore' => new DateTimeImmutable('2020-10-05 04:03:02'),
+			'notBeforeTimezone' => 'UTC',
+			'notAfter' => new DateTimeImmutable('2021-11-06 14:13:12'),
+			'notAfterTimezone' => 'Europe/Prague',
+		];
+		$certificate = $this->certificateFactory->fromDatabaseRow(Row::from($data));
+		Assert::same('foo.example', $certificate->getCommonName());
+		Assert::same('ec', $certificate->getCommonNameExt());
+		Assert::same(1601870582, $certificate->getNotBefore()->getTimestamp());
+		Assert::same('UTC', $certificate->getNotBefore()->getTimezone()->getName());
+		Assert::same(1636204392, $certificate->getNotAfter()->getTimestamp());
+		Assert::same('Europe/Prague', $certificate->getNotAfter()->getTimezone()->getName());
 	}
 
 }


### PR DESCRIPTION
Store timezone to notBefore, noAfter & request when logging issued certificates and re-construct notBefore and notAfter objects using the stored timezone id.

The re-construction is a different operation than calling `DateTimeImmutable::setTimezone()` because unlike that method, the re-construction will change the underlying point-in-time here. Say you have an object with "17:18:19 UTC", this will change it to "17:18:19 Europe/Prague" or any other depending what you provide as a timezone identifier.

Close #167