### PR TITLE
Support the new ARES (Administrativní registr ekonomických subjektů) version

### DIFF
--- a/site/config/parameters.neon
+++ b/site/config/parameters.neon
@@ -35,7 +35,7 @@ parameters:
 	vatRate: 0.21
 	loadCompanyDataVisible: true
 	ares:
-		url: 'https://wwwinfo.mfcr.cz/cgi-bin/ares/darv_bas.cgi?ico=%s'
+		url: 'https://ares.gov.cz/ekonomicke-subjekty-v-be/rest/ekonomicke-subjekty/%s'
 	registerUz:
 		rootUrl: 'http://www.registeruz.sk/cruz-public/api/'
 	returningUser:

--- a/site/tests/CompanyInfo/CompanyRegisterAresTest.phpt
+++ b/site/tests/CompanyInfo/CompanyRegisterAresTest.phpt
@@ -1,0 +1,99 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\CompanyInfo;
+
+use MichalSpacekCz\CompanyInfo\Exceptions\CompanyNotFoundException;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\Environment;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class CompanyRegisterAresTest extends TestCase
+{
+
+	public function __construct(
+		private readonly CompanyRegisterAres $ares,
+	) {
+	}
+
+
+	public function testGetDetails(): void
+	{
+		if (getenv(Environment::VariableRunner)) {
+			$file = basename(__FILE__);
+			Environment::skip("The test uses the Internet, to not skip the test run it with `php {$file}`");
+		}
+		$expected = new CompanyInfoDetails(
+			200,
+			'OK',
+			'26688093',
+			'CZ26688093',
+			'Landis+Gyr s.r.o.',
+			'Plzeňská 3185/5a',
+			'Praha',
+			'15000',
+			'cz',
+		);
+		Assert::equal($expected, $this->ares->getDetails('26688093'), 'All house number & street number & extra letter');
+		sleep(3);
+
+		$expected = new CompanyInfoDetails(
+			200,
+			'OK',
+			'44741561',
+			'CZ44741561',
+			'VSACAN TOUR, s.r.o.',
+			'Dolní náměstí 344',
+			'Vsetín',
+			'75501',
+			'cz',
+		);
+		Assert::equal($expected, $this->ares->getDetails('44741561'), 'Just house number');
+		sleep(3);
+
+		$expected = new CompanyInfoDetails(
+			200,
+			'OK',
+			'00256081',
+			'CZ00256081',
+			'Obec Srní',
+			'Srní 113',
+			'Srní',
+			'34192',
+			'cz',
+		);
+		Assert::equal($expected, $this->ares->getDetails('00256081'), 'No street');
+		sleep(3);
+
+		$expected = new CompanyInfoDetails(
+			200,
+			'OK',
+			'12466743',
+			'',
+			'JUDr. Ivo Javůrek',
+			'Jeřabinová 874/12',
+			'Plzeň',
+			'32600',
+			'cz',
+		);
+		Assert::equal($expected, $this->ares->getDetails('12466743'), 'No tax id');
+		sleep(3);
+
+		Assert::exception(function (): void {
+			$this->ares->getDetails('1337');
+		}, CompanyNotFoundException::class, 'Invalid status 400');
+		sleep(3);
+
+		Assert::exception(function (): void {
+			$this->ares->getDetails('13371338');
+		}, CompanyNotFoundException::class, 'Company not found');
+	}
+
+}
+
+TestCaseRunner::run(CompanyRegisterAresTest::class);


### PR DESCRIPTION
The new version uses JSON instead of XML.

[The announcement](https://wwwinfo.mfcr.cz/ares/ares_info.html.cz) & [archived](https://web.archive.org/web/20230914225112/https%3A%2F%2Fwwwinfo.mfcr.cz%2Fares%2Fares_info.html.cz)

See https://ares.gov.cz/stranky/vyvojar-info & https://ares.gov.cz/swagger-ui/ for the docs.
This is using the `/ekonomicke-subjekty` endpoint because it returns DIČ/tax id as well.