### PR TITLE
Reverse the flag option in certmonitor

### DIFF
--- a/site/app/Tls/CertificateMonitor.php
+++ b/site/app/Tls/CertificateMonitor.php
@@ -35,7 +35,7 @@ class CertificateMonitor implements CliArgsProvider
 		try {
 			// Not running in parallel because those sites are hosted on just a few tiny servers
 			foreach ($this->certificatesApiClient->getLoggedCertificates() as $loggedCertificate) {
-				$this->compareCertificates($loggedCertificate, $this->certificateGatherer->fetchCertificates($loggedCertificate->getCommonName(), $this->cliArgs->getFlag(self::NO_IPV6)));
+				$this->compareCertificates($loggedCertificate, $this->certificateGatherer->fetchCertificates($loggedCertificate->getCommonName(), !$this->cliArgs->getFlag(self::NO_IPV6)));
 			}
 			exit($this->hasErrors ? 1 : 0);
 		} catch (Exception $e) {


### PR DESCRIPTION
I messed it up in #229 commit 780e9a99fb7a3f55e934be4cf739f79435c2009a