### PR TITLE
Use static `::run` instead of returning the runner instance from bootstrap file

### DIFF
--- a/site/app/Test/TestCaseRunner.php
+++ b/site/app/Test/TestCaseRunner.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Test;
 
 use LogicException;
-use Nette\DI\Container;
+use MichalSpacekCz\Application\Bootstrap;
 use Nette\Utils\Type;
 use ReflectionException;
 use ReflectionMethod;
@@ -13,21 +13,16 @@ use Tester\TestCase;
 class TestCaseRunner
 {
 
-	public function __construct(
-		private readonly Container $container,
-	) {
-	}
-
-
 	/**
 	 * @param class-string<TestCase> $test
 	 * @return void
 	 */
-	public function run(string $test): void
+	public static function run(string $test): void
 	{
 		$params = [];
 		try {
 			$method = new ReflectionMethod($test, '__construct');
+			$container = Bootstrap::bootTest();
 			foreach ($method->getParameters() as $parameter) {
 				$type = Type::fromReflection($parameter);
 				$paramIdent = "Parameter #{$parameter->getPosition()} \${$parameter->getName()}";
@@ -46,7 +41,7 @@ class TestCaseRunner
 				if (!class_exists($type->getSingleName()) && !interface_exists($type->getSingleName())) {
 					throw new LogicException("{$paramIdent} specifies a type {$type} but the class or interface doesn't exist");
 				}
-				$params[] = $this->container->getByType($type->getSingleName());
+				$params[] = $container->getByType($type->getSingleName());
 			}
 		} catch (ReflectionException) {
 			// pass, __construct() does not exist

--- a/site/tests/Application/AppRequestTest.phpt
+++ b/site/tests/Application/AppRequestTest.phpt
@@ -9,11 +9,12 @@ use Error;
 use Exception;
 use MichalSpacekCz\Application\Exceptions\NoOriginalRequestException;
 use MichalSpacekCz\ShouldNotHappenException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Request;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class AppRequestTest extends TestCase
@@ -112,4 +113,4 @@ class AppRequestTest extends TestCase
 
 }
 
-$runner->run(AppRequestTest::class);
+TestCaseRunner::run(AppRequestTest::class);

--- a/site/tests/Application/BootstrapTest.phpt
+++ b/site/tests/Application/BootstrapTest.phpt
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\DI\Container;
 use Tester\Assert;
 use Tester\TestCase;
 use Tracy\Debugger;
 use Tracy\ILogger;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class BootstrapTest extends TestCase
@@ -76,4 +77,4 @@ class BootstrapTest extends TestCase
 
 }
 
-$runner->run(BootstrapTest::class);
+TestCaseRunner::run(BootstrapTest::class);

--- a/site/tests/Application/LocaleLinkGeneratorTest.phpt
+++ b/site/tests/Application/LocaleLinkGeneratorTest.phpt
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Application;
 
 use MichalSpacekCz\Test\NoOpTranslator;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\LinkGenerator;
 use Nette\Application\UI\InvalidLinkException;
@@ -12,7 +13,7 @@ use Nette\Http\IRequest;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class LocaleLinkGeneratorTest extends TestCase
@@ -133,4 +134,4 @@ class LocaleLinkGeneratorTest extends TestCase
 
 }
 
-$runner->run(LocaleLinkGeneratorTest::class);
+TestCaseRunner::run(LocaleLinkGeneratorTest::class);

--- a/site/tests/Application/ServerEnvTest.phpt
+++ b/site/tests/Application/ServerEnvTest.phpt
@@ -7,10 +7,11 @@ namespace MichalSpacekCz\Application;
 use MichalSpacekCz\Application\Exceptions\ServerEnvNotArrayException;
 use MichalSpacekCz\Application\Exceptions\ServerEnvNotFoundException;
 use MichalSpacekCz\Application\Exceptions\ServerEnvNotStringException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class ServerEnvTest extends TestCase
@@ -106,4 +107,4 @@ class ServerEnvTest extends TestCase
 
 }
 
-$runner->run(ServerEnvTest::class);
+TestCaseRunner::run(ServerEnvTest::class);

--- a/site/tests/Application/ThemeTest.phpt
+++ b/site/tests/Application/ThemeTest.phpt
@@ -5,10 +5,11 @@ namespace MichalSpacekCz\Application;
 
 use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\Http\Response;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class ThemeTest extends TestCase
@@ -74,4 +75,4 @@ class ThemeTest extends TestCase
 
 }
 
-$runner->run(ThemeTest::class);
+TestCaseRunner::run(ThemeTest::class);

--- a/site/tests/Articles/ArticlesTest.phpt
+++ b/site/tests/Articles/ArticlesTest.phpt
@@ -12,10 +12,11 @@ use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Tags\Tags;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NoOpTranslator;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class ArticlesTest extends TestCase
@@ -195,4 +196,4 @@ class ArticlesTest extends TestCase
 
 }
 
-$runner->run(ArticlesTest::class);
+TestCaseRunner::run(ArticlesTest::class);

