### PR TITLE
Pass a training action, not a name

### DIFF
--- a/site/app/Www/Presenters/templates/CompanyTrainings/training.latte
+++ b/site/app/Www/Presenters/templates/CompanyTrainings/training.latte
@@ -59,7 +59,7 @@
 	<div class="indent"><p>{$review->getReview()} <small n:if="$review->getHref()">(<a href="{$review->getHref()}">{_messages.trainings.more}</a>)</small></p></div>
 {/foreach}
 </div>
-<p>{_messages.companytrainings.morereviews|format:"link:Www:Trainings:reviews {$training->getName()}"}</p>
+<p>{_messages.companytrainings.morereviews|format:"link:Www:Trainings:reviews {$training->getAction()}"}</p>
 <hr>
 {/if}
 


### PR DESCRIPTION
Regression introduced in #179 commit dcb4c384a41fa61659bca1e41bc8358368d6ffab because previously `$name` was the action.