### PR TITLE
Display trainings on a venue page again

### DIFF
--- a/site/app/Training/DateList/UpcomingTrainingDatesList.php
+++ b/site/app/Training/DateList/UpcomingTrainingDatesList.php
@@ -3,12 +3,18 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\DateList;
 
+use Countable;
 use MichalSpacekCz\Application\UiControl;
+use MichalSpacekCz\Training\Dates\UpcomingTraining;
 use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use MichalSpacekCz\Training\FreeSeats;
 
-class UpcomingTrainingDatesList extends UiControl
+class UpcomingTrainingDatesList extends UiControl implements Countable
 {
+
+	/** @var array<string, UpcomingTraining>|null */
+	private ?array $upcomingTrainings = null;
+
 
 	public function __construct(
 		private readonly UpcomingTrainingDates $upcomingTrainingDates,
@@ -22,13 +28,31 @@ class UpcomingTrainingDatesList extends UiControl
 
 	public function render(): void
 	{
-		$upcomingTrainings = $this->venueId ? $this->upcomingTrainingDates->getPublicUpcomingAtVenue($this->venueId) : $this->upcomingTrainingDates->getPublicUpcoming();
-		if ($this->excludeTraining) {
-			unset($upcomingTrainings[$this->excludeTraining]);
-		}
+		$upcomingTrainings = $this->getUpcomingTrainingDates();
 		$this->template->lastFreeSeats = $this->showLastFreeSeats && $this->freeSeats->lastFreeSeatsAnyTraining($upcomingTrainings);
 		$this->template->upcomingTrainings = $upcomingTrainings;
 		$this->template->render(__DIR__ . '/upcomingTrainingDatesList.latte');
+	}
+
+
+	/**
+	 * @return array<string, UpcomingTraining>
+	 */
+	private function getUpcomingTrainingDates(): array
+	{
+		if ($this->upcomingTrainings === null) {
+			$this->upcomingTrainings = $this->venueId ? $this->upcomingTrainingDates->getPublicUpcomingAtVenue($this->venueId) : $this->upcomingTrainingDates->getPublicUpcoming();
+			if ($this->excludeTraining) {
+				unset($this->upcomingTrainings[$this->excludeTraining]);
+			}
+		}
+		return $this->upcomingTrainings;
+	}
+
+
+	public function count(): int
+	{
+		return count($this->getUpcomingTrainingDates());
 	}
 
 }

--- a/site/app/Training/DateList/UpcomingTrainingDatesList.php
+++ b/site/app/Training/DateList/UpcomingTrainingDatesList.php
@@ -15,7 +15,7 @@ class UpcomingTrainingDatesList extends UiControl
 		private readonly FreeSeats $freeSeats,
 		private readonly ?string $excludeTraining,
 		private readonly bool $showLastFreeSeats,
-		private readonly ?int $venueId = null,
+		private readonly ?int $venueId,
 	) {
 	}
 

--- a/site/app/Training/DateList/UpcomingTrainingDatesListFactory.php
+++ b/site/app/Training/DateList/UpcomingTrainingDatesListFactory.php
@@ -3,9 +3,34 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\DateList;
 
-interface UpcomingTrainingDatesListFactory
+use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
+use MichalSpacekCz\Training\FreeSeats;
+
+class UpcomingTrainingDatesListFactory
 {
 
-	public function create(?string $excludeTraining, bool $showLastFreeSeats, ?int $venueId = null): UpcomingTrainingDatesList;
+	public function __construct(
+		private readonly UpcomingTrainingDates $upcomingTrainingDates,
+		private readonly FreeSeats $freeSeats,
+	) {
+	}
+
+
+	public function create(): UpcomingTrainingDatesList
+	{
+		return new UpcomingTrainingDatesList($this->upcomingTrainingDates, $this->freeSeats, null, true, null);
+	}
+
+
+	public function createExclude(string $excludeTraining): UpcomingTrainingDatesList
+	{
+		return new UpcomingTrainingDatesList($this->upcomingTrainingDates, $this->freeSeats, $excludeTraining, false, null);
+	}
+
+
+	public function createForVenue(int $venueId): UpcomingTrainingDatesList
+	{
+		return new UpcomingTrainingDatesList($this->upcomingTrainingDates, $this->freeSeats, null, true, $venueId);
+	}
 
 }