--- a/site/tests/Articles/Blog/BlogPostPreviewTest.phpt
+++ b/site/tests/Articles/Blog/BlogPostPreviewTest.phpt
@@ -6,13 +6,14 @@ namespace MichalSpacekCz\Articles\Blog;
 
 use DateTime;
 use MichalSpacekCz\Templating\TemplateFactory;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\UI\Presenter;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class BlogPostPreviewTest extends TestCase
@@ -63,4 +64,4 @@ class BlogPostPreviewTest extends TestCase
 
 }
 
-$runner->run(BlogPostPreviewTest::class);
+TestCaseRunner::run(BlogPostPreviewTest::class);

--- a/site/tests/Articles/Blog/BlogPostRecommendedLinkTest.phpt
+++ b/site/tests/Articles/Blog/BlogPostRecommendedLinkTest.phpt
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Articles\Blog;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class BlogPostRecommendedLinkTest extends TestCase
@@ -37,4 +38,4 @@ class BlogPostRecommendedLinkTest extends TestCase
 
 }
 
-$runner->run(BlogPostRecommendedLinkTest::class);
+TestCaseRunner::run(BlogPostRecommendedLinkTest::class);

--- a/site/tests/Articles/Blog/BlogPostRecommendedLinksTest.phpt
+++ b/site/tests/Articles/Blog/BlogPostRecommendedLinksTest.phpt
@@ -4,12 +4,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Articles\Blog;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Schema\ValidationException;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class BlogPostRecommendedLinksTest extends TestCase
@@ -64,4 +65,4 @@ class BlogPostRecommendedLinksTest extends TestCase
 
 }
 
-$runner->run(BlogPostRecommendedLinksTest::class);
+TestCaseRunner::run(BlogPostRecommendedLinksTest::class);

--- a/site/tests/DateTime/DateTimeFactoryTest.phpt
+++ b/site/tests/DateTime/DateTimeFactoryTest.phpt
@@ -7,10 +7,11 @@ namespace MichalSpacekCz\DateTime;
 use DateTimeImmutable;
 use MichalSpacekCz\DateTime\Exceptions\CannotParseDateTimeException;
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class DateTimeFactoryTest extends TestCase
@@ -51,4 +52,4 @@ class DateTimeFactoryTest extends TestCase
 
 }
 
-$runner->run(DateTimeFactoryTest::class);
+TestCaseRunner::run(DateTimeFactoryTest::class);

--- a/site/tests/DateTime/DateTimeZoneFactoryTest.phpt
+++ b/site/tests/DateTime/DateTimeZoneFactoryTest.phpt
@@ -5,10 +5,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\DateTime;
 
 use MichalSpacekCz\DateTime\Exceptions\InvalidTimezoneException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class DateTimeZoneFactoryTest extends TestCase
@@ -34,4 +35,4 @@ class DateTimeZoneFactoryTest extends TestCase
 
 }
 
-$runner->run(DateTimeZoneFactoryTest::class);
+TestCaseRunner::run(DateTimeZoneFactoryTest::class);

--- a/site/tests/EasterEgg/FourOhFourButFoundTest.phpt
+++ b/site/tests/EasterEgg/FourOhFourButFoundTest.phpt
@@ -8,12 +8,13 @@ namespace MichalSpacekCz\EasterEgg;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Application\UiPresenterMock;
 use MichalSpacekCz\Test\Http\Request;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Responses\TextResponse;
 use Nette\Http\UrlScript;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class FourOhFourButFoundTest extends TestCase
@@ -71,4 +72,4 @@ class FourOhFourButFoundTest extends TestCase
 
 }
 
-$runner->run(FourOhFourButFoundTest::class);
+TestCaseRunner::run(FourOhFourButFoundTest::class);

--- a/site/tests/EasterEgg/NetteCve202015227Test.phpt
+++ b/site/tests/EasterEgg/NetteCve202015227Test.phpt
@@ -3,11 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\EasterEgg;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\BadRequestException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class NetteCve202015227Test extends TestCase
@@ -121,4 +122,4 @@ class NetteCve202015227Test extends TestCase
 
 }
 
-$runner->run(NetteCve202015227Test::class);
+TestCaseRunner::run(NetteCve202015227Test::class);

--- a/site/tests/EasterEgg/WinterIsComingTest.phpt
+++ b/site/tests/EasterEgg/WinterIsComingTest.phpt
@@ -8,6 +8,7 @@ namespace MichalSpacekCz\EasterEgg;
 
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Application\UiPresenterMock;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Responses\TextResponse;
 use Nette\Application\UI\Form;
 use Nette\Forms\Controls\TextInput;
@@ -15,7 +16,7 @@ use Nette\InvalidStateException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class WinterIsComingTest extends TestCase
@@ -150,4 +151,4 @@ class WinterIsComingTest extends TestCase
 
 }
 
-$runner->run(WinterIsComingTest::class);
+TestCaseRunner::run(WinterIsComingTest::class);

--- a/site/tests/Feed/ExportsTest.phpt
+++ b/site/tests/Feed/ExportsTest.phpt
@@ -9,6 +9,7 @@ use MichalSpacekCz\Articles\ArticleEdit;
 use MichalSpacekCz\Formatter\TexyFormatter;
 use MichalSpacekCz\Test\Articles\ArticlesMock;
 use MichalSpacekCz\Test\NoOpTranslator;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\BadRequestException;
 use Nette\Caching\Storage;
 use Nette\Utils\Html;
