### PR TITLE
Latte templates with `strict types = 1`

### DIFF
--- a/site/app/Formatter/TexyFormatter.php
+++ b/site/app/Formatter/TexyFormatter.php
@@ -7,6 +7,7 @@ use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\Translator;
 use Nette\Utils\Html;
 use Nette\Utils\Strings;
+use Stringable;
 use Symfony\Contracts\Cache\CacheInterface;
 use Texy\Texy;
 
@@ -113,11 +114,11 @@ class TexyFormatter
 
 
 	/**
-	 * @param list<string|int> $args
+	 * @param list<string|Stringable|int> $args
 	 */
-	public function substitute(string $format, array $args): Html
+	public function substitute(string|Stringable $format, array $args): Html
 	{
-		return $this->format(vsprintf($format, $args));
+		return $this->format(vsprintf((string)$format, $args));
 	}
 
 

--- a/site/app/Templating/Filters.php
+++ b/site/app/Templating/Filters.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Templating;
 use MichalSpacekCz\DateTime\DateTimeFormatter;
 use MichalSpacekCz\Formatter\TexyFormatter;
 use Nette\Utils\Html;
+use Stringable;
 
 class Filters
 {
@@ -46,7 +47,7 @@ class Filters
 	}
 
 
-	public function format(string $message, string|int ...$args): Html
+	public function format(string|Stringable $message, string|Stringable|int ...$args): Html
 	{
 		return $this->texyFormatter->substitute($message, array_values($args));
 	}

--- a/site/config/common.neon
+++ b/site/config/common.neon
@@ -35,6 +35,8 @@ di:
 		parameters: false
 		tags: false
 
+latte:
+	strictTypes: true
 
 database:
 	default:

--- a/site/phpstan-latte-templates.neon
+++ b/site/phpstan-latte-templates.neon
@@ -4,6 +4,7 @@ parameters:
 		- app
 	level: max
 	latte:
+		strictMode: true
 		engineBootstrap: app/PhpStan/latteEngine.php
 		presenterFactoryBootstrap: app/PhpStan/presenterFactory.php
 		features:

--- a/site/tests/Formatter/TexyFormatterTest.phpt
+++ b/site/tests/Formatter/TexyFormatterTest.phpt
@@ -11,6 +11,8 @@ use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
+use Nette\Utils\Html;
+use Stringable;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -115,6 +117,37 @@ class TexyFormatterTest extends TestCase
 	public function testFormatBlock(): void
 	{
 		Assert::same("<p>{$this->expectedFormatted}</p>\n", $this->texyFormatter->formatBlock('**foo "bar":[training:' . self::TRAINING_ACTION . ']**')->toHtml());
+	}
+
+
+	public function testSubstitute(): void
+	{
+		Assert::same('<em>foo</em> bar 303', $this->texyFormatter->substitute('*foo* %s %d', ['bar', 303])->render());
+
+		$toString = new class () implements Stringable {
+
+			public function __toString(): string
+			{
+				return __FUNCTION__;
+			}
+
+		};
+		$toStringNoInterface = new class () {
+
+			public function __toString(): string
+			{
+				return __FUNCTION__;
+			}
+
+		};
+		$html = Html::fromText('foo');
+		Assert::same('__toString', $this->texyFormatter->substitute($toString, [])->render());
+		Assert::same('<code>__toString</code>', $this->texyFormatter->substitute("`%s`", [$toString])->render());
+		Assert::same('__toString', $this->texyFormatter->substitute($toStringNoInterface, [])->render());
+		Assert::same('<code>__toString</code>', $this->texyFormatter->substitute("`%s`", [$toStringNoInterface])->render());
+
+		Assert::same('foo', $this->texyFormatter->substitute($html, [])->render());
+		Assert::same('<strong>foo</strong>', $this->texyFormatter->substitute("**%s**", [$html])->render());
 	}
 
 

--- a/site/tests/Templating/FiltersTest.phpt
+++ b/site/tests/Templating/FiltersTest.phpt
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Templating;
 
 use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Utils\Html;
+use Stringable;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,6 +25,31 @@ class FiltersTest extends TestCase
 	public function testFormat(): void
 	{
 		Assert::same('<em>foo</em> bar 303', $this->filters->format('*foo* %s %d', 'bar', 303)->render());
+
+		$toString = new class () implements Stringable {
+
+			public function __toString(): string
+			{
+				return __FUNCTION__;
+			}
+
+		};
+		$toStringNoInterface = new class () {
+
+			public function __toString(): string
+			{
+				return __FUNCTION__;
+			}
+
+		};
+		$html = Html::fromText('foo');
+		Assert::same('__toString', $this->filters->format($toString)->render());
+		Assert::same('<code>__toString</code>', $this->filters->format("`%s`", $toString)->render());
+		Assert::same('__toString', $this->filters->format($toStringNoInterface)->render());
+		Assert::same('<code>__toString</code>', $this->filters->format("`%s`", $toStringNoInterface)->render());
+
+		Assert::same('foo', $this->filters->format($html)->render());
+		Assert::same('<strong>foo</strong>', $this->filters->format("**%s**", $html)->render());
 	}
 
 }


### PR DESCRIPTION
Enable `strict_types = 1` for compiled Latte templates both for the app, and for the PHPStan Latte tests.

As suggested https://github.com/nette/application/issues/313#issuecomment-1706384973 which I also think is a fairly good idea, given that I write code with `strict_types = 1`, check this and that with PHPStan etc.

And change places that need changing to support that, as reported by the PHPStan Latte extension.