### PR TITLE
Use xxHash to hash text for non-cryptographic purposes

### DIFF
--- a/site/app/Formatter/TexyFormatter.php
+++ b/site/app/Formatter/TexyFormatter.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Formatter;
 
 use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\Translator;
+use MichalSpacekCz\Utils\Hash;
 use Nette\Utils\Html;
 use Nette\Utils\Strings;
 use Stringable;
@@ -194,9 +195,8 @@ class TexyFormatter
 	public function getCacheKey(string $text): string
 	{
 		// Make the key shorter because Symfony Cache stores it in comments in cache files
-		// Use MD5 to favor speed over security, which is not an issue here, and Symfony Cache itself uses MD5 as well
 		// Don't hash the locale to make it visible inside cache files
-		return md5($text) . '.' . $this->translator->getDefaultLocale();
+		return Hash::nonCryptographic($text) . '.' . $this->translator->getDefaultLocale();
 	}
 
 

--- a/site/app/Talks/TalkSlides.php
+++ b/site/app/Talks/TalkSlides.php
@@ -14,6 +14,7 @@ use MichalSpacekCz\Talks\Exceptions\DuplicatedSlideException;
 use MichalSpacekCz\Talks\Exceptions\SlideImageUploadFailedException;
 use MichalSpacekCz\Talks\Exceptions\UnknownSlideException;
 use MichalSpacekCz\Utils\Base64;
+use MichalSpacekCz\Utils\Hash;
 use Nette\Database\Explorer;
 use Nette\Database\Row;
 use Nette\Database\UniqueConstraintViolationException;
@@ -130,7 +131,7 @@ class TalkSlides
 
 	private function getSlideImageFileBasename(string $contents): string
 	{
-		return Base64::urlEncode(sha1($contents, true));
+		return Base64::urlEncode(Hash::nonCryptographic($contents, true));
 	}
 
 

--- a/site/app/Utils/Hash.php
+++ b/site/app/Utils/Hash.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Utils;
+
+class Hash
+{
+
+	public static function nonCryptographic(string $data, bool $binary = false): string
+	{
+		return hash('xxh128', $data, $binary);
+	}
+
+}

--- a/site/app/Www/Presenters/ExportsPresenter.php
+++ b/site/app/Www/Presenters/ExportsPresenter.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Www\Presenters;
 
 use MichalSpacekCz\Feed\Exports;
-use Spaze\Exports\Atom\Feed;
+use MichalSpacekCz\Utils\Hash;
 use Spaze\Exports\Bridges\Nette\Atom\Response;
 
 class ExportsPresenter extends BasePresenter
@@ -22,15 +22,9 @@ class ExportsPresenter extends BasePresenter
 		$feed = $this->exports->getArticles($this->link('//this'), $param);
 		$updated = $feed->getUpdated();
 		if ($updated) {
-			$this->lastModified($updated, $this->getEtag($feed), '1 hour');
+			$this->lastModified($updated, Hash::nonCryptographic((string)$feed), '1 hour');
 		}
 		$this->sendResponse(new Response($feed));
-	}
-
-
-	private function getEtag(Feed $feed): string
-	{
-		return sha1((string)$feed);
 	}
 
 }

--- a/site/disallowed-calls.neon
+++ b/site/disallowed-calls.neon
@@ -3,17 +3,6 @@ parameters:
 		-
 			function: 'pcntl_*()'
 		-
-			function: 'md5()'
-			message: 'use hash() with at least SHA-256 for secure hash, or password_hash() for passwords'
-			allowInMethods:
-				- 'MichalSpacekCz\Formatter\TexyFormatter::getCacheKey()'
-		-
-			function: 'sha1()'
-			message: 'use hash() with at least SHA-256 for secure hash, or password_hash() for passwords'
-			allowInMethods:
-				- 'MichalSpacekCz\Talks\TalkSlides::getSlideImageFileBasename()'
-				- 'MichalSpacekCz\Www\Presenters\ExportsPresenter::getEtag()'
-		-
 			function: 'rand()'
 			message: 'it is not a cryptographically secure generator, use random_int() instead'
 			allowIn:


### PR DESCRIPTION
xxHash is much faster than MD5 or SHA-1 which in these cases were used to favor speed over security which wasn't an issue anyway. xxHash is even faster than MurmurHash3.

https://php.watch/versions/8.1/xxHash
https://xxhash.com/