@@ -16,7 +17,7 @@ use SimpleXMLElement;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class ExportsTest extends TestCase
@@ -155,4 +156,4 @@ class ExportsTest extends TestCase
 
 }
 
-$runner->run(ExportsTest::class);
+TestCaseRunner::run(ExportsTest::class);

--- a/site/tests/Form/FormValuesTest.phpt
+++ b/site/tests/Form/FormValuesTest.phpt
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace Form;
 
 use MichalSpacekCz\Form\FormValues;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Forms\Controls\SubmitButton;
 use Nette\Forms\Form;
 use Nette\InvalidStateException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class FormValuesTest extends TestCase
@@ -51,4 +52,4 @@ class FormValuesTest extends TestCase
 
 }
 
-$runner->run(FormValuesTest::class);
+TestCaseRunner::run(FormValuesTest::class);

--- a/site/tests/Formatter/TexyFormatterTest.phpt
+++ b/site/tests/Formatter/TexyFormatterTest.phpt
@@ -9,11 +9,12 @@ namespace MichalSpacekCz\Formatter;
 use DateTime;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TexyFormatterTest extends TestCase
@@ -135,4 +136,4 @@ class TexyFormatterTest extends TestCase
 
 }
 
-$runner->run(TexyFormatterTest::class);
+TestCaseRunner::run(TexyFormatterTest::class);

--- a/site/tests/Formatter/TexyPhraseHandlerTest.phpt
+++ b/site/tests/Formatter/TexyPhraseHandlerTest.phpt
@@ -9,12 +9,13 @@ use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Application\LocaleLinkGeneratorMock;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NoOpTranslator;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Tester\Assert;
 use Tester\TestCase;
 use Texy\Texy;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TexyPhraseHandlerTest extends TestCase
@@ -163,4 +164,4 @@ class TexyPhraseHandlerTest extends TestCase
 
 }
 
-$runner->run(TexyPhraseHandlerTest::class);
+TestCaseRunner::run(TexyPhraseHandlerTest::class);

--- a/site/tests/Http/HttpInputTest.phpt
+++ b/site/tests/Http/HttpInputTest.phpt
@@ -6,10 +6,11 @@ namespace MichalSpacekCz\Http;
 
 use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class HttpInputTest extends TestCase
@@ -53,4 +54,4 @@ class HttpInputTest extends TestCase
 
 }
 
-$runner->run(HttpInputTest::class);
+TestCaseRunner::run(HttpInputTest::class);

--- a/site/tests/Http/HttpStreamContextTest.phpt
+++ b/site/tests/Http/HttpStreamContextTest.phpt
@@ -5,10 +5,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Http;
 
 use MichalSpacekCz\Http\Exceptions\HttpStreamException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class HttpStreamContextTest extends TestCase
@@ -67,4 +68,4 @@ class HttpStreamContextTest extends TestCase
 
 }
 
-$runner->run(HttpStreamContextTest::class);
+TestCaseRunner::run(HttpStreamContextTest::class);

--- a/site/tests/Http/RedirectionsTest.phpt
+++ b/site/tests/Http/RedirectionsTest.phpt
@@ -5,11 +5,12 @@ namespace MichalSpacekCz\Http;
 
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Http\UrlScript;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class RedirectionsTest extends TestCase
@@ -44,4 +45,4 @@ class RedirectionsTest extends TestCase
 
 }
 
-$runner->run(RedirectionsTest::class);
+TestCaseRunner::run(RedirectionsTest::class);

--- a/site/tests/Http/SecurityHeadersTest.phpt
+++ b/site/tests/Http/SecurityHeadersTest.phpt
@@ -7,6 +7,7 @@ namespace MichalSpacekCz\Http;
 use MichalSpacekCz\Test\Http\Response;
 use MichalSpacekCz\Test\Http\SecurityHeadersFactory;
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\UI\Presenter;
@@ -14,7 +15,7 @@ use Spaze\ContentSecurityPolicy\CspConfig;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class SecurityHeadersTest extends TestCase
@@ -104,4 +105,4 @@ class SecurityHeadersTest extends TestCase
 
 }
 
-$runner->run(SecurityHeadersTest::class);
+TestCaseRunner::run(SecurityHeadersTest::class);

--- a/site/tests/Interviews/InterviewsTest.phpt
+++ b/site/tests/Interviews/InterviewsTest.phpt
@@ -6,10 +6,11 @@ namespace MichalSpacekCz\Interviews;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class InterviewsTest extends TestCase
@@ -132,4 +133,4 @@ class InterviewsTest extends TestCase
 
 }
 
-$runner->run(InterviewsTest::class);
+TestCaseRunner::run(InterviewsTest::class);

--- a/site/tests/Makefile/MakefileTest.phpt
+++ b/site/tests/Makefile/MakefileTest.phpt
@@ -6,11 +6,12 @@ namespace MichalSpacekCz\Makefile;
 
 use MichalSpacekCz\Makefile\Exceptions\MakefileContainsRealTargetsException;
 use MichalSpacekCz\Makefile\Exceptions\MakefileNotFoundException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\FileMock;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class MakefileTest extends TestCase
