### PR TITLE
No locale links in blog post previews

### DIFF
--- a/site/app/Articles/Blog/BlogPostPreview.php
+++ b/site/app/Articles/Blog/BlogPostPreview.php
@@ -36,6 +36,7 @@ class BlogPostPreview
 		$template->showBreadcrumbsMenu = false;
 		$template->showHeaderTabs = false;
 		$template->showFooter = false;
+		$template->localeLinks = [];
 		$this->blogPosts->setTemplateTitleAndHeader($post, $template);
 		foreach ($post->cspSnippets as $snippet) {
 			$this->contentSecurityPolicy->addSnippet($snippet);


### PR DESCRIPTION
Regression introduced in #196 commit 49a312bcfb115bcd0d5de127f0dc8dd2e866e709 by removing `{ifset $localeLinks}` from `@layout.latte`