--- a/site/app/Www/Presenters/HomepagePresenter.php
+++ b/site/app/Www/Presenters/HomepagePresenter.php
@@ -44,7 +44,7 @@ class HomepagePresenter extends BasePresenter
 
 	protected function createComponentUpcomingDatesList(): UpcomingTrainingDatesList
 	{
-		return $this->upcomingTrainingDatesListFactory->create(null, true);
+		return $this->upcomingTrainingDatesListFactory->create();
 	}
 
 

--- a/site/app/Www/Presenters/TrainingsPresenter.php
+++ b/site/app/Www/Presenters/TrainingsPresenter.php
@@ -34,7 +34,7 @@ class TrainingsPresenter extends BasePresenter
 	/** @var array<int, TrainingDate> id => date */
 	private array $dates;
 
-	private ?string $trainingAction = null;
+	private string $trainingAction;
 
 
 	public function __construct(
@@ -66,7 +66,7 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentUpcomingDatesList(): UpcomingTrainingDatesList
 	{
-		return $this->upcomingTrainingDatesListFactory->create(null, true);
+		return $this->upcomingTrainingDatesListFactory->create();
 	}
 
 
@@ -312,7 +312,7 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentOtherUpcomingDatesList(): UpcomingTrainingDatesList
 	{
-		return $this->upcomingTrainingDatesListFactory->create($this->trainingAction, false);
+		return $this->upcomingTrainingDatesListFactory->createExclude($this->trainingAction);
 	}
 
 

--- a/site/app/Www/Presenters/VenuesPresenter.php
+++ b/site/app/Www/Presenters/VenuesPresenter.php
@@ -14,6 +14,7 @@ class VenuesPresenter extends BasePresenter
 {
 
 	private int $venueId;
+	private UpcomingTrainingDatesList $upcomingTrainingDatesList;
 
 
 	public function __construct(
@@ -33,15 +34,17 @@ class VenuesPresenter extends BasePresenter
 			throw new BadRequestException("Where in the world is {$name}?", previous: $e);
 		}
 		$this->venueId = $venue->getId();
+		$this->upcomingTrainingDatesList = $this->upcomingTrainingDatesListFactory->createForVenue($this->venueId);
 
 		$this->template->pageTitle = $this->texyFormatter->translate('messages.title.venue', [$venue->getName()]);
 		$this->template->venue = $venue;
+		$this->template->hasUpcomingTrainings = count($this->upcomingTrainingDatesList) > 0;
 	}
 
 
 	protected function createComponentUpcomingDatesList(): UpcomingTrainingDatesList
 	{
-		return $this->upcomingTrainingDatesListFactory->createForVenue($this->venueId);
+		return $this->upcomingTrainingDatesList;
 	}
 
 }

--- a/site/app/Www/Presenters/VenuesPresenter.php
+++ b/site/app/Www/Presenters/VenuesPresenter.php
@@ -41,7 +41,7 @@ class VenuesPresenter extends BasePresenter
 
 	protected function createComponentUpcomingDatesList(): UpcomingTrainingDatesList
 	{
-		return $this->upcomingTrainingDatesListFactory->create(null, true, $this->venueId);
+		return $this->upcomingTrainingDatesListFactory->createForVenue($this->venueId);
 	}
 
 }

--- a/site/app/Www/Presenters/templates/Venues/venue.latte
+++ b/site/app/Www/Presenters/templates/Venues/venue.latte
@@ -17,7 +17,7 @@
 </p>
 
 <h3>{_messages.venues.trainingshere}</h3>
-{if empty($upcomingTrainings)}
+{if !$hasUpcomingTrainings}
 <p>{_messages.venues.notraininghere|format:"link:Www:Contact:"}</p>
 {else}
 {control upcomingDatesList}


### PR DESCRIPTION
This was a regression introduced in #143 in commit f0fc546 when I've converted included pages to a component and forgot there's no variable anymore. They were right, `empty()` considered harmful.