@@ -66,4 +67,4 @@ class MakefileTest extends TestCase
 
 }
 
-$runner->run(MakefileTest::class);
+TestCaseRunner::run(MakefileTest::class);

--- a/site/tests/Media/VideoFactoryTest.phpt
+++ b/site/tests/Media/VideoFactoryTest.phpt
@@ -5,11 +5,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Media;
 
 use MichalSpacekCz\Media\Resources\InterviewMediaResources;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Database\Row;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class VideoFactoryTest extends TestCase
@@ -65,4 +66,4 @@ class VideoFactoryTest extends TestCase
 
 }
 
-$runner->run(VideoFactoryTest::class);
+TestCaseRunner::run(VideoFactoryTest::class);

--- a/site/tests/Pulse/Passwords/AlgorithmAttributesFactoryTest.phpt
+++ b/site/tests/Pulse/Passwords/AlgorithmAttributesFactoryTest.phpt
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Pulse\Passwords;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Schema\ValidationException;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class AlgorithmAttributesFactoryTest extends TestCase
@@ -84,4 +85,4 @@ class AlgorithmAttributesFactoryTest extends TestCase
 
 }
 
-$runner->run(AlgorithmAttributesFactoryTest::class);
+TestCaseRunner::run(AlgorithmAttributesFactoryTest::class);

--- a/site/tests/Pulse/Passwords/AlgorithmTest.phpt
+++ b/site/tests/Pulse/Passwords/AlgorithmTest.phpt
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Pulse\Passwords;
 
 use DateTime;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class AlgorithmTest extends TestCase
@@ -72,4 +73,4 @@ class AlgorithmTest extends TestCase
 
 }
 
-$runner->run(AlgorithmTest::class);
+TestCaseRunner::run(AlgorithmTest::class);

--- a/site/tests/Pulse/Passwords/RatingTest.phpt
+++ b/site/tests/Pulse/Passwords/RatingTest.phpt
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Pulse\Passwords;
 
 use DateTime;
+use MichalSpacekCz\Test\TestCaseRunner;
 use RuntimeException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class RatingTest extends TestCase
@@ -123,4 +124,4 @@ class RatingTest extends TestCase
 
 }
 
-$runner->run(RatingTest::class);
+TestCaseRunner::run(RatingTest::class);

--- a/site/tests/Tags/TagsTest.phpt
+++ b/site/tests/Tags/TagsTest.phpt
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Tags;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TagsTest extends TestCase
@@ -52,4 +53,4 @@ class TagsTest extends TestCase
 
 }
 
-$runner->run(TagsTest::class);
+TestCaseRunner::run(TagsTest::class);

--- a/site/tests/Talks/TalkLocaleUrlsTest.phpt
+++ b/site/tests/Talks/TalkLocaleUrlsTest.phpt
@@ -6,11 +6,12 @@ namespace MichalSpacekCz\Talks;
 use DateTime;
 use MichalSpacekCz\Media\Video;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Utils\Html;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TalkLocaleUrlsTest extends TestCase
@@ -82,4 +83,4 @@ class TalkLocaleUrlsTest extends TestCase
 
 }
 
-$runner->run(TalkLocaleUrlsTest::class);
+TestCaseRunner::run(TalkLocaleUrlsTest::class);

--- a/site/tests/Talks/TalkSlidesTest.phpt
+++ b/site/tests/Talks/TalkSlidesTest.phpt
@@ -7,10 +7,11 @@ namespace MichalSpacekCz\Talks;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Talks\Exceptions\UnknownSlideException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TalkSlidesTest extends TestCase
@@ -46,4 +47,4 @@ class TalkSlidesTest extends TestCase
 
 }
 
-$runner->run(TalkSlidesTest::class);
+TestCaseRunner::run(TalkSlidesTest::class);

--- a/site/tests/Templating/FiltersTest.phpt
+++ b/site/tests/Templating/FiltersTest.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Templating;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 
@@ -26,4 +27,4 @@ class FiltersTest extends TestCase
 
 }
 
-$runner->run(FiltersTest::class);
+TestCaseRunner::run(FiltersTest::class);

--- a/site/tests/Templating/TemplateFactoryTest.phpt
+++ b/site/tests/Templating/TemplateFactoryTest.phpt
@@ -5,6 +5,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Templating;
 
 use MichalSpacekCz\Templating\Exceptions\WrongTemplateClassException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Nette\Bridges\ApplicationLatte\LatteFactory;
 use Nette\Bridges\ApplicationLatte\Template;
@@ -13,7 +14,7 @@ use Spaze\NonceGenerator\Nonce;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TemplateFactoryTest extends TestCase
@@ -58,4 +59,4 @@ class TemplateFactoryTest extends TestCase
 
 }
 
-$runner->run(TemplateFactoryTest::class);
+TestCaseRunner::run(TemplateFactoryTest::class);

