### PR TITLE
Run the security.txt check on PHP 8.3 again, ext-gnupg is available

### DIFF
--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -13,6 +13,7 @@ jobs:
       matrix:
         php-version:
           - "8.2"
+          - "8.3"
         host:
           - www.michalspacek.cz
           - www.michalspacek.com


### PR DESCRIPTION
Indeed:
```
==> Setup PHP
✓ PHP Installed PHP 8.3.0

==> Setup Extensions
✓ gnupg Installed and enabled
```

Revert "Don't run the security.txt check on PHP 8.3, ext-gnupg is not yet available"
This reverts commit c141bf0bccc3a1961d754c2ee3e35cb439c5cbe5 #163