### PR TITLE
preg_match() always returns the full string at offset 0, ignore it

### DIFF
--- a/site/app/UpcKeys/Technicolor.php
+++ b/site/app/UpcKeys/Technicolor.php
@@ -102,7 +102,7 @@ class Technicolor implements RouterInterface
 			if (!preg_match('/([^,]+),([^,]+),(\d+)/', $line, $matches)) {
 				throw new RuntimeException('Incorrect number of tokens in ' . $line);
 			}
-			[$serial, $key, $type] = $matches;
+			[, $serial, $key, $type] = $matches;
 			$keys["{$type}-{$serial}"] = $this->buildKey($serial, $key, (int)$type);
 		}
 		ksort($keys);


### PR DESCRIPTION
Messed up in a5044812575839272c15a544d5b0dcf2e389e0cc PR #229 because this code is not tested, unfortunately.