--- a/site/tests/Tls/CertificateAttemptFactoryTest.phpt
+++ b/site/tests/Tls/CertificateAttemptFactoryTest.phpt
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Tls;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class CertificateAttemptFactoryTest extends TestCase
@@ -39,4 +40,4 @@ class CertificateAttemptFactoryTest extends TestCase
 
 }
 
-$runner->run(CertificateAttemptFactoryTest::class);
+TestCaseRunner::run(CertificateAttemptFactoryTest::class);

--- a/site/tests/Tls/CertificateFactoryTest.phpt
+++ b/site/tests/Tls/CertificateFactoryTest.phpt
@@ -6,12 +6,13 @@ namespace MichalSpacekCz\Tls;
 
 use DateTimeImmutable;
 use MichalSpacekCz\DateTime\DateTime;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Database\Row;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class CertificateFactoryTest extends TestCase
@@ -96,4 +97,4 @@ class CertificateFactoryTest extends TestCase
 
 }
 
-$runner->run(CertificateFactoryTest::class);
+TestCaseRunner::run(CertificateFactoryTest::class);

--- a/site/tests/Tls/CertificatesTest.phpt
+++ b/site/tests/Tls/CertificatesTest.phpt
@@ -9,12 +9,13 @@ use MichalSpacekCz\DateTime\DateTime;
 use MichalSpacekCz\DateTime\DateTimeZoneFactory;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Tls\Exceptions\SomeCertificatesLoggedToFileException;
 use Nette\Database\DriverException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class CertificatesTest extends TestCase
@@ -105,4 +106,4 @@ class CertificatesTest extends TestCase
 
 }
 
-$runner->run(CertificatesTest::class);
+TestCaseRunner::run(CertificatesTest::class);

--- a/site/tests/Tls/OpenSslTest.phpt
+++ b/site/tests/Tls/OpenSslTest.phpt
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Tls;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class OpenSslTest extends TestCase
@@ -37,4 +38,4 @@ class OpenSslTest extends TestCase
 
 }
 
-$runner->run(OpenSslTest::class);
+TestCaseRunner::run(OpenSslTest::class);

--- a/site/tests/Training/ApplicationForm/TrainingApplicationFormDataLoggerTest.phpt
+++ b/site/tests/Training/ApplicationForm/TrainingApplicationFormDataLoggerTest.phpt
@@ -7,6 +7,7 @@ use DateTime;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Http\NullSession;
 use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\ApplicationForm\TrainingApplicationFormDataLogger;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Applications\TrainingApplicationSessionSection;
@@ -17,7 +18,7 @@ use stdClass;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationFormDataLoggerTest extends TestCase
@@ -154,4 +155,4 @@ class TrainingApplicationFormDataLoggerTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationFormDataLoggerTest::class);
+TestCaseRunner::run(TrainingApplicationFormDataLoggerTest::class);

--- a/site/tests/Training/ApplicationForm/TrainingApplicationFormSpamTest.phpt
+++ b/site/tests/Training/ApplicationForm/TrainingApplicationFormSpamTest.phpt
@@ -6,12 +6,13 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\ApplicationForm;
 
 use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Exceptions\SpammyApplicationException;
 use Nette\Utils\ArrayHash;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationFormSpamTest extends TestCase
@@ -96,4 +97,4 @@ class TrainingApplicationFormSpamTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationFormSpamTest::class);
+TestCaseRunner::run(TrainingApplicationFormSpamTest::class);

--- a/site/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
+++ b/site/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\NullSession;
 use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Applications\TrainingApplicationSessionSection;
 use MichalSpacekCz\Training\Dates\TrainingDate;
 use MichalSpacekCz\Training\Dates\TrainingDateStatus;
@@ -26,7 +27,7 @@ use ReflectionMethod;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationFormSuccessTest extends TestCase
@@ -282,4 +283,4 @@ class TrainingApplicationFormSuccessTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationFormSuccessTest::class);
+TestCaseRunner::run(TrainingApplicationFormSuccessTest::class);

--- a/site/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
@@ -6,11 +6,12 @@ namespace MichalSpacekCz\Training\Applications;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Database\Row;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationFactoryTest extends TestCase
@@ -88,4 +89,4 @@ class TrainingApplicationFactoryTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationFactoryTest::class);
+TestCaseRunner::run(TrainingApplicationFactoryTest::class);

--- a/site/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Training;
 
 use DateTime;
 use MichalSpacekCz\ShouldNotHappenException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Applications\TrainingApplicationSessionSection;
 use MichalSpacekCz\Training\Dates\TrainingDate;
@@ -18,7 +19,7 @@ use Nette\Utils\Html;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationSessionSectionTest extends TestCase
@@ -311,4 +312,4 @@ class TrainingApplicationSessionSectionTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationSessionSectionTest::class);
+TestCaseRunner::run(TrainingApplicationSessionSectionTest::class);

--- a/site/tests/Training/Applications/TrainingApplicationSourcesTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationSourcesTest.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\Applications;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationSourcesTest extends TestCase
@@ -43,4 +44,4 @@ class TrainingApplicationSourcesTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationSourcesTest::class);
+TestCaseRunner::run(TrainingApplicationSourcesTest::class);

