### PR TITLE
Have to use parent classes to get current action/params for `LocaleLinkGenerator`

### DIFF
--- a/site/app/Www/Presenters/TalksPresenter.php
+++ b/site/app/Www/Presenters/TalksPresenter.php
@@ -65,7 +65,8 @@ class TalksPresenter extends BasePresenter
 		try {
 			$talk = $this->talks->get($name);
 			if ($talk->getLocale() !== $this->translator->getDefaultLocale()) {
-				$this->redirectUrl($this->localeLinkGenerator->links(...$this->getLocaleLinksGeneratorParams())[$talk->getLocale()]->getUrl(), IResponse::S301_MovedPermanently);
+				$links = $this->localeLinkGenerator->links(parent::getLocaleLinkAction(), parent::getLocaleLinkParams());
+				$this->redirectUrl($links[$talk->getLocale()]->getUrl(), IResponse::S301_MovedPermanently);
 			}
 			if ($talk->getSlidesTalkId()) {
 				$slidesTalk = $this->talks->getById($talk->getSlidesTalkId());


### PR DESCRIPTION
Because `$this` ones are overwritten.

This was working before in #196 but I broke it in a12a6cb03e81e3a8849275838f98508506cb0a4c by adding `getLocaleLinkAction()` and `getLocaleLinkParams()`.