### PR TITLE
Rename `blog_post_locales` table and columns to more general `locales`

### DIFF
--- a/site/app/Articles/Articles.php
+++ b/site/app/Articles/Articles.php
@@ -67,7 +67,7 @@ class Articles
 			UNION ALL
 				SELECT
 					bp.id_blog_post,
-					l.id_blog_post_locale,
+					l.id_locale,
 					bp.key_translation_group,
 					l.locale,
 					bp.title,
@@ -89,8 +89,8 @@ class Articles
 					null AS twitterCardId,
 					bp.omit_exports AS omitExports
 				FROM blog_posts bp
-				LEFT JOIN blog_post_locales l
-					ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l
+					ON l.id_locale = bp.key_locale
 				WHERE bp.published IS NOT NULL
 					AND bp.published <= ?
 					AND l.locale = ?
@@ -115,7 +115,7 @@ class Articles
 	{
 		$query = 'SELECT
 					bp.id_blog_post AS id,
-					l.id_blog_post_locale AS localeId,
+					l.id_locale AS localeId,
 					bp.key_translation_group AS translationGroupId,
 					l.locale,
 					bp.title AS titleTexy,
@@ -136,8 +136,8 @@ class Articles
 					null AS twitterCardId,
 					bp.omit_exports AS omitExports
 				FROM blog_posts bp
-				LEFT JOIN blog_post_locales l
-					ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l
+					ON l.id_locale = bp.key_locale
 				WHERE
 					JSON_CONTAINS(bp.slug_tags, ?)
 					AND bp.published IS NOT NULL
@@ -162,8 +162,8 @@ class Articles
 					bp.slug_tags AS slugTags,
 					bp.published
 				FROM blog_posts bp
-				LEFT JOIN blog_post_locales l
-					ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l
+					ON l.id_locale = bp.key_locale
 				WHERE
 					bp.tags IS NOT NULL
 					AND bp.published IS NOT NULL
@@ -197,8 +197,8 @@ class Articles
 					bp.tags,
 					bp.slug_tags AS slugTags
 				FROM blog_posts bp
-				LEFT JOIN blog_post_locales l
-					ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l
+					ON l.id_locale = bp.key_locale
 				WHERE
 					JSON_CONTAINS(bp.slug_tags, ?)
 					AND bp.published IS NOT NULL
@@ -230,7 +230,7 @@ class Articles
 		$query = 'SELECT a.date FROM articles a WHERE a.date > ?
 			UNION ALL
 			SELECT bp.published FROM blog_posts bp
-				LEFT JOIN blog_post_locales l ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l ON l.id_locale = bp.key_locale
 			WHERE bp.published IS NOT NULL AND bp.published > ? AND l.locale = ?
 			ORDER BY date
 			LIMIT 1';
@@ -253,7 +253,7 @@ class Articles
 	public function getNearestPublishDateByTags(array $tags): ?DateTime
 	{
 		$query = 'SELECT bp.published FROM blog_posts bp
-				LEFT JOIN blog_post_locales l ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l ON l.id_locale = bp.key_locale
 			WHERE JSON_CONTAINS(bp.slug_tags, ?)
 				AND bp.published IS NOT NULL
 				AND bp.published > ?

--- a/site/app/Articles/Blog/BlogPostLoader.php
+++ b/site/app/Articles/Blog/BlogPostLoader.php
@@ -45,7 +45,7 @@ class BlogPostLoader
 			$result = $this->database->fetch(
 				'SELECT
 					bp.id_blog_post AS postId,
-					l.id_blog_post_locale AS localeId,
+					l.id_locale AS localeId,
 					bp.key_translation_group AS translationGroupId,
 					l.locale,
 					bp.slug,
@@ -66,8 +66,8 @@ class BlogPostLoader
 					tct.card AS twitterCard,
 					tct.title AS twitterCardTitle
 				FROM blog_posts bp
-				LEFT JOIN blog_post_locales l
-					ON l.id_blog_post_locale = bp.key_locale
+				LEFT JOIN locales l
+					ON l.id_locale = bp.key_locale
 				LEFT JOIN twitter_card_types tct
 					ON tct.id_twitter_card_type = bp.key_twitter_card_type
 				WHERE bp.slug = ?

--- a/site/app/Articles/Blog/BlogPostLocaleUrls.php
+++ b/site/app/Articles/Blog/BlogPostLocaleUrls.php
@@ -35,10 +35,10 @@ class BlogPostLocaleUrls
 				bp.slug_tags AS slugTags
 			FROM
 				blog_posts bp
-			LEFT JOIN blog_post_locales l ON l.id_blog_post_locale = bp.key_locale
+			LEFT JOIN locales l ON l.id_locale = bp.key_locale
 			WHERE bp.key_translation_group = (SELECT key_translation_group FROM blog_posts WHERE slug = ?)
 				OR bp.slug = ?
-			ORDER BY l.id_blog_post_locale';
+			ORDER BY l.id_locale';
 		foreach ($this->database->fetchAll($sql, $slug, $slug) as $row) {
 			$post = new BlogPost();
 			$post->locale = $row->locale;

--- a/site/app/Articles/Blog/BlogPosts.php
+++ b/site/app/Articles/Blog/BlogPosts.php
@@ -99,7 +99,7 @@ class BlogPosts
 		$result = $this->database->fetch(
 			'SELECT
 				bp.id_blog_post AS postId,
-				l.id_blog_post_locale AS localeId,
+				l.id_locale AS localeId,
 				bp.key_translation_group AS translationGroupId,
 				l.locale,
 				bp.slug,
@@ -120,8 +120,8 @@ class BlogPosts
 				tct.card AS twitterCard,
 				tct.title AS twitterCardTitle
 			FROM blog_posts bp
-			LEFT JOIN blog_post_locales l
-				ON l.id_blog_post_locale = bp.key_locale
+			LEFT JOIN locales l
+				ON l.id_locale = bp.key_locale
 			LEFT JOIN twitter_card_types tct
 				ON tct.id_twitter_card_type = bp.key_twitter_card_type
 			WHERE bp.id_blog_post = ?',
@@ -146,7 +146,7 @@ class BlogPosts
 		$posts = [];
 		$sql = 'SELECT
 				bp.id_blog_post AS postId,
-				l.id_blog_post_locale AS localeId,
+				l.id_locale AS localeId,
 				bp.key_translation_group AS translationGroupId,
 				l.locale,
 				bp.slug,
@@ -166,8 +166,8 @@ class BlogPosts
 				null AS twitterCardId
 			FROM
 				blog_posts bp
-			LEFT JOIN blog_post_locales l
-				ON l.id_blog_post_locale = bp.key_locale
+			LEFT JOIN locales l
+				ON l.id_locale = bp.key_locale
 			ORDER BY
 				published, slug';
 		foreach ($this->database->fetchAll($sql) as $row) {
@@ -320,7 +320,7 @@ class BlogPosts
 	public function getAllLocales(): array
 	{
 		if ($this->locales === null) {
-			$this->locales = $this->database->fetchPairs('SELECT id_blog_post_locale, locale FROM blog_post_locales ORDER BY id_blog_post_locale');
+			$this->locales = $this->database->fetchPairs('SELECT id_locale, locale FROM locales ORDER BY id_locale');
 		}
 		return $this->locales;
 	}


### PR DESCRIPTION
Column `id_blog_post_locale` has been renamed to `id_locale` only.

SQL queries:
```sql
ALTER TABLE `blog_post_locales` RENAME TO `locales`;
ALTER TABLE `locales` CHANGE `id_blog_post_locale` `id_locale` int unsigned NOT NULL AUTO_INCREMENT FIRST;
ALTER TABLE `locales` COLLATE 'utf8mb4_general_ci';
```