--- a/site/tests/Training/Applications/TrainingApplicationStorageTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationStorageTest.phpt
@@ -6,13 +6,14 @@ namespace MichalSpacekCz\Training\Applications;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Dates\TrainingDate;
 use MichalSpacekCz\Training\Dates\TrainingDateStatus;
 use RuntimeException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationStorageTest extends TestCase
@@ -187,4 +188,4 @@ class TrainingApplicationStorageTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationStorageTest::class);
+TestCaseRunner::run(TrainingApplicationStorageTest::class);

--- a/site/tests/Training/Applications/TrainingApplicationsTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationsTest.phpt
@@ -5,11 +5,12 @@ namespace MichalSpacekCz\Training;
 
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Applications\TrainingApplications;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingApplicationsTest extends TestCase
@@ -35,4 +36,4 @@ class TrainingApplicationsTest extends TestCase
 
 }
 
-$runner->run(TrainingApplicationsTest::class);
+TestCaseRunner::run(TrainingApplicationsTest::class);

--- a/site/tests/Training/Dates/TrainingDateStatusesTest.phpt
+++ b/site/tests/Training/Dates/TrainingDateStatusesTest.phpt
@@ -5,10 +5,11 @@ namespace MichalSpacekCz\Training\Dates;
 
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingDateStatusesTest extends TestCase
@@ -89,4 +90,4 @@ class TrainingDateStatusesTest extends TestCase
 
 }
 
-$runner->run(TrainingDateStatusesTest::class);
+TestCaseRunner::run(TrainingDateStatusesTest::class);

--- a/site/tests/Training/Dates/TrainingDatesFormValidatorTest.phpt
+++ b/site/tests/Training/Dates/TrainingDatesFormValidatorTest.phpt
@@ -4,12 +4,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Dates\TrainingDatesFormValidator;
 use Nette\Forms\Controls\TextInput;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingDatesFormValidatorTest extends TestCase
@@ -94,4 +95,4 @@ class TrainingDatesFormValidatorTest extends TestCase
 
 }
 
-$runner->run(TrainingDatesFormValidatorTest::class);
+TestCaseRunner::run(TrainingDatesFormValidatorTest::class);

--- a/site/tests/Training/Dates/TrainingDatesTest.phpt
+++ b/site/tests/Training/Dates/TrainingDatesTest.phpt
@@ -6,10 +6,11 @@ namespace MichalSpacekCz\Training\Dates;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingDatesTest extends TestCase
@@ -255,4 +256,4 @@ class TrainingDatesTest extends TestCase
 
 }
 
-$runner->run(TrainingDatesTest::class);
+TestCaseRunner::run(TrainingDatesTest::class);

--- a/site/tests/Training/Dates/UpcomingTrainingDatesTest.phpt
+++ b/site/tests/Training/Dates/UpcomingTrainingDatesTest.phpt
@@ -5,10 +5,11 @@ namespace MichalSpacekCz\Training\Dates;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class UpcomingTrainingDatesTest extends TestCase
@@ -205,4 +206,4 @@ class UpcomingTrainingDatesTest extends TestCase
 
 }
 
-$runner->run(UpcomingTrainingDatesTest::class);
+TestCaseRunner::run(UpcomingTrainingDatesTest::class);

--- a/site/tests/Training/Discontinued/DiscontinuedTrainingsTest.phpt
+++ b/site/tests/Training/Discontinued/DiscontinuedTrainingsTest.phpt
@@ -6,13 +6,14 @@ namespace MichalSpacekCz\Training\Discontinued;
 
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\Response;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Nette\Bridges\ApplicationLatte\LatteFactory;
 use Nette\Http\IResponse;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class DiscontinuedTrainingsTest extends TestCase
@@ -101,4 +102,4 @@ class DiscontinuedTrainingsTest extends TestCase
 
 }
 
-$runner->run(DiscontinuedTrainingsTest::class);
+TestCaseRunner::run(DiscontinuedTrainingsTest::class);

--- a/site/tests/Training/Files/TrainingFilesCollectionTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesCollectionTest.phpt
@@ -5,11 +5,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Files;
 
 use DateTimeImmutable;
+use MichalSpacekCz\Test\TestCaseRunner;
 use SplFileInfo;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingFilesCollectionTest extends TestCase
@@ -58,4 +59,4 @@ class TrainingFilesCollectionTest extends TestCase
 
 }
 
-$runner->run(TrainingFilesCollectionTest::class);
+TestCaseRunner::run(TrainingFilesCollectionTest::class);

--- a/site/tests/Training/Files/TrainingFilesDownloadTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesDownloadTest.phpt
@@ -10,13 +10,14 @@ use MichalSpacekCz\Test\Application\UiPresenterMock;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\NullSession;
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Nette\Application\BadRequestException;
 use Nette\Application\Responses\RedirectResponse;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingFilesDownloadTest extends TestCase
@@ -132,4 +133,4 @@ class TrainingFilesDownloadTest extends TestCase
 
 }
 
-$runner->run(TrainingFilesDownloadTest::class);
+TestCaseRunner::run(TrainingFilesDownloadTest::class);

