### PR TITLE
The `userId` property is normalized to int so no need to type-cast it

### DIFF
--- a/site/app/Test/PrivateProperty.php
+++ b/site/app/Test/PrivateProperty.php
@@ -18,4 +18,14 @@ class PrivateProperty
 		$property->setValue($object, $value);
 	}
 
+
+	/**
+	 * @throws ReflectionException
+	 */
+	public static function getValue(object $object, string $property): mixed
+	{
+		$property = new ReflectionProperty($object, $property);
+		return $property->getValue($object);
+	}
+
 }

--- a/site/app/User/Manager.php
+++ b/site/app/User/Manager.php
@@ -124,19 +124,18 @@ class Manager implements Authenticator
 		if (!$user) {
 			throw new AuthenticationException('The username is incorrect.', self::IdentityNotFound);
 		}
-		$userId = (int)$user->userId;
 		try {
 			$hash = $this->passwordEncryption->decrypt((string)$user->password);
 			if (!$this->passwords->verify($password, $hash)) {
 				throw new AuthenticationException('The password is incorrect.', self::InvalidCredential);
 			} elseif ($this->passwords->needsRehash($hash)) {
-				$this->updatePassword($userId, $password);
+				$this->updatePassword($user->userId, $password);
 			}
 		} catch (HaliteAlert $e) {
 			Debugger::log($e);
 			throw new AuthenticationException('Oops... Something went wrong.', self::Failure);
 		}
-		return $userId;
+		return $user->userId;
 	}
 
 

--- a/site/config/tests.neon
+++ b/site/config/tests.neon
@@ -9,9 +9,12 @@ parameters:
 			com: burger.test
 	encryption:
 		keys:
+			password:
+				test: "f015033d6b0b24e77bc9cbd86ec52ed5bc94ca4901c9f1378768423ec0278d66"
 			email:
 				test: "17fa3225effc107a689eb72fd8c20983bbc690bf9ea42a2f0306e0c226720845"
 		activeKeyIds:
+			password: test
 			email: test
 	awsLambda:
 		upcKeys:

--- a/site/tests/User/ManagerTest.phpt
+++ b/site/tests/User/ManagerTest.phpt
@@ -6,14 +6,19 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User;
 
+use MichalSpacekCz\ShouldNotHappenException;
+use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\PrivateProperty;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use MichalSpacekCz\User\Exceptions\IdentityUsernameNotStringException;
 use MichalSpacekCz\User\Exceptions\IdentityWithoutUsernameException;
+use Nette\DI\Container;
+use Nette\Security\Passwords;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
+use Spaze\Encryption\Symmetric\StaticKey;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,10 +28,21 @@ require __DIR__ . '/../bootstrap.php';
 class ManagerTest extends TestCase
 {
 
+	private readonly StaticKey $passwordEncryption;
+
+
 	public function __construct(
 		private readonly Manager $authenticator,
 		private readonly User $user,
+		private readonly Database $database,
+		private readonly Passwords $passwords,
+		Container $container,
 	) {
+		$service = $container->getService('passwordEncryption');
+		if (!$service instanceof StaticKey) {
+			throw new ShouldNotHappenException(sprintf('passwordEncryption should be a %s instance, but it is a %s', StaticKey::class, $service::class));
+		}
+		$this->passwordEncryption = $service;
 	}
 
 
@@ -89,6 +105,29 @@ class ManagerTest extends TestCase
 		PrivateProperty::setValue($this->user, 'authenticated', true);
 		PrivateProperty::setValue($this->user, 'identity', $identity);
 		Assert::same($username, $this->authenticator->getIdentityUsernameByUser($this->user));
+	}
+
+
+	public function testChangePassword(): void
+	{
+		$oldPassword = 'hunter2';
+		$newPassword = 'hunter3';
+		PrivateProperty::setValue($this->user, 'authenticated', true);
+		PrivateProperty::setValue($this->user, 'identity', new SimpleIdentity(1337, [], ['username' => '303']));
+		$this->database->setFetchResult([
+			'userId' => 1337,
+			'username' => '303',
+			'password' => $this->passwordEncryption->encrypt($this->passwords->hash($oldPassword)),
+		]);
+		Assert::noError(function () use ($oldPassword, $newPassword): void {
+			$this->authenticator->changePassword($this->user, $oldPassword, $newPassword);
+		});
+		$encryptedHash = $this->database->getParamsForQuery('UPDATE users SET password = ? WHERE id_user = ?')[0];
+		if (is_string($encryptedHash)) {
+			Assert::true($this->passwords->verify($newPassword, $this->passwordEncryption->decrypt($encryptedHash)));
+		} else {
+			Assert::fail('Encrypted hash should be a string but is ' . get_debug_type($encryptedHash));
+		}
 	}
 
 


### PR DESCRIPTION
Resolves
```
 ------ -------------------------------------------------------
  Line   app/User/Manager.php
 ------ -------------------------------------------------------
  129    Unreachable statement - code above always terminates.
 ------ -------------------------------------------------------
```
which happens because nette/database 3.2.0 added `never` return type to Row::__get().

This way, PhpStorm complains "Return value must be of type 'int', 'never' returned" but PHPStan doesn't, so...