### PR TITLE
ARES country "upgrade"

### DIFF
--- a/.github/workflows/php-tester-include-skipped.yml
+++ b/.github/workflows/php-tester-include-skipped.yml
@@ -1,0 +1,36 @@
+name: PHP tests, including skipped tests
+
+on:
+  schedule:
+    - cron: '45 23 * * 4'
+  workflow_dispatch:
+
+jobs:
+  tester-include-skipped:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.2"
+          - "8.3"
+    steps:
+    - uses: actions/checkout@v4
+    - uses: shivammathur/setup-php@v2
+      with:
+        coverage: pcov
+        php-version: ${{ matrix.php-version }}
+    - name: Create symlink in /srv/www
+      run: |
+        sudo mkdir --parents /srv/www
+        sudo ln --symbolic $GITHUB_WORKSPACE /srv/www
+    - run: make --directory=site tester-include-skipped
+    - name: Failed test output, if any
+      if: failure()
+      run: for i in $(find ./site/tests -name \*.actual); do echo "--- $i"; cat $i; echo; echo; done
+    - name: Upload test code coverage
+      uses: actions/upload-artifact@v3
+      if: success()
+      with:
+        name: Test code coverage (PHP ${{ matrix.php-version }})
+        path: 'site/temp/coverage.html'
+        retention-days: 5

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test audit cs-fix check-file-patterns check-makefile lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester
+.PHONY: test audit cs-fix check-file-patterns check-makefile lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester tester-include-skipped
 
 test: audit check-file-patterns check-makefile lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor
 
@@ -46,3 +46,7 @@ psalm:
 
 tester:
 	vendor/nette/tester/src/tester -s -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/
+
+tester-include-skipped:
+	TEST_CASE_RUNNER_INCLUDE_SKIPPED=1 \
+	$(MAKE) tester

--- a/site/Makefile
+++ b/site/Makefile
@@ -45,4 +45,4 @@ psalm:
 	vendor/bin/psalm.phar
 
 tester:
-	vendor/nette/tester/src/tester -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/
+	vendor/nette/tester/src/tester -s -c tests/php-unix.ini --colors 1 --coverage temp/coverage.html --coverage-src app/ tests/

--- a/site/app/Test/TestCaseRunner.php
+++ b/site/app/Test/TestCaseRunner.php
@@ -8,10 +8,16 @@ use MichalSpacekCz\Application\Bootstrap;
 use Nette\Utils\Type;
 use ReflectionException;
 use ReflectionMethod;
+use Tester\Environment;
 use Tester\TestCase;
 
 class TestCaseRunner
 {
+
+	private const ENV_VAR_NAME = 'TEST_CASE_RUNNER_INCLUDE_SKIPPED';
+	private const ENV_VAR_VALUE = '1';
+	public const ENV_VAR = self::ENV_VAR_NAME . '=' . self::ENV_VAR_VALUE;
+
 
 	/**
 	 * @param class-string<TestCase> $test
@@ -48,6 +54,15 @@ class TestCaseRunner
 			// pass, __construct() does not exist
 		}
 		(new $test(...$params))->run();
+	}
+
+
+	public static function skip(string $message): void
+	{
+		if (getenv(self::ENV_VAR_NAME) === self::ENV_VAR_VALUE) {
+			return;
+		}
+		Environment::skip($message);
 	}
 
 }

--- a/site/disallowed-calls.neon
+++ b/site/disallowed-calls.neon
@@ -15,6 +15,12 @@ parameters:
 		-
 			function: 'setcookie()'
 			message: 'use methods from MichalSpacekCz\Http\Cookies'
+	disallowedStaticCalls:
+		-
+			method: 'Tester\Environment::skip()'
+			message: 'use TestCaseRunner::skip() instead, it can ignore skipping with an environment variable'
+			allowInMethods:
+				- 'MichalSpacekCz\Test\TestCaseRunner::skip()'
 	disallowedMethodCalls:
 		-
 			method:

--- a/site/phpstan-vendor.neon
+++ b/site/phpstan-vendor.neon
@@ -189,6 +189,11 @@ parameters:
 			message: 'use logger instead, debug bar is not visible in production'
 			allowIn:
 				- vendor/tracy/tracy/src/Tracy/functions.php
+		-
+			method: 'Tester\Environment::skip()'
+			message: 'use TestCaseRunner::skip() instead, it can ignore skipping with an environment variable'
+			allowIn:
+				- vendor/nette/tester/src/Framework/TestCase.php
 	disallowedSuperglobals:
 		-
 			superglobal: '$_SERVER'

--- a/site/tests/CompanyInfo/CompanyRegisterAresTest.phpt
+++ b/site/tests/CompanyInfo/CompanyRegisterAresTest.phpt
@@ -10,7 +10,6 @@ use MichalSpacekCz\Test\Http\Client\HttpClientMock;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Schema\Processor;
 use Tester\Assert;
-use Tester\Environment;
 use Tester\TestCase;
 
 require __DIR__ . '/../bootstrap.php';
@@ -32,10 +31,7 @@ class CompanyRegisterAresTest extends TestCase
 
 	public function testGetDetails(): void
 	{
-		if (getenv(Environment::VariableRunner)) {
-			$file = basename(__FILE__);
-			Environment::skip("The test uses the Internet, to not skip the test run it with `php {$file}`");
-		}
+		TestCaseRunner::skip('The test uses the Internet, to not skip the test case run it with `' . TestCaseRunner::ENV_VAR . '`');
 		$expected = new CompanyInfoDetails(
 			200,
 			'OK',

--- a/site/tests/CompanyInfo/CompanyRegisterRegisterUzTest.phpt
+++ b/site/tests/CompanyInfo/CompanyRegisterRegisterUzTest.phpt
@@ -8,7 +8,6 @@ use MichalSpacekCz\CompanyInfo\Exceptions\CompanyNotFoundException;
 use MichalSpacekCz\Http\Client\HttpClient;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
-use Tester\Environment;
 use Tester\TestCase;
 
 require __DIR__ . '/../bootstrap.php';
@@ -28,10 +27,7 @@ class CompanyRegisterRegisterUzTest extends TestCase
 
 	public function testGetDetails(): void
 	{
-		if (getenv(Environment::VariableRunner)) {
-			$file = basename(__FILE__);
-			Environment::skip("The test uses the Internet, to not skip the test run it with `php {$file}`");
-		}
+		TestCaseRunner::skip('The test uses the Internet, to not skip the test case run it with `' . TestCaseRunner::ENV_VAR . '`');
 		$expected = new CompanyInfoDetails(
 			200,
 			'OK',


### PR DESCRIPTION
I don't understand why but for this 'res' source, the country code is returned as "1", yes a string, instead of "cz", so let's deal with that. This wasn't happening when I've build the support in #225.

It could be easily removed in the future, and there's a test for it (the one for the company with id 00256081), so if it is removed and it shouldn't be, I should know about it rather soon.

Fix #242

The test querying the service is marked as "skipped" because it uses the Internet to actually query the live service and I don't want to query it when I'm running my tests in dev env for example. But I'd like to run the tests someday, so I've introduced a way to run all skipped tests, just define an environment variable `TEST_CASE_RUNNER_INCLUDE_SKIPPED=1` and run the test case again. Will also do it automatically with GitHub Actions.