### PR TITLE
Psalm `PropertyNotSetInConstructor`

### DIFF
--- a/site/app/Admin/Presenters/InterviewsPresenter.php
+++ b/site/app/Admin/Presenters/InterviewsPresenter.php
@@ -10,12 +10,13 @@ use MichalSpacekCz\Interviews\Interview;
 use MichalSpacekCz\Interviews\InterviewInputs;
 use MichalSpacekCz\Interviews\InterviewInputsFactory;
 use MichalSpacekCz\Interviews\Interviews;
+use MichalSpacekCz\ShouldNotHappenException;
 use Nette\Application\BadRequestException;
 
 class InterviewsPresenter extends BasePresenter
 {
 
-	private Interview $interview;
+	private ?Interview $interview = null;
 
 
 	public function __construct(
@@ -49,6 +50,9 @@ class InterviewsPresenter extends BasePresenter
 
 	protected function createComponentEditInterviewInputs(): InterviewInputs
 	{
+		if (!$this->interview) {
+			throw new ShouldNotHappenException('actionInterview() will be called first');
+		}
 		return $this->interviewInputsFactory->createFor($this->interview);
 	}
 

--- a/site/app/Admin/Presenters/PresenterTemplates/Interviews/InterviewsDefault.php
+++ b/site/app/Admin/Presenters/PresenterTemplates/Interviews/InterviewsDefault.php
@@ -4,16 +4,17 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Admin\Presenters\PresenterTemplates\Interviews;
 
 use MichalSpacekCz\Interviews\Interview;
-use Nette\Bridges\ApplicationLatte\Template;
 
-class InterviewsDefault extends Template
+class InterviewsDefault
 {
 
-	public string $pageTitle;
-
-	/** @var list<Interview> */
-	public array $interviews;
-
-	public null $interview;
+	/**
+	 * @param list<Interview> $interviews
+	 */
+	public function __construct(
+		public string $pageTitle,
+		public array $interviews,
+	) {
+	}
 
 }

--- a/site/app/Admin/Presenters/PresenterTemplates/Interviews/InterviewsInterview.php
+++ b/site/app/Admin/Presenters/PresenterTemplates/Interviews/InterviewsInterview.php
@@ -4,13 +4,14 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Admin\Presenters\PresenterTemplates\Interviews;
 
 use MichalSpacekCz\Interviews\Interview;
-use Nette\Bridges\ApplicationLatte\Template;
 
-class InterviewsInterview extends Template
+class InterviewsInterview
 {
 
-	public string $pageTitle;
-
-	public Interview $interview;
+	public function __construct(
+		public string $pageTitle,
+		public Interview $interview,
+	) {
+	}
 
 }

--- a/site/app/Admin/Presenters/TalksPresenter.php
+++ b/site/app/Admin/Presenters/TalksPresenter.php
@@ -23,8 +23,8 @@ class TalksPresenter extends BasePresenter
 
 	private Talk $talk;
 
-	/** @var Row[] */
-	private array $slides;
+	/** @var array<int, Row> slide number => data */
+	private array $slides = [];
 
 	private int $newCount;
 

--- a/site/app/Admin/Presenters/TalksPresenter.php
+++ b/site/app/Admin/Presenters/TalksPresenter.php
@@ -7,6 +7,7 @@ use Contributte\Translation\Translator;
 use MichalSpacekCz\Form\TalkSlidesFormFactory;
 use MichalSpacekCz\Http\HttpInput;
 use MichalSpacekCz\Media\Exceptions\ContentTypeException;
+use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Talks\Exceptions\TalkDoesNotExistException;
 use MichalSpacekCz\Talks\Talk;
 use MichalSpacekCz\Talks\TalkInputs;
@@ -21,7 +22,7 @@ use Nette\Utils\Html;
 class TalksPresenter extends BasePresenter
 {
 
-	private Talk $talk;
+	private ?Talk $talk = null;
 
 	/** @var array<int, Row> slide number => data */
 	private array $slides = [];
@@ -86,6 +87,9 @@ class TalksPresenter extends BasePresenter
 
 	protected function createComponentEditTalkInputs(): TalkInputs
 	{
+		if (!$this->talk) {
+			throw new ShouldNotHappenException('actionTalk() will be called first');
+		}
 		return $this->talkInputsFactory->createFor($this->talk);
 	}
 
@@ -98,6 +102,9 @@ class TalksPresenter extends BasePresenter
 
 	protected function createComponentSlides(): Form
 	{
+		if (!$this->talk) {
+			throw new ShouldNotHappenException('actionSlides() will be called first');
+		}
 		return $this->talkSlidesFormFactory->create(
 			function (Html $message, string $type, int $talkId): never {
 				$this->flashMessage($message, $type);

--- a/site/app/Admin/Presenters/TalksPresenter.php
+++ b/site/app/Admin/Presenters/TalksPresenter.php
@@ -26,9 +26,7 @@ class TalksPresenter extends BasePresenter
 	/** @var array<int, Row> slide number => data */
 	private array $slides = [];
 
-	private int $newCount;
-
-	private int $maxSlideUploads;
+	private int $newCount = 0;
 
 
 	public function __construct(
@@ -78,7 +76,7 @@ class TalksPresenter extends BasePresenter
 		$this->template->talkTitle = $this->talk->getTitle();
 		$this->template->slides = $this->slides;
 		$this->template->talk = $this->talk;
-		$this->template->maxSlideUploads = $this->maxSlideUploads = (int)ini_get('max_file_uploads');
+		$this->template->maxSlideUploads = $this->talkSlidesFormFactory->getMaxSlideUploads();
 		$new = $this->httpInput->getPostArray('new');
 		$count = $new ? count($new) : 0;
 		$this->template->newCount = $this->newCount = ($count ?: (int)empty($this->slides));
@@ -108,7 +106,6 @@ class TalksPresenter extends BasePresenter
 			$this->talk->getId(),
 			$this->slides,
 			$this->newCount,
-			$this->maxSlideUploads,
 			$this->request,
 		);
 	}

--- a/site/app/Admin/Presenters/TrainingsPresenter.php
+++ b/site/app/Admin/Presenters/TrainingsPresenter.php
@@ -36,7 +36,7 @@ class TrainingsPresenter extends BasePresenter
 {
 
 	/** @var list<TrainingApplication> */
-	private array $applications;
+	private array $applications = [];
 
 	/** @var int[] */
 	private array $applicationIdsAllowedFiles = [];

--- a/site/app/Admin/Presenters/TrainingsPresenter.php
+++ b/site/app/Admin/Presenters/TrainingsPresenter.php
@@ -9,6 +9,7 @@ use MichalSpacekCz\Form\TrainingApplicationAdminFormFactory;
 use MichalSpacekCz\Form\TrainingApplicationMultipleFormFactory;
 use MichalSpacekCz\Form\TrainingFileFormFactory;
 use MichalSpacekCz\Form\TrainingStatusesFormFactory;
+use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Applications\TrainingApplications;
 use MichalSpacekCz\Training\DateList\DateListOrder;
@@ -41,11 +42,11 @@ class TrainingsPresenter extends BasePresenter
 	/** @var int[] */
 	private array $applicationIdsAllowedFiles = [];
 
-	private TrainingApplication $application;
+	private ?TrainingApplication $application = null;
 
-	private TrainingReview $review;
+	private ?TrainingReview $review = null;
 
-	private TrainingDate $training;
+	private ?TrainingDate $training = null;
 
 	/** @var list<TrainingDate> */
 	private array $pastWithPersonalData = [];
@@ -243,6 +244,9 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentApplications(): Form
 	{
+		if (!$this->training) {
+			throw new ShouldNotHappenException('actionDate() will be called first');
+		}
 		return $this->trainingApplicationMultipleFormFactory->create(
 			function (int $dateId): never {
 				$this->redirect($this->getAction(), $dateId);
@@ -254,6 +258,9 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentApplicationForm(): Form
 	{
+		if (!$this->application) {
+			throw new ShouldNotHappenException('actionApplication() will be called first');
+		}
 		return $this->trainingApplicationAdminFactory->create(
 			function (?int $dateId): never {
 				if ($dateId) {
@@ -272,6 +279,9 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentFile(): Form
 	{
+		if (!$this->training) {
+			throw new ShouldNotHappenException('actionDate() or actionFiles() will be called first');
+		}
 		return $this->trainingFileFormFactory->create(
 			function (Html|string $message, string $type): never {
 				$this->flashMessage($message, $type);
@@ -285,6 +295,9 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentEditTrainingDateInputs(): TrainingDateInputs
 	{
+		if (!$this->training) {
+			throw new ShouldNotHappenException('actionDate() will be called first');
+		}
 		return $this->trainingDateInputsFactory->createFor($this->training);
 	}
 
@@ -321,12 +334,18 @@ class TrainingsPresenter extends BasePresenter
 
 	protected function createComponentEditReviewInputs(): TrainingReviewInputs
 	{
+		if (!$this->review) {
+			throw new ShouldNotHappenException('actionReview() will be called first');
+		}
 		return $this->trainingReviewInputsFactory->create(false, $this->review->getDateId(), $this->review);
 	}
 
 
 	protected function createComponentAddReviewInputs(): TrainingReviewInputs
 	{
+		if (!$this->training) {
+			throw new ShouldNotHappenException('actionDate() will be called first');
+		}
 		return $this->trainingReviewInputsFactory->create(true, $this->training->getId());
 	}
 

--- a/site/app/Form/TalkSlidesFormFactory.php
+++ b/site/app/Form/TalkSlidesFormFactory.php
@@ -31,11 +31,10 @@ class TalkSlidesFormFactory
 	 * @param int $talkId
 	 * @param Row[] $slides
 	 * @param int $newCount
-	 * @param int $maxSlideUploads
 	 * @param Request $request
 	 * @return Form
 	 */
-	public function create(callable $onSuccess, int $talkId, array $slides, int $newCount, int $maxSlideUploads, Request $request): Form
+	public function create(callable $onSuccess, int $talkId, array $slides, int $newCount, Request $request): Form
 	{
 		$form = $this->factory->create();
 		$slidesContainer = $form->addContainer('slides');
@@ -76,7 +75,7 @@ class TalkSlidesFormFactory
 			}
 			$onSuccess($message, $type, $talkId);
 		};
-		$form->onValidate[] = function (Form $form) use ($request, $maxSlideUploads): void {
+		$form->onValidate[] = function (Form $form) use ($request): void {
 			// Check whether max allowed file uploads has been reached
 			$uploaded = 0;
 			$files = $request->getFiles();
@@ -86,8 +85,8 @@ class TalkSlidesFormFactory
 				}
 			});
 			// If there's no error yet then the number of uploaded just coincidentally matches max allowed
-			if ($form->hasErrors() && $uploaded >= $maxSlideUploads) {
-				$form->addError($this->texyFormatter->translate('messages.talks.admin.maxslideuploadsexceeded', [(string)$maxSlideUploads]));
+			if ($form->hasErrors() && $uploaded >= $this->getMaxSlideUploads()) {
+				$form->addError($this->texyFormatter->translate('messages.talks.admin.maxslideuploadsexceeded', [(string)$this->getMaxSlideUploads()]));
 			}
 		};
 
@@ -130,6 +129,12 @@ class TalkSlidesFormFactory
 			->setHtmlAttribute('class', 'slide-filename');
 		$container->addTextArea('speakerNotes', 'Poznámky:')
 			->setRequired('Zadejte prosím poznámky');
+	}
+
+
+	public function getMaxSlideUploads(): int
+	{
+		return (int)ini_get('max_file_uploads');
 	}
 
 }

--- a/site/app/Form/TrainingApplicationMultipleFormFactory.php
+++ b/site/app/Form/TrainingApplicationMultipleFormFactory.php
@@ -6,7 +6,7 @@ namespace MichalSpacekCz\Form;
 use MichalSpacekCz\Form\Controls\TrainingControlsFactory;
 use MichalSpacekCz\Http\HttpInput;
 use MichalSpacekCz\Training\Applications\TrainingApplicationStorage;
-use MichalSpacekCz\Training\Price;
+use MichalSpacekCz\Training\Dates\TrainingDate;
 use MichalSpacekCz\Training\Statuses;
 use Nette\Application\UI\Form;
 
@@ -25,13 +25,8 @@ class TrainingApplicationMultipleFormFactory
 
 	/**
 	 * @param callable(int): void $onSuccess
-	 * @param int $trainingId
-	 * @param int $dateId
-	 * @param Price|null $price
-	 * @param int|null $studentDiscount
-	 * @return Form
 	 */
-	public function create(callable $onSuccess, int $trainingId, int $dateId, ?Price $price, ?int $studentDiscount): Form
+	public function create(callable $onSuccess, TrainingDate $trainingDate): Form
 	{
 		$form = $this->factory->create();
 		$applicationsContainer = $form->addContainer('applications');
@@ -59,12 +54,12 @@ class TrainingApplicationMultipleFormFactory
 
 		$form->addSubmit('submit', 'Přidat');
 
-		$form->onSuccess[] = function (Form $form) use ($trainingId, $dateId, $price, $studentDiscount, $onSuccess): void {
+		$form->onSuccess[] = function (Form $form) use ($trainingDate, $onSuccess): void {
 			$values = $form->getValues();
 			foreach ($values->applications as $application) {
 				$this->trainingApplicationStorage->insertApplication(
-					$trainingId,
-					$dateId,
+					$trainingDate->getTrainingId(),
+					$trainingDate->getId(),
 					$application->name,
 					$application->email,
 					$application->company,
@@ -75,14 +70,14 @@ class TrainingApplicationMultipleFormFactory
 					$application->companyId,
 					$application->companyTaxId,
 					$application->note,
-					$price,
-					$studentDiscount,
+					$trainingDate->getPrice(),
+					$trainingDate->getStudentDiscount(),
 					$values->status,
 					$values->source,
 					$values->date,
 				);
 			}
-			$onSuccess($dateId);
+			$onSuccess($trainingDate->getId());
 		};
 
 		return $form;

--- a/site/app/Form/TrainingDateFormFactory.php
+++ b/site/app/Form/TrainingDateFormFactory.php
@@ -36,7 +36,7 @@ class TrainingDateFormFactory
 
 	/**
 	 * @param callable(): void $onSuccessAdd
-	 * @param callable(): void $onSuccessEdit
+	 * @param callable(int): void $onSuccessEdit
 	 * @param TrainingDate|null $date
 	 * @return Form
 	 */
@@ -183,7 +183,7 @@ class TrainingDateFormFactory
 					$values->feedbackHref,
 				);
 			}
-			$date ? $onSuccessEdit() : $onSuccessAdd();
+			$date ? $onSuccessEdit($date->getId()) : $onSuccessAdd();
 		};
 
 		return $form;

--- a/site/app/Pulse/Presenters/PasswordsStoragesPresenter.php
+++ b/site/app/Pulse/Presenters/PasswordsStoragesPresenter.php
@@ -16,9 +16,9 @@ use Nette\Application\UI\InvalidLinkException;
 class PasswordsStoragesPresenter extends BasePresenter
 {
 
-	private ?string $rating;
-	private ?string $sort;
-	private ?string $search;
+	private ?string $rating = null;
+	private ?string $sort = null;
+	private ?string $search = null;
 
 
 	public function __construct(

--- a/site/app/Pulse/Presenters/PresenterTemplates/PasswordsStorages/PasswordsStoragesDefaultTemplate.php
+++ b/site/app/Pulse/Presenters/PresenterTemplates/PasswordsStorages/PasswordsStoragesDefaultTemplate.php
@@ -4,22 +4,21 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Pulse\Presenters\PresenterTemplates\PasswordsStorages;
 
 use MichalSpacekCz\Pulse\Passwords\StorageRegistry;
-use Nette\Bridges\ApplicationLatte\Template;
 
-class PasswordsStoragesDefaultTemplate extends Template
+class PasswordsStoragesDefaultTemplate
 {
 
-	public bool $isDetail;
-
-	public string $pageTitle;
-
-	public StorageRegistry $data;
-
-	/** @var string[] */
-	public array $ratingGuide;
-
-	public bool $openSearchSort;
-
-	public ?string $canonicalLink;
+	/**
+	 * @param array<string, string> $ratingGuide
+	 */
+	public function __construct(
+		public bool $isDetail,
+		public string $pageTitle,
+		public StorageRegistry $data,
+		public array $ratingGuide,
+		public bool $openSearchSort,
+		public ?string $canonicalLink,
+	) {
+	}
 
 }

--- a/site/app/Training/DateList/UpcomingTrainingDatesListFactory.php
+++ b/site/app/Training/DateList/UpcomingTrainingDatesListFactory.php
@@ -22,7 +22,7 @@ class UpcomingTrainingDatesListFactory
 	}
 
 
-	public function createExclude(string $excludeTraining): UpcomingTrainingDatesList
+	public function createExclude(?string $excludeTraining): UpcomingTrainingDatesList
 	{
 		return new UpcomingTrainingDatesList($this->upcomingTrainingDates, $this->freeSeats, $excludeTraining, false, null);
 	}

--- a/site/app/Training/Dates/TrainingDateInputs.php
+++ b/site/app/Training/Dates/TrainingDateInputs.php
@@ -13,7 +13,6 @@ class TrainingDateInputs extends UiControl
 	public function __construct(
 		private readonly TrainingDateFormFactory $trainingDateFormFactory,
 		private readonly ?TrainingDate $trainingDate,
-		private readonly ?int $redirectParam,
 	) {
 	}
 
@@ -31,9 +30,9 @@ class TrainingDateInputs extends UiControl
 			function (): never {
 				$this->getPresenter()->redirect('Trainings:');
 			},
-			function (): never {
+			function (int $dateId): never {
 				$this->flashMessage('Termín upraven');
-				$this->getPresenter()->redirect($this->getPresenter()->getAction(), $this->redirectParam);
+				$this->getPresenter()->redirect($this->getPresenter()->getAction(), $dateId);
 			},
 			$this->trainingDate,
 		);

--- a/site/app/Training/Dates/TrainingDateInputsFactory.php
+++ b/site/app/Training/Dates/TrainingDateInputsFactory.php
@@ -14,15 +14,15 @@ class TrainingDateInputsFactory
 	}
 
 
-	public function createFor(TrainingDate $trainingDate, int $redirectParam): TrainingDateInputs
+	public function createFor(TrainingDate $trainingDate): TrainingDateInputs
 	{
-		return new TrainingDateInputs($this->trainingDateFormFactory, $trainingDate, $redirectParam);
+		return new TrainingDateInputs($this->trainingDateFormFactory, $trainingDate);
 	}
 
 
 	public function create(): TrainingDateInputs
 	{
-		return new TrainingDateInputs($this->trainingDateFormFactory, null, null);
+		return new TrainingDateInputs($this->trainingDateFormFactory, null);
 	}
 
 }

--- a/site/app/UpcKeys/Presenters/HomepagePresenter.php
+++ b/site/app/UpcKeys/Presenters/HomepagePresenter.php
@@ -14,7 +14,7 @@ use Nette\Http\IResponse;
 class HomepagePresenter extends BasePresenter
 {
 
-	private ?string $ssid;
+	private ?string $ssid = null;
 
 
 	public function __construct(

--- a/site/app/Www/Presenters/TrainingsPresenter.php
+++ b/site/app/Www/Presenters/TrainingsPresenter.php
@@ -36,9 +36,9 @@ class TrainingsPresenter extends BasePresenter
 	private Training $training;
 
 	/** @var array<int, TrainingDate> id => date */
-	private array $dates;
+	private array $dates = [];
 
-	private string $trainingAction;
+	private ?string $trainingAction = null;
 
 
 	public function __construct(
@@ -197,7 +197,7 @@ class TrainingsPresenter extends BasePresenter
 		} catch (TrainingDoesNotExistException $e) {
 			throw new BadRequestException($e->getMessage(), previous: $e);
 		}
-		$application = $this->trainingFilesDownload->start($this->trainingAction, $param);
+		$application = $this->trainingFilesDownload->start($name, $param);
 		$trainingStart = $application->getTrainingStart();
 		$trainingEnd = $application->getTrainingEnd();
 		if (!$trainingStart || !$trainingEnd) {
@@ -289,7 +289,7 @@ class TrainingsPresenter extends BasePresenter
 	 */
 	protected function getLocaleLinkParams(): array
 	{
-		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction ?? null, $this->getParameters());
+		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction, $this->getParameters());
 	}
 
 

--- a/site/app/Www/Presenters/VenuesPresenter.php
+++ b/site/app/Www/Presenters/VenuesPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Www\Presenters;
 
 use MichalSpacekCz\Formatter\TexyFormatter;
+use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Training\DateList\UpcomingTrainingDatesList;
 use MichalSpacekCz\Training\DateList\UpcomingTrainingDatesListFactory;
 use MichalSpacekCz\Training\Exceptions\TrainingVenueNotFoundException;
@@ -13,7 +14,7 @@ use Nette\Application\BadRequestException;
 class VenuesPresenter extends BasePresenter
 {
 
-	private UpcomingTrainingDatesList $upcomingTrainingDatesList;
+	private ?UpcomingTrainingDatesList $upcomingTrainingDatesList = null;
 
 
 	public function __construct(
@@ -42,6 +43,9 @@ class VenuesPresenter extends BasePresenter
 
 	protected function createComponentUpcomingDatesList(): UpcomingTrainingDatesList
 	{
+		if (!$this->upcomingTrainingDatesList) {
+			throw new ShouldNotHappenException('actionVenue() will be called first');
+		}
 		return $this->upcomingTrainingDatesList;
 	}
 


### PR DESCRIPTION
Resolve `PropertyNotSetInConstructor` errors 

By mostly dropping the properties in favor of a method or local variable, or by setting the default property of "current" objects to null.

These will always be initialized in the `action*()` methods and so will always be available in the `createComponent*()` methods. But Psalm can't possibly know that. Still not sure I like it this way, it's there mostly for Psalm only but maybe it's ok.

Resolves errors like
```
ERROR: PropertyNotSetInConstructor - app/Admin/Presenters/TrainingsPresenter.php:44:30 - Property MichalSpacekCz\Admin\Presenters\TrainingsPresenter::$application is not defined in constructor of MichalSpacekCz\Admin\Presenters\TrainingsPresenter or in any private or final methods called in the constructor (see https://psalm.dev/074)
        private TrainingApplication $application;