### PR TITLE
Add `#[\Override]` attribute

### DIFF
--- a/site/.editorconfig
+++ b/site/.editorconfig
@@ -7,6 +7,7 @@ indent_style = tab
 insert_final_newline = true
 trim_trailing_whitespace = true
 
+ij_php_attributes_wrap = split_into_lines
 ij_php_spaces_around_assignment_in_declare = true
 ij_php_blank_lines_around_class = 1
 ij_php_blank_lines_around_constants = 1

--- a/site/app/Admin/Presenters/BasePresenter.php
+++ b/site/app/Admin/Presenters/BasePresenter.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Admin\Presenters;
 
 use MichalSpacekCz\Www\Presenters\BasePresenter as WwwBasePresenter;
 use Nette\Security\User;
+use Override;
 use Spaze\Session\MysqlSessionHandler;
 
 abstract class BasePresenter extends WwwBasePresenter
@@ -36,6 +37,7 @@ abstract class BasePresenter extends WwwBasePresenter
 	}
 
 
+	#[Override]
 	protected function startup(): void
 	{
 		parent::startup();

--- a/site/app/Api/Presenters/CertificatesPresenter.php
+++ b/site/app/Api/Presenters/CertificatesPresenter.php
@@ -11,6 +11,7 @@ use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\SomeCertificatesLoggedToFileException;
 use MichalSpacekCz\Www\Presenters\BasePresenter;
 use Nette\Security\AuthenticationException;
+use Override;
 use Tracy\Debugger;
 
 class CertificatesPresenter extends BasePresenter
@@ -26,6 +27,7 @@ class CertificatesPresenter extends BasePresenter
 	}
 
 
