### PR TITLE
Talks locale links

### DIFF
--- a/site/app/Admin/Presenters/TalksPresenter.php
+++ b/site/app/Admin/Presenters/TalksPresenter.php
@@ -44,6 +44,7 @@ class TalksPresenter extends BasePresenter
 	public function renderDefault(): void
 	{
 		$this->template->pageTitle = $this->translator->translate('messages.title.talks');
+		$this->template->defaultLocale = $this->translator->getDefaultLocale();
 		$this->template->upcomingTalks = $this->talks->getUpcoming();
 		$this->template->talks = $this->talks->getAll();
 	}

--- a/site/app/Admin/Presenters/templates/Talks/default.latte
+++ b/site/app/Admin/Presenters/templates/Talks/default.latte
@@ -1,10 +1,12 @@
-{define #itemTalk, MichalSpacekCz\Talks\Talk $item, bool $upcoming}
-	<li><a n:href="Talks:talk $item->getId()"><strong n:tag-if="$upcoming">{$item->getTitle()}</strong></a>
+{define #itemTalk, MichalSpacekCz\Talks\Talk $item, bool $upcoming, string $defaultLocale}
+<li>
+	<a n:href="Talks:talk $item->getId()"><strong n:tag-if="$upcoming">{$item->getTitle()}</strong></a>
+	<small n:if="$item->getLocale() !== $defaultLocale">{icon flag} {_"messages.locales.{$item->getLocale()}"}</small>
 	<small><strong class="date">{$item->getDate()|localeDay}</strong>, {$item->getEvent()}</small>
 	<span n:if="$item->isHasSlides()" title="{_messages.label.slides}">{icon images}</span>
 	<span n:if="$item->getVideo()->getVideoHref()" title="{_messages.label.videorecording}">{icon camera-video}</span>
 	<small>(<a n:href="slides $item->getId()">upravit slajdy</a>)</small>
-	</li>
+</li>
 {/define}
 
 {define #content}
@@ -19,11 +21,11 @@
 <ol reversed>
 {foreach $upcomingTalks as $item}
 	{var $upcoming = true}
-	{include #itemTalk, item: $item, upcoming: $upcoming}
+	{include #itemTalk, item: $item, upcoming: $upcoming, defaultLocale: $defaultLocale}
 {/foreach}
 {foreach $talks as $item}
 	{var $upcoming = false}
-	{include #itemTalk, item: $item, upcoming: $upcoming}
+	{include #itemTalk, item: $item, upcoming: $upcoming, defaultLocale: $defaultLocale}
 {/foreach}
 </ol>
 {/define}

--- a/site/app/Application/LocaleLink.php
+++ b/site/app/Application/LocaleLink.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+class LocaleLink
+{
+
+	public function __construct(
+		private readonly string $locale,
+		private readonly string $languageCode,
+		private readonly string $languageName,
+		private readonly string $url,
+	) {
+	}
+
+
+	public function getLocale(): string
+	{
+		return $this->locale;
+	}
+
+
+	public function getLanguageCode(): string
+	{
+		return $this->languageCode;
+	}
+
+
+	public function getLanguageName(): string
+	{
+		return $this->languageName;
+	}
+
+
+	public function getUrl(): string
+	{
+		return $this->url;
+	}
+
+
+	public function withUrl(string $url): self
+	{
+		return new self(
+			$this->getLocale(),
+			$this->getLanguageCode(),
+			$this->getLanguageName(),
+			$url,
+		);
+	}
+
+}

--- a/site/app/Application/LocaleLinkGeneratorInterface.php
+++ b/site/app/Application/LocaleLinkGeneratorInterface.php
@@ -11,7 +11,7 @@ interface LocaleLinkGeneratorInterface
 	/**
 	 * @param string $destination destination in format "[[[module:]presenter:]action] [#fragment]"
 	 * @param array<string, array<string, string|null>> $params of locale => [name => value]
-	 * @return array<string, string> of locale => URL
+	 * @return array<string, LocaleLink> of locale => URL
 	 * @throws InvalidLinkException
 	 */
 	public function links(string $destination, array $params = []): array;

--- a/site/app/Articles/Blog/BlogPosts.php
+++ b/site/app/Articles/Blog/BlogPosts.php
@@ -186,7 +186,7 @@ class BlogPosts
 			$post->href = $this->linkGenerator->link('Www:Post:', $params);
 		} else {
 			$links = $this->localeLinkGenerator->links('Www:Post:', $this->localeLinkGenerator->defaultParams($params));
-			$post->href = $links[$post->locale];
+			$post->href = $links[$post->locale]->getUrl();
 		}
 	}
 

--- a/site/app/Form/TalkFormFactory.php
+++ b/site/app/Form/TalkFormFactory.php
@@ -38,6 +38,8 @@ class TalkFormFactory
 		$form = $this->factory->create();
 		$allTalks = $this->getAllTalksExcept($talk ? (string)$talk->getAction() : null);
 
+		$form->addInteger('translationGroup', 'Skupina překladů:')
+			->setRequired(false);
 		$form->addSelect('locale', 'Jazyk:', $this->locales->getAllLocales())
 			->setRequired('Zadejte prosím jazyk')
 			->setPrompt('- vyberte -');
@@ -112,6 +114,7 @@ class TalkFormFactory
 				$this->talks->update(
 					$talk->getId(),
 					$values->locale,
+					$values->translationGroup,
 					$values->action,
 					$values->title,
 					$values->description,
@@ -145,6 +148,7 @@ class TalkFormFactory
 			} else {
 				$talkId = $this->talks->add(
 					$values->locale,
+					$values->translationGroup,
 					$values->action,
 					$values->title,
 					$values->description,
@@ -185,6 +189,7 @@ class TalkFormFactory
 		$values = [
 			'action' => $talk->getAction(),
 			'locale' => $talk->getLocaleId(),
+			'translationGroup' => $talk->getTranslationGroupId(),
 			'title' => $talk->getTitleTexy(),
 			'description' => $talk->getDescriptionTexy(),
 			'date' => $talk->getDate()->format('Y-m-d H:i'),

--- a/site/app/Talks/Talk.php
+++ b/site/app/Talks/Talk.php
@@ -13,6 +13,7 @@ class Talk
 	public function __construct(
 		private readonly int $id,
 		private readonly int $localeId,
+		private readonly string $locale,
 		private readonly ?string $action,
 		private readonly Html $title,
 		private readonly string $titleTexy,
@@ -52,6 +53,12 @@ class Talk
 	public function getLocaleId(): int
 	{
 		return $this->localeId;
+	}
+
+
+	public function getLocale(): string
+	{
+		return $this->locale;
 	}
 
 

--- a/site/app/Talks/Talk.php
+++ b/site/app/Talks/Talk.php
@@ -15,6 +15,7 @@ class Talk
 		private readonly int $localeId,
 		private readonly string $locale,
 		private readonly ?string $action,
+		private readonly ?string $url,
 		private readonly Html $title,
 		private readonly string $titleTexy,
 		private readonly ?Html $description,
@@ -65,6 +66,12 @@ class Talk
 	public function getAction(): ?string
 	{
 		return $this->action;
+	}
+
+
+	public function getUrl(): ?string
+	{
+		return $this->url;
 	}
 
 

--- a/site/app/Talks/Talk.php
+++ b/site/app/Talks/Talk.php
@@ -14,6 +14,7 @@ class Talk
 		private readonly int $id,
 		private readonly int $localeId,
 		private readonly string $locale,
+		private readonly ?int $translationGroupId,
 		private readonly ?string $action,
 		private readonly ?string $url,
 		private readonly Html $title,
@@ -60,6 +61,12 @@ class Talk
 	public function getLocale(): string
 	{
 		return $this->locale;
+	}
+
+
+	public function getTranslationGroupId(): ?int
+	{
+		return $this->translationGroupId;
 	}
 
 

--- a/site/app/Talks/TalkFactory.php
+++ b/site/app/Talks/TalkFactory.php
@@ -3,9 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Talks;
 
+use Contributte\Translation\Translator;
+use MichalSpacekCz\Application\LocaleLinkGeneratorInterface;
 use MichalSpacekCz\Formatter\TexyFormatter;
 use MichalSpacekCz\Media\Exceptions\ContentTypeException;
 use MichalSpacekCz\Media\VideoFactory;
+use Nette\Application\UI\InvalidLinkException;
 use Nette\Database\Row;
 
 class TalkFactory
@@ -14,20 +17,28 @@ class TalkFactory
 	public function __construct(
 		private readonly TexyFormatter $texyFormatter,
 		private readonly VideoFactory $videoFactory,
+		private readonly Translator $translator,
+		private readonly LocaleLinkGeneratorInterface $localeLinkGenerator,
 	) {
 	}
 
 
 	/**
 	 * @throws ContentTypeException
+	 * @throws InvalidLinkException
 	 */
 	public function createFromDatabaseRow(Row $row): Talk
 	{
+		if ($this->translator->getDefaultLocale() !== $row->locale && $row->action) {
+			$links = $this->localeLinkGenerator->links('Www:Talks:talk', $this->localeLinkGenerator->defaultParams(['name' => $row->action]));
+			$url = isset($links[$row->locale]) ? $links[$row->locale]->getUrl() : null;
+		}
 		return new Talk(
 			$row->id,
 			$row->localeId,
 			$row->locale,
 			$row->action,
+			$url ?? null,
 			$this->texyFormatter->format($row->title),
 			$row->title,
 			$row->description ? $this->texyFormatter->formatBlock($row->description) : null,

--- a/site/app/Talks/TalkFactory.php
+++ b/site/app/Talks/TalkFactory.php
@@ -37,6 +37,7 @@ class TalkFactory
 			$row->id,
 			$row->localeId,
 			$row->locale,
+			$row->translationGroupId,
 			$row->action,
 			$url ?? null,
 			$this->texyFormatter->format($row->title),

--- a/site/app/Talks/TalkFactory.php
+++ b/site/app/Talks/TalkFactory.php
@@ -26,6 +26,7 @@ class TalkFactory
 		return new Talk(
 			$row->id,
 			$row->localeId,
+			$row->locale,
 			$row->action,
 			$this->texyFormatter->format($row->title),
 			$row->title,

--- a/site/app/Talks/TalkLocaleUrls.php
+++ b/site/app/Talks/TalkLocaleUrls.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Talks;
+
+use Nette\Database\Explorer;
+
+class TalkLocaleUrls
+{
+
+	public function __construct(
+		private readonly Explorer $database,
+	) {
+	}
+
+
+	/**
+	 * @return array<string, string> locale => action
+	 */
+	public function get(Talk $talk): array
+	{
+		if (!$talk->getTranslationGroupId()) {
+			return [];
+		}
+		return $this->database->fetchPairs(
+			'SELECT l.locale, t.action FROM talks t JOIN locales l ON t.key_locale = l.id_locale WHERE t.key_translation_group = ?',
+			$talk->getTranslationGroupId(),
+		);
+	}
+
+}

--- a/site/app/Talks/Talks.php
+++ b/site/app/Talks/Talks.php
@@ -33,6 +33,7 @@ class Talks
 				t.id_talk AS id,
 				t.key_locale AS localeId,
 				l.locale,
+				t.key_translation_group AS translationGroupId,
 				t.action,
 				t.title,
 				t.description,
@@ -94,6 +95,7 @@ class Talks
 				t.id_talk AS id,
 				t.key_locale AS localeId,
 				l.locale,
+				t.key_translation_group AS translationGroupId,
 				t.action,
 				t.title,
 				t.description,
@@ -143,6 +145,7 @@ class Talks
 				t.id_talk AS id,
 				t.key_locale AS localeId,
 				l.locale,
+				t.key_translation_group AS translationGroupId,
 				t.action,
 				t.title,
 				t.description,
@@ -192,6 +195,7 @@ class Talks
 				t.id_talk AS id,
 				t.key_locale AS localeId,
 				l.locale,
+				t.key_translation_group AS translationGroupId,
 				t.action,
 				t.title,
 				t.description,
@@ -262,6 +266,7 @@ class Talks
 	public function update(
 		int $id,
 		int $localeId,
+		?int $translationGroupId,
 		?string $action,
 		string $title,
 		?string $description,
@@ -286,6 +291,7 @@ class Talks
 	): void {
 		$params = $this->getAddUpdateParams(
 			$localeId,
+			$translationGroupId,
 			$action,
 			$title,
 			$description,
@@ -319,6 +325,7 @@ class Talks
 	 */
 	public function add(
 		int $localeId,
+		?int $translationGroupId,
 		?string $action,
 		string $title,
 		?string $description,
@@ -343,6 +350,7 @@ class Talks
 	): int {
 		$params = $this->getAddUpdateParams(
 			$localeId,
+			$translationGroupId,
 			$action,
 			$title,
 			$description,
@@ -389,6 +397,7 @@ class Talks
 	 */
 	private function getAddUpdateParams(
 		int $localeId,
+		?int $translationGroupId,
 		?string $action,
 		string $title,
 		?string $description,
@@ -418,6 +427,7 @@ class Talks
 		}
 		return [
 			'key_locale' => $localeId,
+			'key_translation_group' => empty($translationGroupId) ? null : $translationGroupId,
 			'action' => (empty($action) ? null : $action),
 			'title' => $title,
 			'description' => (empty($description) ? null : $description),

--- a/site/app/Talks/Talks.php
+++ b/site/app/Talks/Talks.php
@@ -32,6 +32,7 @@ class Talks
 		$query = 'SELECT
 				t.id_talk AS id,
 				t.key_locale AS localeId,
+				l.locale,
 				t.action,
 				t.title,
 				t.description,
@@ -57,6 +58,7 @@ class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
+			    LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.date <= NOW()
 			ORDER BY t.date DESC
@@ -91,6 +93,7 @@ class Talks
 		$query = 'SELECT
 				t.id_talk AS id,
 				t.key_locale AS localeId,
+				l.locale,
 				t.action,
 				t.title,
 				t.description,
@@ -116,6 +119,7 @@ class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
+			    LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.date > NOW()
 			ORDER BY t.date';
@@ -138,6 +142,7 @@ class Talks
 			'SELECT
 				t.id_talk AS id,
 				t.key_locale AS localeId,
+				l.locale,
 				t.action,
 				t.title,
 				t.description,
@@ -163,6 +168,7 @@ class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
+			    LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.action = ?',
 			$name,
@@ -185,6 +191,7 @@ class Talks
 			'SELECT
 				t.id_talk AS id,
 				t.key_locale AS localeId,
+				l.locale,
 				t.action,
 				t.title,
 				t.description,
@@ -210,6 +217,7 @@ class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
+			    LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.id_talk = ?',
 			$id,

--- a/site/app/Talks/TalksList.php
+++ b/site/app/Talks/TalksList.php
@@ -3,16 +3,24 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Talks;
 
+use Contributte\Translation\Translator;
 use MichalSpacekCz\Application\UiControl;
 
 class TalksList extends UiControl
 {
+
+	public function __construct(
+		private readonly Translator $translator,
+	) {
+	}
+
 
 	/**
 	 * @param list<Talk> $talks
 	 */
 	public function render(array $talks): void
 	{
+		$this->template->defaultLocale = $this->translator->getDefaultLocale();
 		$this->template->talks = $talks;
 		$this->template->render(__DIR__ . '/talksList.latte');
 	}

--- a/site/app/Talks/talkInputs.latte
+++ b/site/app/Talks/talkInputs.latte
@@ -4,6 +4,9 @@
 {form talk class => "aligned wide"}
 	<table>
 		<tr>
+			<th>{label translationGroup /}</th><td class="short">{input translationGroup}</td>
+		</tr>
+		<tr>
 			<th>{label locale /}</th><td class="short">{input locale}</td>
 		</tr>
 		<tr>

--- a/site/app/Talks/talksList.latte
+++ b/site/app/Talks/talksList.latte
@@ -1,9 +1,11 @@
 {varType MichalSpacekCz\Talks\Talk[] $talks}
 {varType string $defaultLocale}
 <p class="indent" n:foreach="$talks as $talk">
-	<a href="{plink Talks:talk $talk->getAction()}" n:tag-if="$talk->getAction()"><strong>{$talk->getTitle()}</strong></a>
 	{if $talk->getLocale() !== $defaultLocale}
+		<a href="{$talk->getUrl()}" n:tag-if="$talk->getUrl()"><strong>{$talk->getTitle()}</strong></a>
 		<small>{icon flag} {_"messages.locales.{$talk->getLocale()}"}</small>
+	{else}
+		<a href="{plink Talks:talk $talk->getAction()}" n:tag-if="$talk->getAction()"><strong>{$talk->getTitle()}</strong></a>
 	{/if}
 	<br>
 	<small><strong class="date">{$talk->getDate()|localeDay}</strong>, {$talk->getEvent()}{if $talk->getDuration()} ({_messages.talks.durationshort|format:$talk->getDuration()}){/if}</small>

--- a/site/app/Talks/talksList.latte
+++ b/site/app/Talks/talksList.latte
@@ -1,6 +1,11 @@
 {varType MichalSpacekCz\Talks\Talk[] $talks}
+{varType string $defaultLocale}
 <p class="indent" n:foreach="$talks as $talk">
-	<a href="{plink Talks:talk $talk->getAction()}" n:tag-if="$talk->getAction()"><strong>{$talk->getTitle()}</strong></a><br>
+	<a href="{plink Talks:talk $talk->getAction()}" n:tag-if="$talk->getAction()"><strong>{$talk->getTitle()}</strong></a>
+	{if $talk->getLocale() !== $defaultLocale}
+		<small>{icon flag} {_"messages.locales.{$talk->getLocale()}"}</small>
+	{/if}
+	<br>
 	<small><strong class="date">{$talk->getDate()|localeDay}</strong>, {$talk->getEvent()}{if $talk->getDuration()} ({_messages.talks.durationshort|format:$talk->getDuration()}){/if}</small>
 	<span n:if="$talk->isHasSlides()" title="{_messages.label.slides}">{icon images}</span>
 	<span n:if="$talk->getVideo()->getVideoHref()" title="{_messages.label.videorecording}">{icon camera-video}</span>

--- a/site/app/Www/Presenters/BasePresenter.php
+++ b/site/app/Www/Presenters/BasePresenter.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Www\Presenters;
 
 use Contributte\Translation\Translator;
+use MichalSpacekCz\Application\LocaleLink;
 use MichalSpacekCz\Application\LocaleLinkGeneratorInterface;
 use MichalSpacekCz\Application\Theme;
 use MichalSpacekCz\User\Manager;
@@ -102,11 +103,11 @@ abstract class BasePresenter extends Presenter
 	/**
 	 * The default locale links.
 	 *
-	 * @return string[]|null
+	 * @return array<string, LocaleLink>
 	 */
-	protected function getLocaleLinkDefault(): ?array
+	protected function getLocaleLinkDefault(): array
 	{
-		return null;
+		return [];
 	}
 
 

--- a/site/app/Www/Presenters/ErrorPresenter.php
+++ b/site/app/Www/Presenters/ErrorPresenter.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Www\Presenters;
 
 use MichalSpacekCz\Application\AppRequest;
 use MichalSpacekCz\Application\Exceptions\NoOriginalRequestException;
+use MichalSpacekCz\Application\LocaleLink;
 use MichalSpacekCz\Application\LocaleLinkGeneratorInterface;
 use MichalSpacekCz\EasterEgg\FourOhFourButFound;
 use Nette\Application\BadRequestException;
@@ -60,14 +61,14 @@ class ErrorPresenter extends BaseErrorPresenter
 	/**
 	 * The default locale links.
 	 *
-	 * @return string[]|null
+	 * @return array<string, LocaleLink> of locale => URL
 	 */
-	protected function getLocaleLinkDefault(): ?array
+	protected function getLocaleLinkDefault(): array
 	{
+		$links = [];
 		// Change the request host to the localized "homepage" host
-		$links = $this->localeLinkGenerator->links('Www:Homepage:');
-		foreach ($links as &$link) {
-			$link = $this->getHttpRequest()->getUrl()->withHost((new Url($link))->getHost())->getAbsoluteUrl();
+		foreach ($this->localeLinkGenerator->links('Www:Homepage:') as $locale => $link) {
+			$links[$locale] = $link->withUrl($this->getHttpRequest()->getUrl()->withHost((new Url($link->getUrl()))->getHost())->getAbsoluteUrl());
 		}
 		return $links;
 	}

--- a/site/app/Www/Presenters/TalksPresenter.php
+++ b/site/app/Www/Presenters/TalksPresenter.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Www\Presenters;
 
+use MichalSpacekCz\Application\LocaleLinkGeneratorInterface;
 use MichalSpacekCz\Media\Exceptions\ContentTypeException;
 use MichalSpacekCz\Media\SlidesPlatform;
 use MichalSpacekCz\Talks\Exceptions\TalkDoesNotExistException;
@@ -14,6 +15,7 @@ use MichalSpacekCz\Talks\TalksListFactory;
 use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use Nette\Application\BadRequestException;
 use Nette\Application\UI\InvalidLinkException;
+use Nette\Http\IResponse;
 
 class TalksPresenter extends BasePresenter
 {
@@ -23,6 +25,7 @@ class TalksPresenter extends BasePresenter
 		private readonly TalkSlides $talkSlides,
 		private readonly UpcomingTrainingDates $upcomingTrainingDates,
 		private readonly TalksListFactory $talksListFactory,
+		private readonly LocaleLinkGeneratorInterface $localeLinkGenerator,
 	) {
 		parent::__construct();
 	}
@@ -55,6 +58,9 @@ class TalksPresenter extends BasePresenter
 	{
 		try {
 			$talk = $this->talks->get($name);
+			if ($talk->getLocale() !== $this->translator->getDefaultLocale()) {
+				$this->redirectUrl($this->localeLinkGenerator->links(...$this->getLocaleLinksGeneratorParams())[$talk->getLocale()], IResponse::S301_MovedPermanently);
+			}
 			if ($talk->getSlidesTalkId()) {
 				$slidesTalk = $this->talks->getById($talk->getSlidesTalkId());
 				$slides = ($slidesTalk->isPublishSlides() ? $this->talkSlides->getSlides($slidesTalk->getId(), $slidesTalk->getFilenamesTalkId()) : []);

--- a/site/app/Www/Presenters/TalksPresenter.php
+++ b/site/app/Www/Presenters/TalksPresenter.php
@@ -59,7 +59,7 @@ class TalksPresenter extends BasePresenter
 		try {
 			$talk = $this->talks->get($name);
 			if ($talk->getLocale() !== $this->translator->getDefaultLocale()) {
-				$this->redirectUrl($this->localeLinkGenerator->links(...$this->getLocaleLinksGeneratorParams())[$talk->getLocale()], IResponse::S301_MovedPermanently);
+				$this->redirectUrl($this->localeLinkGenerator->links(...$this->getLocaleLinksGeneratorParams())[$talk->getLocale()]->getUrl(), IResponse::S301_MovedPermanently);
 			}
 			if ($talk->getSlidesTalkId()) {
 				$slidesTalk = $this->talks->getById($talk->getSlidesTalkId());

--- a/site/app/Www/Presenters/templates/@layout.latte
+++ b/site/app/Www/Presenters/templates/@layout.latte
@@ -50,9 +50,7 @@
 	<link rel="apple-touch-icon" href="{='michal-spacek.jpg'|staticImageUrl}">
 	<meta property="article:author" content="https://www.facebook.com/spaze">
 	<link rel="icon" href="{='/favicon.ico'|staticUrl}">
-	{ifset $localeLinks}
-		<link rel="alternate" n:foreach="$localeLinks as $language => $url" hreflang="{_"html.langs.$language"}" href="{$url}">
-	{/ifset}
+	<link rel="alternate" n:foreach="$localeLinks as $localeLink" hreflang="{$localeLink->getLanguageCode()}" href="{$localeLink->getUrl()}">
 	{include #feeds}
 </head>
 <body>
@@ -100,7 +98,7 @@
 	<a n:href="darkFuture!" title="{_messages.label.mode.dark}" id="theme-dark" class="tools"><small>{icon moon}</small></a>
 	<a n:href="brightFuture!" title="{_messages.label.mode.light}" id="theme-light" class="tools"><small>{icon sun}</small></a>
 	{if !isset($headerLinks) || $headerLinks !== false}
-		<a n:foreach="$localeLinks as $language => $url" href="{$url}" lang="{_"html.langs.$language"}" class="tools"><small>{icon flag} {_"messages.langs.$language"}</small></a>
+		<a n:foreach="$localeLinks as $localeLink" href="{$localeLink->getUrl()}" lang="{$localeLink->getLanguageCode()}" class="tools"><small>{icon flag} {$localeLink->getLanguageName()}</small></a>
 		<a n:href=":UpcKeys:Homepage:" title="{_messages.label.upckeys}"><small>{icon wifi} {_messages.label.upckeys}</small></a>
 		<a n:href=":Pulse:PasswordsStorages:" title="{_messages.label.pulse.passwordstorages}"><small>{icon key} {_messages.label.pulse.passwordstorages}</small></a>
 		<a n:href=":Www:Projects:" title="{_messages.label.otherprojects}" id="other-projects"><small>{icon dots-horizontal} {_messages.label.otherprojects}</small></a>

--- a/site/app/lang/html.cs_CZ.neon
+++ b/site/app/lang/html.cs_CZ.neon
@@ -27,6 +27,3 @@ id:
 	transcript: prepis
 attribute:
 	lang: cs
-langs:
-	cs_CZ: cs
-	en_US: en

--- a/site/app/lang/html.en_US.neon
+++ b/site/app/lang/html.en_US.neon
@@ -27,6 +27,3 @@ id:
 	transcript: transcript
 attribute:
 	lang: en
-langs:
-	cs_CZ: cs
-	en_US: en

--- a/site/app/lang/messages.cs_CZ.neon
+++ b/site/app/lang/messages.cs_CZ.neon
@@ -1,3 +1,6 @@
+locales:
+	cs_CZ: česky
+	en_US: anglicky
 title:
 	who: "Kdo?"
 	contact: Kontakt

--- a/site/app/lang/messages.cs_CZ.neon
+++ b/site/app/lang/messages.cs_CZ.neon
@@ -1,6 +1,3 @@
-langs:
-	cs_CZ: Česky
-	en_US: English
 title:
 	who: "Kdo?"
 	contact: Kontakt

--- a/site/app/lang/messages.en_US.neon
+++ b/site/app/lang/messages.en_US.neon
@@ -1,3 +1,6 @@
+locales:
+	cs_CZ: Czech
+	en_US: English
 title:
 	who: "Who?"
 	contact: Contact

--- a/site/app/lang/messages.en_US.neon
+++ b/site/app/lang/messages.en_US.neon
@@ -1,6 +1,3 @@
-langs:
-	cs_CZ: Česky
-	en_US: English
 title:
 	who: "Who?"
 	contact: Contact

--- a/site/config/common.neon
+++ b/site/config/common.neon
@@ -62,7 +62,7 @@ database:
 translation:
 	locales:
 		default: cs_CZ
-		whitelist: [cs_CZ, en_US]
+		whitelist: %locales.all%
 	localeResolvers!: []
 	dirs:
 		- %siteDir%/app/lang

--- a/site/config/parameters.neon
+++ b/site/config/parameters.neon
@@ -1,5 +1,13 @@
 parameters:
 	locales:
+		all: [cs_CZ, en_US]
+		languages:
+			cs_CZ:
+				code: cs
+				name: Česky
+			en_US:
+				code: en
+				name: English
 		supported:
 			# The value is a FQDN if it ends with a dot, otherwise the rootDomainMapping.$value domain is appended to the host name
 			admin:

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -1,7 +1,7 @@
 services:
 	- MichalSpacekCz\Application\AppRequest
 	- MichalSpacekCz\Application\Error
-	localeLinkGenerator: MichalSpacekCz\Application\LocaleLinkGenerator
+	localeLinkGenerator: MichalSpacekCz\Application\LocaleLinkGenerator(languages: %locales.languages%)
 	- MichalSpacekCz\Application\Locales
 	- MichalSpacekCz\Application\RouterFactory(supportedLocales: %locales.supported%, rootDomainMapping: %locales.rootDomainMapping%, translatedRoutes: %translatedRoutes.presenters%)
 	- @MichalSpacekCz\Application\RouterFactory::createRouter

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -84,6 +84,7 @@ services:
 	- MichalSpacekCz\Tags\Tags
 	- MichalSpacekCz\Talks\TalkFactory(videoFactory: @talkVideoFactory)
 	- MichalSpacekCz\Talks\TalkInputsFactory(videoThumbnails: @talkVideoThumbnails)
+	- MichalSpacekCz\Talks\TalkLocaleUrls
 	- MichalSpacekCz\Talks\Talks
 	- MichalSpacekCz\Talks\TalkSlides
 	- MichalSpacekCz\Talks\TalksListFactory

--- a/site/tests/Application/LocaleLinkGeneratorTest.phpt
+++ b/site/tests/Application/LocaleLinkGeneratorTest.phpt
@@ -33,7 +33,16 @@ class LocaleLinkGeneratorTest extends TestCase
 
 	protected function setUp(): void
 	{
-		$this->localeLinkGenerator = new LocaleLinkGenerator($this->routerFactory, $this->httpRequest, $this->presenterFactory, $this->linkGenerator, $this->translator);
+		$this->localeLinkGenerator = new LocaleLinkGenerator($this->routerFactory, $this->httpRequest, $this->presenterFactory, $this->linkGenerator, $this->translator, [
+			'cs_CZ' => [
+				'code' => 'cs',
+				'name' => 'Česky',
+			],
+			'en_US' => [
+				'code' => 'en',
+				'name' => 'English',
+			],
+		]);
 	}
 
 
@@ -45,7 +54,7 @@ class LocaleLinkGeneratorTest extends TestCase
 		];
 		$links = $this->localeLinkGenerator->links('Www:Talks:talk', $params);
 		Assert::same('cs_CZ', $this->translator->getDefaultLocale());
-		Assert::same(['en_US' => 'https://www.burger.test/talks/foo'], $links);
+		Assert::equal(['en_US' => new LocaleLink('en_US', 'en', 'English', 'https://www.burger.test/talks/foo')], $links);
 	}
 
 

--- a/site/tests/Talks/TalkLocaleUrlsTest.phpt
+++ b/site/tests/Talks/TalkLocaleUrlsTest.phpt
@@ -1,0 +1,85 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Talks;
+
+use DateTime;
+use MichalSpacekCz\Media\Video;
+use MichalSpacekCz\Test\Database\Database;
+use Nette\Utils\Html;
+use Tester\Assert;
+use Tester\TestCase;
+
+$runner = require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class TalkLocaleUrlsTest extends TestCase
+{
+
+	public function __construct(
+		private readonly TalkLocaleUrls $talkLocaleUrls,
+		private readonly Database $database,
+	) {
+	}
+
+
+	public function testGet(): void
+	{
+		$expected = ['cs_CZ' => 'foobar'];
+		$this->database->setFetchPairsResult($expected);
+		Assert::same([], $this->talkLocaleUrls->get($this->buildTalk(null)));
+		Assert::same($expected, $this->talkLocaleUrls->get($this->buildTalk(1337)));
+	}
+
+
+	private function buildTalk(?int $translationGroup): Talk
+	{
+		$video = new Video(
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			320,
+			200,
+			null,
+		);
+		return new Talk(
+			10,
+			1,
+			'cs_CZ',
+			$translationGroup,
+			null,
+			null,
+			Html::fromText('title'),
+			'title',
+			null,
+			null,
+			new DateTime(),
+			null,
+			null,
+			false,
+			null,
+			null,
+			$video,
+			null,
+			Html::fromText('event'),
+			'event',
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			null,
+			false,
+		);
+	}
+
+}
+
+$runner->run(TalkLocaleUrlsTest::class);


### PR DESCRIPTION
This improves how talks in the other language are displayed.

Up until now, you could have a talk in English on a `.cz` site and vice versa which I think caused some troubles for search engines and people alike. So now when the talk is in English, you'll have a `.com` link in the list of talks together with a flag icon and a language name. Also, HTTP redirects will take you where you're supposed to be, English talks on `.com` site etc., when you're not.

Also, if there's an other locale talk, and it's correctly paired with the original locale talk using `key_translation_group`, you'll have a link in the header directly to the talk in the other locale.

Follow-up to #194 #192