--- a/site/tests/Training/Files/TrainingFilesSessionSectionTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesSessionSectionTest.phpt
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Training\Files;
 
 use DateTime;
 use MichalSpacekCz\ShouldNotHappenException;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Mails\TrainingMailMessageFactory;
 use MichalSpacekCz\Training\Statuses;
@@ -14,7 +15,7 @@ use Nette\Utils\Html;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingFilesSessionSectionTest extends TestCase
@@ -165,4 +166,4 @@ class TrainingFilesSessionSectionTest extends TestCase
 
 }
 
-$runner->run(TrainingFilesSessionSectionTest::class);
+TestCaseRunner::run(TrainingFilesSessionSectionTest::class);

--- a/site/tests/Training/Files/TrainingFilesStorageTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesStorageTest.phpt
@@ -5,10 +5,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Files;
 
 use DateTimeImmutable;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingFilesStorageTest extends TestCase
@@ -30,4 +31,4 @@ class TrainingFilesStorageTest extends TestCase
 
 }
 
-$runner->run(TrainingFilesStorageTest::class);
+TestCaseRunner::run(TrainingFilesStorageTest::class);

--- a/site/tests/Training/FreeSeatsTest.phpt
+++ b/site/tests/Training/FreeSeatsTest.phpt
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training;
 
 use DateTime;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Dates\TrainingDate;
 use MichalSpacekCz\Training\Dates\TrainingDateStatus;
 use MichalSpacekCz\Training\Dates\UpcomingTraining;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class FreeSeatsTest extends TestCase
@@ -98,4 +99,4 @@ class FreeSeatsTest extends TestCase
 
 }
 
-$runner->run(FreeSeatsTest::class);
+TestCaseRunner::run(FreeSeatsTest::class);

--- a/site/tests/Training/Mails/TrainingMailMessageFactoryTest.phpt
+++ b/site/tests/Training/Mails/TrainingMailMessageFactoryTest.phpt
@@ -8,6 +8,7 @@ use MichalSpacekCz\DateTime\DateTimeFormatter;
 use MichalSpacekCz\DateTime\DateTimeZoneFactory;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Files\TrainingFiles;
 use MichalSpacekCz\Training\Statuses;
@@ -15,7 +16,7 @@ use Nette\Utils\Html;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingMailMessageFactoryTest extends TestCase
@@ -150,4 +151,4 @@ class TrainingMailMessageFactoryTest extends TestCase
 
 }
 
-$runner->run(TrainingMailMessageFactoryTest::class);
+TestCaseRunner::run(TrainingMailMessageFactoryTest::class);

--- a/site/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
+++ b/site/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
@@ -6,10 +6,11 @@ namespace MichalSpacekCz\Training\Preliminary;
 
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class PreliminaryTrainingsTest extends TestCase
@@ -230,4 +231,4 @@ class PreliminaryTrainingsTest extends TestCase
 
 }
 
-$runner->run(PreliminaryTrainingsTest::class);
+TestCaseRunner::run(PreliminaryTrainingsTest::class);

--- a/site/tests/Training/PriceTest.phpt
+++ b/site/tests/Training/PriceTest.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class PriceTest extends TestCase
@@ -24,4 +25,4 @@ class PriceTest extends TestCase
 
 }
 
-$runner->run(PriceTest::class);
+TestCaseRunner::run(PriceTest::class);

--- a/site/tests/Training/PricesTest.phpt
+++ b/site/tests/Training/PricesTest.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class PricesTest extends TestCase
@@ -85,4 +86,4 @@ class PricesTest extends TestCase
 
 }
 
-$runner->run(PricesTest::class);
+TestCaseRunner::run(PricesTest::class);

--- a/site/tests/Training/StatusesTest.phpt
+++ b/site/tests/Training/StatusesTest.phpt
@@ -6,11 +6,12 @@ namespace MichalSpacekCz\Training;
 
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Exceptions\TrainingStatusIdNotIntException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class StatusesTest extends TestCase
@@ -50,4 +51,4 @@ class StatusesTest extends TestCase
 
 }
 
-$runner->run(StatusesTest::class);
+TestCaseRunner::run(StatusesTest::class);

--- a/site/tests/Training/TrainingLocalesTest.phpt
+++ b/site/tests/Training/TrainingLocalesTest.phpt
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training;
 
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TrainingLocalesTest extends TestCase
@@ -37,4 +38,4 @@ class TrainingLocalesTest extends TestCase
 
 }
 
-$runner->run(TrainingLocalesTest::class);
+TestCaseRunner::run(TrainingLocalesTest::class);

--- a/site/tests/Training/Trainings/TrainingFactoryTest.phpt
+++ b/site/tests/Training/Trainings/TrainingFactoryTest.phpt
@@ -3,11 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\Trainings;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Database\Row;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingFactoryTest extends TestCase
@@ -96,4 +97,4 @@ class TrainingFactoryTest extends TestCase
 
 }
 
-$runner->run(TrainingFactoryTest::class);
+TestCaseRunner::run(TrainingFactoryTest::class);