+	#[Override]
 	protected function startup(): void
 	{
 		parent::startup();

--- a/site/app/Api/Presenters/ErrorGenericPresenter.php
+++ b/site/app/Api/Presenters/ErrorGenericPresenter.php
@@ -7,6 +7,7 @@ use MichalSpacekCz\Application\Error;
 use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Application\Response;
+use Override;
 
 class ErrorGenericPresenter implements IPresenter
 {
@@ -17,6 +18,7 @@ class ErrorGenericPresenter implements IPresenter
 	}
 
 
+	#[Override]
 	public function run(Request $request): Response
 	{
 		return $this->error->response($request);

--- a/site/app/Application/Cli/NoCliArgs.php
+++ b/site/app/Application/Cli/NoCliArgs.php
@@ -3,9 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application\Cli;
 
+use Override;
+
 class NoCliArgs implements CliArgsProvider
 {
 
+	#[Override]
 	public static function getArgs(): array
 	{
 		return [];

--- a/site/app/Application/Routing/BlogPostRoute.php
+++ b/site/app/Application/Routing/BlogPostRoute.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Application\Routing;
 use MichalSpacekCz\Articles\Blog\BlogPostLoader;
 use Nette\Application\Routers\Route;
 use Nette\Http\IRequest;
+use Override;
 
 /**
  * The bidirectional route is responsible for mapping
@@ -33,6 +34,7 @@ class BlogPostRoute extends Route
 	 * @param IRequest $httpRequest
 	 * @return array<string, string>|null
 	 */
+	#[Override]
 	public function match(IRequest $httpRequest): ?array
 	{
 		$url = $httpRequest->getUrl();

--- a/site/app/Articles/ArticlePublishedElsewhere.php
+++ b/site/app/Articles/ArticlePublishedElsewhere.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Articles\Components\ArticleWithId;
 use MichalSpacekCz\Articles\Components\ArticleWithPublishTime;
 use MichalSpacekCz\Articles\Components\ArticleWithSummary;
 use Nette\Utils\Html;
+use Override;
 
 class ArticlePublishedElsewhere implements ArticleWithId, ArticleWithSummary, ArticleWithPublishTime
 {
@@ -26,12 +27,14 @@ class ArticlePublishedElsewhere implements ArticleWithId, ArticleWithSummary, Ar
 	}
 
 
+	#[Override]
 	public function hasId(): bool
 	{
 		return true;
 	}
 
 
+	#[Override]
 	public function getId(): ?int
 	{
 		return $this->articleId;
@@ -56,12 +59,14 @@ class ArticlePublishedElsewhere implements ArticleWithId, ArticleWithSummary, Ar
 	}
 
 
+	#[Override]
 	public function hasSummary(): bool
 	{
 		return true;
 	}
 
 
+	#[Override]
 	public function getSummary(): ?Html
 	{
 		return $this->excerpt;
@@ -74,6 +79,7 @@ class ArticlePublishedElsewhere implements ArticleWithId, ArticleWithSummary, Ar
 	}
 
 
+	#[Override]
 	public function getPublishTime(): ?DateTime
 	{
 		return $this->published;

--- a/site/app/Articles/Blog/BlogPost.php
+++ b/site/app/Articles/Blog/BlogPost.php
@@ -16,6 +16,7 @@ use MichalSpacekCz\Articles\Components\ArticleWithUpdateTime;
 use MichalSpacekCz\Feed\ExportsOmittable;
 use MichalSpacekCz\Twitter\TwitterCard;
 use Nette\Utils\Html;
+use Override;
 
 class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, ArticleWithSummary, ArticleWithText, ArticleWithTags, ArticleWithUpdateTime, ArticleWithPublishTime, ArticleWithEdits
 {
@@ -59,18 +60,21 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function hasId(): bool
 	{
 		return $this->id !== null;
 	}
 
 
+	#[Override]
 	public function getId(): ?int
 	{
 		return $this->id;
 	}
 
 
+	#[Override]
 	public function getSlug(): string
 	{
 		return $this->slug;
@@ -107,12 +111,14 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function hasSummary(): bool
 	{
 		return $this->lead !== null;
 	}
 
 
+	#[Override]
 	public function getSummary(): ?Html
 	{
 		return $this->lead;
@@ -125,6 +131,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function getText(): Html
 	{
 		return $this->text;
@@ -149,6 +156,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function getPublishTime(): ?DateTime
 	{
 		return $this->published;
@@ -176,6 +184,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	/**
 	 * @return list<string>
 	 */
+	#[Override]
 	public function getTags(): array
 	{
 		return $this->tags;
@@ -185,6 +194,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	/**
 	 * @return list<string>
 	 */
+	#[Override]
 	public function getSlugTags(): array
 	{
 		return $this->slugTags;
@@ -206,6 +216,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function getUpdateTime(): ?DateTime
 	{
 		return $this->edits ? current($this->edits)->getEditedAt() : null;
@@ -221,6 +232,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	/**
 	 * @return list<ArticleEdit>
 	 */
+	#[Override]
 	public function getEdits(): array
 	{
 		return $this->edits;
@@ -245,6 +257,7 @@ class BlogPost implements ExportsOmittable, ArticleWithId, ArticleWithSlug, Arti
 	}
 
 
+	#[Override]
 	public function omitExports(): bool
 	{
 		return $this->omitExports;

--- a/site/app/Articles/Blog/BlogPostRecommendedLink.php
+++ b/site/app/Articles/Blog/BlogPostRecommendedLink.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Articles\Blog;
 
 use JsonSerializable;
+use Override;
 
 class BlogPostRecommendedLink implements JsonSerializable
 {
@@ -30,6 +31,7 @@ class BlogPostRecommendedLink implements JsonSerializable
 	/**
 	 * @return array{url:string, text:string}
 	 */
+	#[Override]
 	public function jsonSerialize(): array
 	{
 		return [

--- a/site/app/CompanyInfo/CompanyInfoDetails.php
+++ b/site/app/CompanyInfo/CompanyInfoDetails.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\CompanyInfo;
 
 use JsonSerializable;
+use Override;
 
 class CompanyInfoDetails implements JsonSerializable
 {
@@ -31,6 +32,7 @@ class CompanyInfoDetails implements JsonSerializable
 	/**
 	 * @return array<string, int|string|null>
 	 */
+	#[Override]
 	public function jsonSerialize(): array
 	{
 		return array_filter([

--- a/site/app/CompanyInfo/CompanyRegisterAres.php
+++ b/site/app/CompanyInfo/CompanyRegisterAres.php
@@ -14,6 +14,7 @@ use Nette\Schema\Processor;
 use Nette\Schema\ValidationException;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use Override;
 
 /**
  * ARES service.
@@ -31,6 +32,7 @@ class CompanyRegisterAres implements CompanyRegister
 	}
 
 
+	#[Override]
 	public function getCountry(): string
 	{
 		return 'cz';
@@ -41,6 +43,7 @@ class CompanyRegisterAres implements CompanyRegister
 	 * @throws CompanyInfoException
 	 * @throws CompanyNotFoundException
 	 */
+	#[Override]
 	public function getDetails(string $companyId): CompanyInfoDetails
 	{
 		if (empty($companyId)) {

--- a/site/app/CompanyInfo/CompanyRegisterRegisterUz.php
+++ b/site/app/CompanyInfo/CompanyRegisterRegisterUz.php
@@ -11,6 +11,7 @@ use MichalSpacekCz\Http\Exceptions\HttpClientRequestException;
 use Nette\Http\IResponse;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use Override;
 use stdClass;
 
 /**
@@ -32,6 +33,7 @@ class CompanyRegisterRegisterUz implements CompanyRegister
 	}
 
 
+	#[Override]
 	public function getCountry(): string
 	{
 		return 'sk';
@@ -42,6 +44,7 @@ class CompanyRegisterRegisterUz implements CompanyRegister
 	 * @throws CompanyInfoException
 	 * @throws CompanyNotFoundException
 	 */
+	#[Override]
 	public function getDetails(string $companyId): CompanyInfoDetails
 	{
 		if (empty($companyId)) {

--- a/site/app/Form/UiForm.php
+++ b/site/app/Form/UiForm.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Form;
 use MichalSpacekCz\ShouldNotHappenException;
 use Nette\Application\UI\Form;
 use Nette\Utils\ArrayHash;
+use Override;
 
 class UiForm extends Form
 {
@@ -35,6 +36,7 @@ class UiForm extends Form
 	 * @return object|array<string, mixed>
 	 * @deprecated Use getFormValues() instead
 	 */
+	#[Override]
 	public function getValues($returnType = null, ?array $controls = null): object|array
 	{
 		if (func_num_args() === 0) {
@@ -49,6 +51,7 @@ class UiForm extends Form
 	 * @return object|array<string, mixed>
 	 * @deprecated Use getUntrustedFormValues() instead
 	 * */
+	#[Override]
 	public function getUntrustedValues($returnType = ArrayHash::class, ?array $controls = null): object|array
 	{
 		if (func_num_args() === 0) {

--- a/site/app/Formatter/TrainingDateTexyFormatterPlaceholder.php
+++ b/site/app/Formatter/TrainingDateTexyFormatterPlaceholder.php
@@ -7,6 +7,7 @@ use Contributte\Translation\Translator;
 use MichalSpacekCz\DateTime\DateTimeFormatter;
 use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use Nette\Utils\Html;
+use Override;
 
 class TrainingDateTexyFormatterPlaceholder implements TexyFormatterPlaceholder
 {
@@ -19,12 +20,14 @@ class TrainingDateTexyFormatterPlaceholder implements TexyFormatterPlaceholder
 	}
 
 
+	#[Override]
 	public static function getPlaceholder(): string
 	{
 		return 'TRAINING_DATE';
 	}
 
 
+	#[Override]
 	public function replace(string $placeholder): string
 	{
 		$upcoming = $this->upcomingTrainingDates->getPublicUpcoming();

--- a/site/app/Http/SessionSectionDeprecatedGetSet.php
+++ b/site/app/Http/SessionSectionDeprecatedGetSet.php
@@ -3,12 +3,15 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Http;
 
+use Override;
+
 trait SessionSectionDeprecatedGetSet
 {
 
 	/**
 	 * @deprecated Add get<Property>() method instead
 	 */
+	#[Override]
 	public function &__get(string $name): null
 	{
 		trigger_error('Add get<Property>() method instead', E_USER_DEPRECATED);
@@ -20,6 +23,7 @@ trait SessionSectionDeprecatedGetSet
 	/**
 	 * @deprecated Add get<Property>() method instead
 	 */
+	#[Override]
 	public function get(string $name): void
 	{
 		trigger_error('Add get<Property>() method instead', E_USER_DEPRECATED);
@@ -29,6 +33,7 @@ trait SessionSectionDeprecatedGetSet
 	/**
 	 * @deprecated Add set<Property>() method instead
 	 */
+	#[Override]
 	public function __set(string $name, mixed $value): void
 	{
 		trigger_error('Add set<Property>() method instead', E_USER_DEPRECATED);
@@ -38,6 +43,7 @@ trait SessionSectionDeprecatedGetSet
 	/**
 	 * @deprecated Add set<Property>() method instead
 	 */
+	#[Override]
 	public function set(string $name, mixed $value, ?string $expire = null): void
 	{
 		trigger_error('Add set<Property>() method instead', E_USER_DEPRECATED);
@@ -47,6 +53,7 @@ trait SessionSectionDeprecatedGetSet
 	/**
 	 * @deprecated Add get<Property>() method instead
 	 */
+	#[Override]
 	public function __isset(string $name): bool
 	{
 		trigger_error('Add get<Property>() method instead', E_USER_DEPRECATED);
@@ -57,6 +64,7 @@ trait SessionSectionDeprecatedGetSet
 	/**
 	 * @deprecated Add remove<Property>() method instead
 	 */
+	#[Override]
 	public function __unset(string $name): void
 	{
 		trigger_error('Add remove<Property>() method instead', E_USER_DEPRECATED);
@@ -67,6 +75,7 @@ trait SessionSectionDeprecatedGetSet
 	 * @param string|array<array-key, string>|null $name
 	 * @deprecated Add remove<Property>() method instead
 	 */
+	#[Override]
 	public function remove($name = null): void
 	{
 		// Deprecated silently, no error, because it's used in Nette\Http\SessionSection::set() when $value is null.

--- a/site/app/Media/Resources/InterviewMediaResources.php
+++ b/site/app/Media/Resources/InterviewMediaResources.php
@@ -3,9 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Media\Resources;
 
+use Override;
+
 class InterviewMediaResources extends MediaResources
 {
 
+	#[Override]
 	protected function getSubDir(): string
 	{
 		return 'interviews';

--- a/site/app/Media/Resources/TalkMediaResources.php
+++ b/site/app/Media/Resources/TalkMediaResources.php
@@ -3,9 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Media\Resources;
 
+use Override;
+
 class TalkMediaResources extends MediaResources
 {
 
+	#[Override]
 	protected function getSubDir(): string
 	{
 		return 'talks';

--- a/site/app/Pulse/Presenters/ErrorGenericPresenter.php
+++ b/site/app/Pulse/Presenters/ErrorGenericPresenter.php
@@ -7,6 +7,7 @@ use MichalSpacekCz\Application\Error;
 use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Application\Response;
+use Override;
 
 class ErrorGenericPresenter implements IPresenter
 {
@@ -17,6 +18,7 @@ class ErrorGenericPresenter implements IPresenter
 	}
 
 
+	#[Override]
 	public function run(Request $request): Response
 	{
 		return $this->error->response($request);

--- a/site/app/Pulse/WildcardSite.php
+++ b/site/app/Pulse/WildcardSite.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Pulse;
 use MichalSpacekCz\Pulse\Passwords\Algorithm;
 use MichalSpacekCz\Pulse\Passwords\Rating;
 use MichalSpacekCz\Pulse\Passwords\RatingGrade;
+use Override;
 
 class WildcardSite implements Site
 {
@@ -27,42 +28,49 @@ class WildcardSite implements Site
 	}
 
 
+	#[Override]
 	public function getId(): string
 	{
 		return $this->id;
 	}
 
 
+	#[Override]
 	public function getCompany(): Company
 	{
 		return $this->company;
 	}
 
 
+	#[Override]
 	public function getStorageId(): string
 	{
 		return $this->storageId;
 	}
 
 
+	#[Override]
 	public function getAlgorithm(string $id): Algorithm
 	{
 		return $this->algorithms[$id];
 	}
 
 
+	#[Override]
 	public function hasAlgorithm(string $id): bool
 	{
 		return isset($this->algorithms[$id]);
 	}
 
 
+	#[Override]
 	public function addAlgorithm(Algorithm $algorithm): void
 	{
 		$this->algorithms[$algorithm->getId()] = $algorithm;
 	}
 
 
+	#[Override]
 	public function getLatestAlgorithm(): Algorithm
 	{
 		return $this->algorithms[array_key_first($this->algorithms)];
@@ -72,12 +80,14 @@ class WildcardSite implements Site
 	/**
 	 * @return array<string, Algorithm>
 	 */
+	#[Override]
 	public function getHistoricalAlgorithms(): array
 	{
 		return array_slice($this->algorithms, 1);
 	}
 
 
+	#[Override]
 	public function getRating(): RatingGrade
 	{
 		if (!$this->ratingGrade) {
@@ -90,18 +100,21 @@ class WildcardSite implements Site
 	/**
 	 * @return array<string, Algorithm>
 	 */
+	#[Override]
 	public function getAlgorithms(): array
 	{
 		return $this->algorithms;
 	}
 
 
+	#[Override]
 	public function isSecureStorage(): bool
 	{
 		return $this->rating->isSecureStorage($this->getRating());
 	}
 
 
+	#[Override]
 	public function getRecommendation(): ?string
 	{
 		return $this->rating->getRecommendation($this->getRating());

--- a/site/app/Talks/Slides/TalkSlideCollection.php
+++ b/site/app/Talks/Slides/TalkSlideCollection.php
@@ -7,6 +7,7 @@ use ArrayIterator;
 use Countable;
 use IteratorAggregate;
 use MichalSpacekCz\Talks\Exceptions\TalkSlideDoesNotExistException;
+use Override;
 
 /**
  * @implements IteratorAggregate<int, TalkSlide>
@@ -45,12 +46,14 @@ class TalkSlideCollection implements IteratorAggregate, Countable
 	/**
 	 * @return ArrayIterator<int, TalkSlide>
 	 */
+	#[Override]
 	public function getIterator(): ArrayIterator
 	{
 		return new ArrayIterator($this->slides);
 	}
 
 
+	#[Override]
 	public function count(): int
 	{
 		return count($this->slides);

--- a/site/app/Templating/TemplateFactory.php
+++ b/site/app/Templating/TemplateFactory.php
@@ -10,6 +10,7 @@ use Nette\Application\UI\Control;
 use Nette\Application\UI\TemplateFactory as UiTemplateFactory;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Nette\Bridges\ApplicationLatte\TemplateFactory as ApplicationTemplateFactory;
+use Override;
 
 class TemplateFactory implements UiTemplateFactory
 {
@@ -23,6 +24,7 @@ class TemplateFactory implements UiTemplateFactory
 	}
 
 
+	#[Override]
 	public function createTemplate(Control $control = null, string $class = null): DefaultTemplate
 	{
 		$template = $this->templateFactory->createTemplate($control, $class);

--- a/site/app/Test/Application/ApplicationPresenter.php
+++ b/site/app/Test/Application/ApplicationPresenter.php
@@ -10,6 +10,7 @@ use Nette\Application\AbortException;
 use Nette\Application\Application;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\UI\Presenter;
+use Override;
 use ReflectionException;
 
 class ApplicationPresenter
@@ -41,6 +42,7 @@ class ApplicationPresenter
 			/**
 			 * @param list<mixed>|mixed $args
 			 */
+			#[Override]
 			public function link(string $destination, $args = []): string
 			{
 				$args = func_num_args() < 3 && is_array($args)

--- a/site/app/Test/Application/LocaleLinkGeneratorMock.php
+++ b/site/app/Test/Application/LocaleLinkGeneratorMock.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Test\Application;
 
 use MichalSpacekCz\Application\Locale\LocaleLinkGenerator;
+use Override;
 
 class LocaleLinkGeneratorMock extends LocaleLinkGenerator
 {
@@ -18,18 +19,21 @@ class LocaleLinkGeneratorMock extends LocaleLinkGenerator
 	}
 
 
+	#[Override]
 	public function links(string $destination, array $params = []): array
 	{
 		return [];
 	}
 
 
+	#[Override]
 	public function defaultParams(array $params): array
 	{
 		return ['*' => $params];
 	}
 
 
+	#[Override]
 	public function setDefaultParams(array &$params, array $defaultParams): void
 	{
 		$params['*'] = $defaultParams;
@@ -45,6 +49,7 @@ class LocaleLinkGeneratorMock extends LocaleLinkGenerator
 	}
 
 
+	#[Override]
 	public function allLinks(string $destination, array $params = []): array
 	{
 		return $this->allLinks;

--- a/site/app/Test/Application/UiPresenterMock.php
+++ b/site/app/Test/Application/UiPresenterMock.php
@@ -7,6 +7,7 @@ use LogicException;
 use Nette\Application\Response;
 use Nette\Application\Responses\RedirectResponse;
 use Nette\Application\UI\Presenter;
+use Override;
 
 class UiPresenterMock extends Presenter
 {
@@ -23,6 +24,7 @@ class UiPresenterMock extends Presenter
 	}
 
 
+	#[Override]
 	public function sendResponse(Response $response): never
 	{
 		$this->response = $response;
@@ -46,6 +48,7 @@ class UiPresenterMock extends Presenter
 	}
 
 
+	#[Override]
 	public function redirect(string $destination, $args = []): never
 	{
 		$this->sendResponse(new RedirectResponse($destination));

--- a/site/app/Test/Articles/ArticlesMock.php
+++ b/site/app/Test/Articles/ArticlesMock.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Articles\ArticleEdit;
 use MichalSpacekCz\Articles\Articles;
 use MichalSpacekCz\Articles\Blog\BlogPost;
 use Nette\Utils\Html;
+use Override;
 
 class ArticlesMock extends Articles
 {
@@ -22,6 +23,7 @@ class ArticlesMock extends Articles
 	}
 
 
+	#[Override]
 	public function getNearestPublishDate(): ?DateTime
 	{
 		return null;
@@ -71,6 +73,7 @@ class ArticlesMock extends Articles
 	/**
 	 * @return list<BlogPost>
 	 */
+	#[Override]
 	public function getAll(?int $limit = null): array
 	{
 		return $this->articles;

--- a/site/app/Test/Database/Database.php
+++ b/site/app/Test/Database/Database.php
@@ -8,6 +8,7 @@ use DateTimeInterface;
 use MichalSpacekCz\Test\WillThrow;
 use Nette\Database\Explorer;
 use Nette\Database\Row;
+use Override;
 
 class Database extends Explorer
 {
@@ -61,11 +62,13 @@ class Database extends Explorer
 	}
 
 
+	#[Override]
 	public function beginTransaction(): void
 	{
 	}
 
 
+	#[Override]
 	public function commit(): void
 	{
 	}
@@ -77,6 +80,7 @@ class Database extends Explorer
 	}
 
 
+	#[Override]
 	public function getInsertId(?string $sequence = null): string
 	{
 		return $this->insertId;
@@ -88,6 +92,7 @@ class Database extends Explorer
 	 * @param string|int|bool|DateTimeInterface|null|array<string, string|int|bool|DateTimeInterface|null> ...$params
 	 * @return ResultSet
 	 */
+	#[Override]
 	public function query(string $sql, ...$params): ResultSet
 	{
 		$this->maybeThrow();
@@ -149,6 +154,7 @@ class Database extends Explorer
 	 * @param literal-string $sql
 	 * @param string ...$params
 	 */
+	#[Override]
 	public function fetch(string $sql, ...$params): ?Row
 	{
 		$row = $this->createRow($this->fetchResult);
@@ -172,6 +178,7 @@ class Database extends Explorer
 	 * @param literal-string $sql
 	 * @param string ...$params
 	 */
+	#[Override]
 	public function fetchField(string $sql, ...$params): mixed
 	{
 		return $this->fetchFieldResults[$this->fetchFieldResultsPosition++] ?? $this->fetchFieldDefaultResult;
@@ -192,6 +199,7 @@ class Database extends Explorer
 	 * @param string ...$params
 	 * @return array<int|string, string>
 	 */
+	#[Override]
 	public function fetchPairs(string $sql, ...$params): array
 	{
 		return $this->fetchPairsResult;
@@ -237,6 +245,7 @@ class Database extends Explorer
 	 * @param string ...$params
 	 * @return list<Row>
 	 */
+	#[Override]
 	public function fetchAll(string $sql, ...$params): array
 	{
 		return $this->fetchAllResults[$this->fetchAllResultsPosition++] ?? $this->fetchAllDefaultResult;

--- a/site/app/Test/Http/Client/HttpClientMock.php
+++ b/site/app/Test/Http/Client/HttpClientMock.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Test\Http\Client;
 use MichalSpacekCz\Http\Client\HttpClient;
 use MichalSpacekCz\Http\Client\HttpClientRequest;
 use MichalSpacekCz\Http\Client\HttpClientResponse;
+use Override;
 
 class HttpClientMock extends HttpClient
 {
@@ -19,6 +20,7 @@ class HttpClientMock extends HttpClient
 	}
 
 
+	#[Override]
 	public function get(HttpClientRequest $request): HttpClientResponse
 	{
 		return new HttpClientResponse($request, $this->response, null);

--- a/site/app/Test/Http/NullSession.php
+++ b/site/app/Test/Http/NullSession.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Test\Http;
 
 use Nette\Http\Session;
+use Override;
 
 /**
  * Session handler that does nothing but it's there
@@ -11,24 +12,28 @@ use Nette\Http\Session;
 class NullSession extends Session
 {
 
+	#[Override]
 	public function start(): void
 	{
 		// And if thou gaze long into an abyss, the abyss will also gaze into thee.
 	}
 
 
+	#[Override]
 	public function autoStart(bool $forWrite): void
 	{
 		// He who fights with monsters should be careful lest he thereby become a monster.
 	}
 
 
+	#[Override]
 	public function exists(): bool
 	{
 		return true;
 	}
 
 
+	#[Override]
 	public function destroy(): void
 	{
 		// He divines remedies for injuries; he knows how to turn serious accidents to his own advantage; that which does not kill him makes him stronger.

--- a/site/app/Test/Http/Request.php
+++ b/site/app/Test/Http/Request.php
@@ -7,6 +7,7 @@ use Nette\Http\FileUpload;
 use Nette\Http\IRequest;
 use Nette\Http\UrlImmutable;
 use Nette\Http\UrlScript;
+use Override;
 
 class Request implements IRequest
 {
@@ -42,6 +43,7 @@ class Request implements IRequest
 	}
 
 
+	#[Override]
 	public function getUrl(): UrlScript
 	{
 		return $this->url;
@@ -54,12 +56,14 @@ class Request implements IRequest
 	}
 
 
+	#[Override]
 	public function getQuery(string $key = null)
 	{
 		return $key === null ? $this->url->getQueryParameters() : $this->url->getQueryParameter($key);
 	}
 
 
+	#[Override]
 	public function getPost(string $key = null)
 	{
 		return func_num_args() === 0 ? $this->post : $this->post[$key] ?? null;
@@ -76,6 +80,7 @@ class Request implements IRequest
 	 * @param string $key
 	 * @return FileUpload|null
 	 */
+	#[Override]
 	public function getFile(string $key): ?FileUpload
 	{
 		return $this->files[$key] ?? null;
@@ -85,12 +90,14 @@ class Request implements IRequest
 	/**
 	 * @return array<string, FileUpload>
 	 */
+	#[Override]
 	public function getFiles(): array
 	{
 		return $this->files;
 	}
 
 
+	#[Override]
 	public function getCookie(string $key): mixed
 	{
 		return $this->cookies[$key] ?? null;
@@ -100,24 +107,28 @@ class Request implements IRequest
 	/**
 	 * @return array<string, mixed>
 	 */
+	#[Override]
 	public function getCookies(): array
 	{
 		return $this->cookies;
 	}
 
 
+	#[Override]
 	public function getMethod(): string
 	{
 		return $this->method;
 	}
 
 
+	#[Override]
 	public function isMethod(string $method): bool
 	{
 		return strcasecmp($this->method, $method) === 0;
 	}
 
 
+	#[Override]
 	public function getHeader(string $header): ?string
 	{
 		return $this->headers[strtolower($header)] ?? null;
@@ -127,36 +138,42 @@ class Request implements IRequest
 	/**
 	 * @return array<string, string>
 	 */
+	#[Override]
 	public function getHeaders(): array
 	{
 		return $this->headers;
 	}
 
 
+	#[Override]
 	public function isSecured(): bool
 	{
 		return $this->url->getScheme() === 'https';
 	}
 
 
+	#[Override]
 	public function isAjax(): bool
 	{
 		return $this->getHeader('X-Requested-With') === 'XMLHttpRequest';
 	}
 
 
+	#[Override]
 	public function getRemoteAddress(): ?string
 	{
 		return $this->remoteAddress;
 	}
 
 
+	#[Override]
 	public function getRemoteHost(): ?string
 	{
 		return $this->remoteHost;
 	}
 
 
+	#[Override]
 	public function getRawBody(): ?string
 	{
 		return $this->rawBody;

--- a/site/app/Test/Http/Response.php
+++ b/site/app/Test/Http/Response.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Test\Http;
 
 use Nette\Http\IResponse;
+use Override;
 
 class Response implements IResponse
 {
@@ -38,6 +39,7 @@ class Response implements IResponse
 	private bool $isSent = false;
 
 
+	#[Override]
 	public function setCode(int $code, string $reason = null): self
 	{
 		$this->code = $code;
@@ -45,12 +47,14 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function getCode(): int
 	{
 		return $this->code;
 	}
 
 
+	#[Override]
 	public function setHeader(string $name, string $value): self
 	{
 		$name = strtolower($name);
@@ -60,6 +64,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function addHeader(string $name, string $value): self
 	{
 		$name = strtolower($name);
@@ -69,6 +74,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function setContentType(string $type, string $charset = null): self
 	{
 		$this->contentType = $type;
@@ -77,6 +83,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function redirect(string $url, int $code = self::S302_Found): void
 	{
 		$this->redirectTo = $url;
@@ -84,6 +91,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function setExpiration(?string $expire): self
 	{
 		$this->expiration = $expire;
@@ -91,12 +99,14 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function isSent(): bool
 	{
 		return $this->isSent;
 	}
 
 
+	#[Override]
 	public function getHeader(string $header): ?string
 	{
 		$header = strtolower($header);
@@ -107,6 +117,7 @@ class Response implements IResponse
 	/**
 	 * @return array<string, string>
 	 */
+	#[Override]
 	public function getHeaders(): array
 	{
 		return $this->headers;
@@ -121,6 +132,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function setCookie(string $name, string $value, $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null): self
 	{
 		$this->cookies[$name] = new Cookie(
@@ -135,6 +147,7 @@ class Response implements IResponse
 	}
 
 
+	#[Override]
 	public function deleteCookie(string $name, string $path = null, string $domain = null, bool $secure = null): void
 	{
 		unset($this->cookies[$name]);

--- a/site/app/Test/NoOpTranslator.php
+++ b/site/app/Test/NoOpTranslator.php
@@ -8,6 +8,7 @@ use Contributte\Translation\Exceptions\InvalidArgument;
 use Contributte\Translation\Translator;
 use Contributte\Translation\Wrappers\Message;
 use Contributte\Translation\Wrappers\NotTranslate;
+use Override;
 
 class NoOpTranslator extends Translator
 {
@@ -22,18 +23,21 @@ class NoOpTranslator extends Translator
 	}
 
 
+	#[Override]
 	public function getDefaultLocale(): string
 	{
 		return $this->defaultLocale;
 	}
 
 
+	#[Override]
 	public function getLocale(): string
 	{
 		return $this->defaultLocale;
 	}
 
 
+	#[Override]
 	public function translate(mixed $message, mixed ...$parameters): string
 	{
 		if ($message === null || $message === '') {
@@ -54,12 +58,14 @@ class NoOpTranslator extends Translator
 	}
 
 
+	#[Override]
 	public function getAvailableLocales(): array
 	{
 		return $this->availableLocales;
 	}
 
 
+	#[Override]
 	public function setFallbackLocales(array $locales): void
 	{
 	}

--- a/site/app/Test/NullLogger.php
+++ b/site/app/Test/NullLogger.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Test;
 
+use Override;
 use Tracy\ILogger;
 
 class NullLogger implements ILogger
@@ -12,6 +13,7 @@ class NullLogger implements ILogger
 	private array $logged = [];
 
 
+	#[Override]
 	public function log(mixed $value, string $level = self::INFO): ?string
 	{
 		$this->logged[] = $value;

--- a/site/app/Test/NullMailer.php
+++ b/site/app/Test/NullMailer.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Test;
 use LogicException;
 use Nette\Mail\Mailer;
 use Nette\Mail\Message;
+use Override;
 
 class NullMailer implements Mailer
 {
@@ -13,6 +14,7 @@ class NullMailer implements Mailer
 	private ?Message $mail = null;
 
 
+	#[Override]
 	public function send(Message $mail): void
 	{
 		$this->mail = $mail;

--- a/site/app/Tls/Certificate.php
+++ b/site/app/Tls/Certificate.php
@@ -7,6 +7,7 @@ use DateTimeImmutable;
 use JsonSerializable;
 use MichalSpacekCz\DateTime\DateTime;
 use MichalSpacekCz\Tls\Exceptions\CertificateException;
+use Override;
 
 class Certificate implements JsonSerializable
 {
@@ -102,6 +103,7 @@ class Certificate implements JsonSerializable
 	/**
 	 * @return array{commonName:string, commonNameExt:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
 	 */
+	#[Override]
 	public function jsonSerialize(): array
 	{
 		return [

--- a/site/app/Tls/CertificateMonitor.php
+++ b/site/app/Tls/CertificateMonitor.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Tls;
 use Exception;
 use MichalSpacekCz\Application\Cli\CliArgs;
 use MichalSpacekCz\Application\Cli\CliArgsProvider;
+use Override;
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 
 class CertificateMonitor implements CliArgsProvider
@@ -149,6 +150,7 @@ class CertificateMonitor implements CliArgsProvider
 	}
 
 
+	#[Override]
 	public static function getArgs(): array
 	{
 		return [self::NO_IPV6];

--- a/site/app/Training/DateList/UpcomingTrainingDatesList.php
+++ b/site/app/Training/DateList/UpcomingTrainingDatesList.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Application\UiControl;
 use MichalSpacekCz\Training\Dates\UpcomingTraining;
 use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use MichalSpacekCz\Training\FreeSeats;
+use Override;
 
 class UpcomingTrainingDatesList extends UiControl implements Countable
 {
@@ -50,6 +51,7 @@ class UpcomingTrainingDatesList extends UiControl implements Countable
 	}
 
 
+	#[Override]
 	public function count(): int
 	{
 		return count($this->getUpcomingTrainingDates());

--- a/site/app/Training/Files/TrainingFilesCollection.php
+++ b/site/app/Training/Files/TrainingFilesCollection.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Training\Files;
 use ArrayIterator;
 use Countable;
 use IteratorAggregate;
+use Override;
 
 /**
  * @implements IteratorAggregate<int, TrainingFile>
@@ -26,12 +27,14 @@ class TrainingFilesCollection implements IteratorAggregate, Countable
 	/**
 	 * @return ArrayIterator<int, TrainingFile>
 	 */
+	#[Override]
 	public function getIterator(): ArrayIterator
 	{
 		return new ArrayIterator($this->files);
 	}
 
 
+	#[Override]
 	public function count(): int
 	{
 		return count($this->files);

--- a/site/app/Training/Resolver/Vrana.php
+++ b/site/app/Training/Resolver/Vrana.php
@@ -4,10 +4,12 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Resolver;
 
 use Nette\Utils\Strings;
+use Override;
 
 class Vrana implements ApplicationSourceResolver
 {
 
+	#[Override]
 	public function isTrainingApplicationOwner(string $note): bool
 	{
 		return (str_contains(Strings::lower($note), 'jakub vrána') || str_contains(Strings::lower($note), 'od jakuba'));

--- a/site/app/UpcKeys/Technicolor.php
+++ b/site/app/UpcKeys/Technicolor.php
@@ -15,6 +15,7 @@ use Nette\Database\Explorer;
 use Nette\Database\UniqueConstraintViolationException;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use Override;
 use PDOException;
 use Tracy\Debugger;
 
@@ -33,6 +34,7 @@ class Technicolor implements UpcWiFiRouter
 	}
 
 
+	#[Override]
 	public function getModelWithPrefixes(): array
 	{
 		return ['Technicolor TC7200' => self::PREFIXES];
@@ -47,6 +49,7 @@ class Technicolor implements UpcWiFiRouter
 	 * @return array<int, WiFiKey>
 	 * @throws HttpClientRequestException
 	 */
+	#[Override]
 	public function getKeys(string $ssid): array
 	{
 		try {

--- a/site/app/UpcKeys/Ubee.php
+++ b/site/app/UpcKeys/Ubee.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\UpcKeys;
 
 use Nette\Database\Explorer;
+use Override;
 
 class Ubee implements UpcWiFiRouter
 {
@@ -18,6 +19,7 @@ class Ubee implements UpcWiFiRouter
 	}
 
 
+	#[Override]
 	public function getModelWithPrefixes(): array
 	{
 		return ['Ubee EVW3226' => [self::PREFIX]];
@@ -30,6 +32,7 @@ class Ubee implements UpcWiFiRouter
 	 * @param string $ssid
 	 * @return array<int, WiFiKey>
 	 */
+	#[Override]
 	public function getKeys(string $ssid): array
 	{
 		$rows = $this->database->fetchAll('SELECT mac, `key` FROM keys_ubee WHERE ssid = ?', substr($ssid, 3));

--- a/site/app/UpcKeys/WiFiKey.php
+++ b/site/app/UpcKeys/WiFiKey.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\UpcKeys;
 
 use JsonSerializable;
+use Override;
 
 class WiFiKey implements JsonSerializable
 {
@@ -58,6 +59,7 @@ class WiFiKey implements JsonSerializable
 	/**
 	 * @return array{serial:string, oui:string|null, mac:string|null, key:string, type:string, typeId:int, serialPrefix:string}
 	 */
+	#[Override]
 	public function jsonSerialize(): array
 	{
 		return [

--- a/site/app/User/Manager.php
+++ b/site/app/User/Manager.php
@@ -26,6 +26,7 @@ use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Nette\Utils\DateTime;
 use Nette\Utils\Random;
+use Override;
 use ParagonIE\Halite\Alerts\HaliteAlert;
 use Spaze\Encryption\Symmetric\StaticKey;
 use Tracy\Debugger;
@@ -63,6 +64,7 @@ class Manager implements Authenticator
 	 * @return IIdentity
 	 * @throws AuthenticationException
 	 */
+	#[Override]
 	public function authenticate(string $user, string $password): IIdentity
 	{
 		$userId = $this->verifyPassword($user, $password);

--- a/site/app/Www/Presenters/BaseErrorPresenter.php
+++ b/site/app/Www/Presenters/BaseErrorPresenter.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Http\Redirections;
 use MichalSpacekCz\ShouldNotHappenException;
 use Nette\Application\Request;
 use Nette\Http\IResponse;
+use Override;
 use Tracy\ILogger;
 
 abstract class BaseErrorPresenter extends BasePresenter
@@ -46,6 +47,7 @@ abstract class BaseErrorPresenter extends BasePresenter
 	}
 
 
+	#[Override]
 	public function startup(): void
 	{
 		parent::startup();

--- a/site/app/Www/Presenters/BasePresenter.php
+++ b/site/app/Www/Presenters/BasePresenter.php
@@ -13,6 +13,7 @@ use Nette\Application\UI\InvalidLinkException;
 use Nette\Application\UI\Presenter;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Nette\Http\IResponse;
+use Override;
 
 /**
  * @property-read DefaultTemplate $template
@@ -76,6 +77,7 @@ abstract class BasePresenter extends Presenter
 	}
 
 
+	#[Override]
 	protected function startup(): void
 	{
 		parent::startup();
@@ -86,6 +88,7 @@ abstract class BasePresenter extends Presenter
 	}
 
 
+	#[Override]
 	public function beforeRender(): void
 	{
 		try {
@@ -158,6 +161,7 @@ abstract class BasePresenter extends Presenter
 	}
 
 
+	#[Override]
 	public function lastModified($lastModified, string $etag = null, string $expire = null): void
 	{
 		$compression = ini_get('zlib.output_compression');

--- a/site/app/Www/Presenters/CompanyTrainingsPresenter.php
+++ b/site/app/Www/Presenters/CompanyTrainingsPresenter.php
@@ -13,6 +13,7 @@ use MichalSpacekCz\Training\Reviews\TrainingReviews;
 use MichalSpacekCz\Training\TrainingLocales;
 use MichalSpacekCz\Training\Trainings\Trainings;
 use Nette\Application\BadRequestException;
+use Override;
 
 class CompanyTrainingsPresenter extends BasePresenter
 {
@@ -70,6 +71,7 @@ class CompanyTrainingsPresenter extends BasePresenter
 	 *
 	 * @return array<string, array<string, string|null>>
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction, $this->getParameters());

--- a/site/app/Www/Presenters/ErrorGenericPresenter.php
+++ b/site/app/Www/Presenters/ErrorGenericPresenter.php
@@ -7,6 +7,7 @@ use MichalSpacekCz\Application\Error;
 use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Application\Response;
+use Override;
 
 class ErrorGenericPresenter implements IPresenter
 {
@@ -17,6 +18,7 @@ class ErrorGenericPresenter implements IPresenter
 	}
 
 
+	#[Override]
 	public function run(Request $request): Response
 	{
 		return $this->error->response($request);

--- a/site/app/Www/Presenters/ErrorPresenter.php
+++ b/site/app/Www/Presenters/ErrorPresenter.php
@@ -13,6 +13,7 @@ use Nette\Application\BadRequestException;
 use Nette\Application\UI\InvalidLinkException;
 use Nette\Http\IResponse;
 use Nette\Http\Url;
+use Override;
 
 class ErrorPresenter extends BaseErrorPresenter
 {
@@ -40,6 +41,7 @@ class ErrorPresenter extends BaseErrorPresenter
 	/**
 	 * @throws InvalidLinkException
 	 */
+	#[Override]
 	protected function getLocaleLinksGeneratorDestination(): string
 	{
 		try {
@@ -53,6 +55,7 @@ class ErrorPresenter extends BaseErrorPresenter
 	/**
 	 * @throws InvalidLinkException
 	 */
+	#[Override]
 	protected function getLocaleLinksGeneratorParams(): array
 	{
 		try {
@@ -78,6 +81,7 @@ class ErrorPresenter extends BaseErrorPresenter
 	 *
 	 * @return array<string, LocaleLink> of locale => URL
 	 */
+	#[Override]
 	protected function getLocaleLinkDefault(): array
 	{
 		$links = [];
@@ -94,6 +98,7 @@ class ErrorPresenter extends BaseErrorPresenter
 	 *
 	 * @throws NoOriginalRequestException
 	 */
+	#[Override]
 	protected function getLocaleLinkAction(): string
 	{
 		$requestParam = $this->appRequest->getOriginalRequest($this->getRequest());
@@ -107,6 +112,7 @@ class ErrorPresenter extends BaseErrorPresenter
 	 * @return array<string, array<string, string|null>>
 	 * @throws NoOriginalRequestException
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		$requestParam = $this->appRequest->getOriginalRequest($this->getRequest());

--- a/site/app/Www/Presenters/PostPresenter.php
+++ b/site/app/Www/Presenters/PostPresenter.php
@@ -9,6 +9,7 @@ use MichalSpacekCz\Articles\Blog\BlogPostLocaleUrls;
 use MichalSpacekCz\Articles\Blog\BlogPosts;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
+use Override;
 use Spaze\ContentSecurityPolicy\CspConfig;
 
 class PostPresenter extends BasePresenter
@@ -61,6 +62,7 @@ class PostPresenter extends BasePresenter
 	/**
 	 * Get original module:presenter:action for locale links.
 	 */
+	#[Override]
 	protected function getLocaleLinkAction(): string
 	{
 		return (count($this->localeLinkParams) > 1 ? parent::getLocaleLinkAction() : 'Www:Articles:');
@@ -72,6 +74,7 @@ class PostPresenter extends BasePresenter
 	 *
 	 * @return array<string, array{slug: string, preview: string|null}>
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		return $this->localeLinkParams;

--- a/site/app/Www/Presenters/TagsPresenter.php
+++ b/site/app/Www/Presenters/TagsPresenter.php
@@ -15,6 +15,7 @@ use MichalSpacekCz\Articles\Components\ArticleWithTags;
 use MichalSpacekCz\Formatter\TexyFormatter;
 use MichalSpacekCz\Utils\Strings;
 use Nette\Application\BadRequestException;
+use Override;
 
 class TagsPresenter extends BasePresenter
 {
@@ -104,6 +105,7 @@ class TagsPresenter extends BasePresenter
 	/**
 	 * Get original module:presenter:action for locale links.
 	 */
+	#[Override]
 	protected function getLocaleLinkAction(): string
 	{
 		return (count($this->localeLinkParams) > 1 ? parent::getLocaleLinkAction() : 'Www:Tags:');
@@ -115,6 +117,7 @@ class TagsPresenter extends BasePresenter
 	 *
 	 * @return array<string, array<string, string>>
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		return $this->localeLinkParams;

--- a/site/app/Www/Presenters/TalksPresenter.php
+++ b/site/app/Www/Presenters/TalksPresenter.php
@@ -19,6 +19,7 @@ use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use Nette\Application\BadRequestException;
 use Nette\Application\UI\InvalidLinkException;
 use Nette\Http\IResponse;
+use Override;
 
 class TalksPresenter extends BasePresenter
 {
@@ -106,6 +107,7 @@ class TalksPresenter extends BasePresenter
 	}
 
 
+	#[Override]
 	protected function getLocaleLinkAction(): string
 	{
 		return (count($this->localeLinkParams) > 1 ? parent::getLocaleLinkAction() : 'Www:Talks:');
@@ -115,6 +117,7 @@ class TalksPresenter extends BasePresenter
 	/**
 	 * @return array<string, array{name: string}>
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		return $this->localeLinkParams;

--- a/site/app/Www/Presenters/TrainingsPresenter.php
+++ b/site/app/Www/Presenters/TrainingsPresenter.php
@@ -28,6 +28,7 @@ use MichalSpacekCz\Training\Trainings\Training;
 use MichalSpacekCz\Training\Trainings\Trainings;
 use Nette\Application\BadRequestException;
 use Nette\Http\IResponse;
+use Override;
 use ParagonIE\Halite\Alerts\HaliteAlert;
 use SodiumException;
 
@@ -297,6 +298,7 @@ class TrainingsPresenter extends BasePresenter
 	 *
 	 * @return array<string, array<string, string|null>>
 	 */
+	#[Override]
 	protected function getLocaleLinkParams(): array
 	{
 		return $this->trainingLocales->getLocaleLinkParams($this->trainingAction, $this->getParameters());

--- a/site/composer.json
+++ b/site/composer.json
@@ -59,7 +59,7 @@
 		"nette/tester": "^2.4.3",
 		"php-parallel-lint/php-console-highlighter": "^1.0",
 		"php-parallel-lint/php-parallel-lint": "^1.3.2",
-		"phpstan/phpstan": "^1.9.12",
+		"phpstan/phpstan": "^1.10.50",
 		"phpstan/phpstan-deprecation-rules": "^1.1.1",
 		"phpstan/phpstan-nette": "^1.2.1",
 		"psalm/phar": "^5.14",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9753c363c0689a8b129be9217a9339e2",
+    "content-hash": "11d418a98f7cf120863f7eb64594e5cf",
     "packages": [
         {
             "name": "contributte/translation",

--- a/site/phpstan.neon
+++ b/site/phpstan.neon
@@ -9,6 +9,7 @@ parameters:
 		- php
 		- phpt
 	level: max
+	checkMissingOverrideMethodAttribute: true
 
 includes:
 	- phar://phpstan.phar/conf/bleedingEdge.neon

--- a/site/tests/Articles/ArticlesTest.phpt
+++ b/site/tests/Articles/ArticlesTest.phpt
@@ -13,6 +13,7 @@ use MichalSpacekCz\Tags\Tags;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NoOpTranslator;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -42,6 +43,7 @@ class ArticlesTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/EasterEgg/WinterIsComingTest.phpt
+++ b/site/tests/EasterEgg/WinterIsComingTest.phpt
@@ -13,6 +13,7 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Responses\TextResponse;
 use Nette\Forms\Controls\TextInput;
 use Nette\InvalidStateException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -44,6 +45,7 @@ class WinterIsComingTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->presenter->reset();

--- a/site/tests/Feed/ExportsTest.phpt
+++ b/site/tests/Feed/ExportsTest.phpt
@@ -13,6 +13,7 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\BadRequestException;
 use Nette\Caching\Storage;
 use Nette\Utils\Html;
+use Override;
 use SimpleXMLElement;
 use Tester\Assert;
 use Tester\TestCase;
@@ -39,6 +40,7 @@ class ExportsTest extends TestCase
 			}
 
 
+			#[Override]
 			public function translate(string $message, array $replacements = []): Html
 			{
 				return Html::el()->setHtml($message);
@@ -49,6 +51,7 @@ class ExportsTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->articles->reset();

--- a/site/tests/Formatter/TexyFormatterTest.phpt
+++ b/site/tests/Formatter/TexyFormatterTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Nette\Utils\Html;
+use Override;
 use Stringable;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Tester\Assert;
@@ -144,6 +145,7 @@ class TexyFormatterTest extends TestCase
 
 		$toString = new class () implements Stringable {
 
+			#[Override]
 			public function __toString(): string
 			{
 				return __FUNCTION__;
@@ -152,6 +154,7 @@ class TexyFormatterTest extends TestCase
 		};
 		$toStringNoInterface = new class () {
 
+			#[Override]
 			public function __toString(): string
 			{
 				return __FUNCTION__;

--- a/site/tests/Formatter/TexyPhraseHandlerTest.phpt
+++ b/site/tests/Formatter/TexyPhraseHandlerTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Test\NoOpTranslator;
 use MichalSpacekCz\Test\PrivateProperty;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 use Texy\Texy;
@@ -43,6 +44,7 @@ class TexyPhraseHandlerTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Templating/FiltersTest.phpt
+++ b/site/tests/Templating/FiltersTest.phpt
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Templating;
 
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Utils\Html;
+use Override;
 use Stringable;
 use Tester\Assert;
 use Tester\TestCase;
@@ -28,6 +29,7 @@ class FiltersTest extends TestCase
 
 		$toString = new class () implements Stringable {
 
+			#[Override]
 			public function __toString(): string
 			{
 				return __FUNCTION__;
@@ -36,6 +38,7 @@ class FiltersTest extends TestCase
 		};
 		$toStringNoInterface = new class () {
 
+			#[Override]
 			public function __toString(): string
 			{
 				return __FUNCTION__;

--- a/site/tests/Tls/CertificatesTest.phpt
+++ b/site/tests/Tls/CertificatesTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Tls\Exceptions\SomeCertificatesLoggedToFileException;
 use Nette\Database\DriverException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -36,6 +37,7 @@ class CertificatesTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->logger->reset();

--- a/site/tests/Training/ApplicationForm/TrainingApplicationFormDataLoggerTest.phpt
+++ b/site/tests/Training/ApplicationForm/TrainingApplicationFormDataLoggerTest.phpt
@@ -14,6 +14,7 @@ use MichalSpacekCz\Training\Applications\TrainingApplicationSessionSection;
 use MichalSpacekCz\Training\Files\TrainingFiles;
 use MichalSpacekCz\Training\Mails\TrainingMailMessageFactory;
 use Nette\Utils\Html;
+use Override;
 use stdClass;
 use Tester\Assert;
 use Tester\TestCase;
@@ -39,6 +40,7 @@ class TrainingApplicationFormDataLoggerTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->session->destroy();

--- a/site/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
+++ b/site/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
@@ -22,6 +22,7 @@ use Nette\Application\IPresenterFactory;
 use Nette\Application\UI\Presenter;
 use Nette\Forms\Controls\SelectBox;
 use Nette\Utils\Html;
+use Override;
 use ReflectionClass;
 use ReflectionMethod;
 use Tester\Assert;
@@ -102,6 +103,7 @@ class TrainingApplicationFormSuccessTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function setUp(): void
 	{
 		$this->onSuccessAction = null;
@@ -121,6 +123,7 @@ class TrainingApplicationFormSuccessTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
@@ -8,6 +8,7 @@ use DateTime;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Database\Row;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -24,6 +25,7 @@ class TrainingApplicationFactoryTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function setUp(): void
 	{
 		$this->database->setFetchFieldDefaultResult(303);

--- a/site/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
+++ b/site/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
@@ -16,6 +16,7 @@ use MichalSpacekCz\Training\Mails\TrainingMailMessageFactory;
 use Nette\Http\Session;
 use Nette\Http\SessionSection;
 use Nette\Utils\Html;
+use Override;
 use stdClass;
 use Tester\Assert;
 use Tester\TestCase;
@@ -58,6 +59,7 @@ class TrainingApplicationSessionSectionTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->sessionSection->remove();

--- a/site/tests/Training/Dates/TrainingDatesTest.phpt
+++ b/site/tests/Training/Dates/TrainingDatesTest.phpt
@@ -8,6 +8,7 @@ use DateTime;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Exceptions\TrainingDateNotRemoteNoVenueException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -24,6 +25,7 @@ class TrainingDatesTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function setUp(): void
 	{
 		$this->database->setFetchAllDefaultResult([
@@ -93,6 +95,7 @@ class TrainingDatesTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Training/Discontinued/DiscontinuedTrainingsTest.phpt
+++ b/site/tests/Training/Discontinued/DiscontinuedTrainingsTest.phpt
@@ -10,6 +10,7 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Bridges\ApplicationLatte\DefaultTemplate;
 use Nette\Bridges\ApplicationLatte\LatteFactory;
 use Nette\Http\IResponse;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -28,6 +29,7 @@ class DiscontinuedTrainingsTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Training/Files/TrainingFilesDownloadTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesDownloadTest.phpt
@@ -14,6 +14,7 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Application;
 use Nette\Application\BadRequestException;
 use Nette\Application\Responses\RedirectResponse;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -41,6 +42,7 @@ class TrainingFilesDownloadTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Training/Files/TrainingFilesSessionSectionTest.phpt
+++ b/site/tests/Training/Files/TrainingFilesSessionSectionTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Training\Statuses;
 use Nette\Http\Session;
 use Nette\Http\SessionSection;
 use Nette\Utils\Html;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -45,6 +46,7 @@ class TrainingFilesSessionSectionTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->sessionSection->remove();

--- a/site/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
+++ b/site/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
@@ -7,6 +7,7 @@ namespace MichalSpacekCz\Training\Preliminary;
 use DateTime;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,6 +24,7 @@ class PreliminaryTrainingsTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Training/StatusesTest.phpt
+++ b/site/tests/Training/StatusesTest.phpt
@@ -8,6 +8,7 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\PrivateProperty;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Training\Exceptions\TrainingStatusIdNotIntException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -24,6 +25,7 @@ class StatusesTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/Twitter/TwitterCardsTest.phpt
+++ b/site/tests/Twitter/TwitterCardsTest.phpt
@@ -7,6 +7,7 @@ namespace MichalSpacekCz\Twitter;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Twitter\Exceptions\TwitterCardNotFoundException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,6 +24,7 @@ class TwitterCardsTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/UpcKeys/TechnicolorTest.phpt
+++ b/site/tests/UpcKeys/TechnicolorTest.phpt
@@ -13,6 +13,7 @@ use MichalSpacekCz\UpcKeys\Exceptions\UpcKeysApiResponseInvalidException;
 use MichalSpacekCz\UpcKeys\Exceptions\UpcKeysApiUnknownPrefixException;
 use Nette\Utils\Json;
 use Nette\Utils\JsonException;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -31,6 +32,7 @@ class TechnicolorTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->database->reset();

--- a/site/tests/User/ManagerTest.phpt
+++ b/site/tests/User/ManagerTest.phpt
@@ -18,6 +18,7 @@ use Nette\DI\Container;
 use Nette\Security\Passwords;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
+use Override;
 use Spaze\Encryption\Symmetric\StaticKey;
 use Tester\Assert;
 use Tester\TestCase;
@@ -46,6 +47,7 @@ class ManagerTest extends TestCase
 	}
 
 
+	#[Override]
 	protected function tearDown(): void
 	{
 		$this->user->refreshStorage();


### PR DESCRIPTION
Checked missing `Override` attribute with PHPStan using the new-ish [`checkMissingOverrideMethodAttribute` config option](https://phpstan.org/config-reference#checkmissingoverridemethodattribute).

Blocked by
- [x] vimeo/psalm#10404