### PR TITLE
`$trainingAction` is not always initialized like in the default action

### DIFF
--- a/site/app/Www/Presenters/TrainingsPresenter.php
+++ b/site/app/Www/Presenters/TrainingsPresenter.php
@@ -323,7 +323,7 @@ class TrainingsPresenter extends BasePresenter
 	 */
 	protected function getLocaleLinkParams(): array
 	{
-		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction, $this->getParameters());
+		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction ?? null, $this->getParameters());
 	}
 
 


### PR DESCRIPTION
Regression introduced in #180 commit c455d80c30ea5532b4074b013d81d179863bc046