--- a/site/tests/Training/Trainings/TrainingsTest.phpt
+++ b/site/tests/Training/Trainings/TrainingsTest.phpt
@@ -5,10 +5,11 @@ namespace MichalSpacekCz\Training\Trainings;
 
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingsTest extends TestCase
@@ -34,4 +35,4 @@ class TrainingsTest extends TestCase
 
 }
 
-$runner->run(TrainingsTest::class);
+TestCaseRunner::run(TrainingsTest::class);

--- a/site/tests/Training/Venues/TrainingVenuesTest.phpt
+++ b/site/tests/Training/Venues/TrainingVenuesTest.phpt
@@ -5,11 +5,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Venues;
 
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Exceptions\TrainingVenueNotFoundException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 class TrainingVenuesTest extends TestCase
@@ -64,4 +65,4 @@ class TrainingVenuesTest extends TestCase
 
 }
 
-$runner->run(TrainingVenuesTest::class);
+TestCaseRunner::run(TrainingVenuesTest::class);

--- a/site/tests/Twitter/TwitterCardsTest.phpt
+++ b/site/tests/Twitter/TwitterCardsTest.phpt
@@ -5,11 +5,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Twitter;
 
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Twitter\Exceptions\TwitterCardNotFoundException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class TwitterCardsTest extends TestCase
@@ -85,4 +86,4 @@ class TwitterCardsTest extends TestCase
 
 }
 
-$runner->run(TwitterCardsTest::class);
+TestCaseRunner::run(TwitterCardsTest::class);

--- a/site/tests/UpcKeys/UbeeTest.phpt
+++ b/site/tests/UpcKeys/UbeeTest.phpt
@@ -4,10 +4,11 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\UpcKeys;
 
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class UbeeTest extends TestCase
@@ -60,4 +61,4 @@ class UbeeTest extends TestCase
 
 }
 
-$runner->run(UbeeTest::class);
+TestCaseRunner::run(UbeeTest::class);

--- a/site/tests/UpcKeys/UpcKeysTest.phpt
+++ b/site/tests/UpcKeys/UpcKeysTest.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\UpcKeys;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class UpcKeysTest extends TestCase
@@ -35,4 +36,4 @@ class UpcKeysTest extends TestCase
 
 }
 
-$runner->run(UpcKeysTest::class);
+TestCaseRunner::run(UpcKeysTest::class);

--- a/site/tests/UpcKeys/WiFiKeyTest.phpt
+++ b/site/tests/UpcKeys/WiFiKeyTest.phpt
@@ -4,11 +4,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\UpcKeys;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Utils\Json;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class WiFiKeyTest extends TestCase
@@ -31,4 +32,4 @@ class WiFiKeyTest extends TestCase
 
 }
 
-$runner->run(WiFiKeyTest::class);
+TestCaseRunner::run(WiFiKeyTest::class);

--- a/site/tests/User/ManagerTest.phpt
+++ b/site/tests/User/ManagerTest.phpt
@@ -7,6 +7,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\User;
 
 use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use MichalSpacekCz\User\Exceptions\IdentityUsernameNotStringException;
@@ -16,7 +17,7 @@ use Nette\Security\User;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class ManagerTest extends TestCase
@@ -98,4 +99,4 @@ class ManagerTest extends TestCase
 
 }
 
-$runner->run(ManagerTest::class);
+TestCaseRunner::run(ManagerTest::class);

--- a/site/tests/Utils/Base64Test.phpt
+++ b/site/tests/Utils/Base64Test.phpt
@@ -3,10 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Utils;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class Base64Test extends TestCase
@@ -29,4 +30,4 @@ class Base64Test extends TestCase
 
 }
 
-$runner->run(Base64Test::class);
+TestCaseRunner::run(Base64Test::class);

--- a/site/tests/Utils/JsonUtilsTest.phpt
+++ b/site/tests/Utils/JsonUtilsTest.phpt
@@ -3,12 +3,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Utils;
 
+use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Utils\Exceptions\JsonItemNotStringException;
 use MichalSpacekCz\Utils\Exceptions\JsonItemsNotArrayException;
 use Tester\Assert;
 use Tester\TestCase;
 
-$runner = require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../bootstrap.php';
 
 /** @testCase */
 class JsonUtilsTest extends TestCase
@@ -37,4 +38,4 @@ class JsonUtilsTest extends TestCase
 
 }
 
-$runner->run(JsonUtilsTest::class);
+TestCaseRunner::run(JsonUtilsTest::class);

--- a/site/tests/bootstrap.php
+++ b/site/tests/bootstrap.php
@@ -1,9 +1,4 @@
 <?php
 declare(strict_types = 1);
 
-use MichalSpacekCz\Application\Bootstrap;
-use MichalSpacekCz\Test\TestCaseRunner;
-
 require __DIR__ . '/../vendor/autoload.php';
-
-return Bootstrap::bootTest()->getByType(TestCaseRunner::class);


### PR DESCRIPTION
Resolves multiple Psalm errors like:

> INFO: PossiblyNullReference - tests/UpcKeys/WiFiKeyTest.phpt:34:10 - Cannot call method run on possibly null value (see https://psalm.dev/083) $runner->run(WiFiKeyTest::class);