### PR TITLE
Blog post edits may be accessed without being previously set

### DIFF
--- a/site/app/Articles/Blog/BlogPost.php
+++ b/site/app/Articles/Blog/BlogPost.php
@@ -75,7 +75,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	public ?string $editSummary;
 
 	/** @var list<ArticleEdit> */
-	public array $edits;
+	public array $edits = [];
 
 	/** @var list<string> */
 	public array $cspSnippets = [];


### PR DESCRIPTION
Another way to fix it would be to set the property to an empty array in `PostFormFactory::buildPost()`.

Close #169