### PR TITLE
`$message` can be null in `stream_context_set_params()` `notification` callback

### DIFF
--- a/site/app/CompanyInfo/CompanyRegisterAres.php
+++ b/site/app/CompanyInfo/CompanyRegisterAres.php
@@ -89,9 +89,9 @@ class CompanyRegisterAres implements CompanyRegister
 	{
 		$context = stream_context_create();
 		$setResult = stream_context_set_params($context, [
-			'notification' => function (int $notificationCode, int $severity, string $message, int $messageCode) {
+			'notification' => function (int $notificationCode, int $severity, ?string $message, int $messageCode) {
 				if ($severity === STREAM_NOTIFY_SEVERITY_ERR) {
-					throw new CompanyInfoException(trim($message) . " ({$notificationCode})", $messageCode);
+					throw new CompanyInfoException($notificationCode . ($message ? trim(' ' . $message) : ''), $messageCode);
 				}
 			},
 			'options' => [

--- a/site/app/UpcKeys/Technicolor.php
+++ b/site/app/UpcKeys/Technicolor.php
@@ -115,9 +115,9 @@ class Technicolor implements RouterInterface
 	{
 		$context = stream_context_create();
 		$setResult = stream_context_set_params($context, [
-			'notification' => function (int $notificationCode, int $severity, string $message, int $messageCode) {
+			'notification' => function (int $notificationCode, int $severity, ?string $message, int $messageCode) {
 				if ($notificationCode == STREAM_NOTIFY_FAILURE && $messageCode >= 500) {
-					throw new RuntimeException(trim($message), $messageCode);
+					throw new RuntimeException($message ? trim($message) : '', $messageCode);
 				}
 			},
 			'options' => [


### PR DESCRIPTION
I had it right in `MichalSpacekCz\Http\HttpStreamContext::create()`, which probably should be used instead, but followed the example in PHP docs that says only `string $message`.

PHP docs PR https://github.com/php/doc-en/pull/2767

Introduced in bd8c0890bd41a4867be17fabdd3966d1d643cf86 in #220