### PR TITLE
Moving the whole repo inside the WSL file system

### DIFF
--- a/conf/nginx/dev-php.conf
+++ b/conf/nginx/dev-php.conf
@@ -1,4 +1,3 @@
 internal;
 fastcgi_param ENVIRONMENT development;
-fastcgi_param TEMP_DIR /tmp/michalspacek.cz;
 include /srv/www/michalspacek.cz/conf/nginx/common-php.conf;

--- a/conf/php/dev-michalspacek.cz.conf
+++ b/conf/php/dev-michalspacek.cz.conf
@@ -15,7 +15,7 @@ pm.max_spare_servers = 3
 
 chdir = /
 
-php_admin_value[open_basedir] = /mnt/c/Users/spaze/htdocs/private/michalspacek.cz/site/:/mnt/c/Users/spaze/htdocs/private/michalspacek.cz/uploads/:/tmp/michalspacek.cz/
+php_admin_value[open_basedir] = /srv/www/htdocs/private/michalspacek.cz/site/:/srv/www/htdocs/private/michalspacek.cz/uploads/:/tmp/michalspacek.cz/
 php_admin_value[session.save_path] = /srv/www/michalspacek.cz/sessions/
 php_admin_value[upload_tmp_dir] = /srv/www/michalspacek.cz/uploads/
 php_admin_value[user_ini.filename] = ""

--- a/site/app/Application/Bootstrap.php
+++ b/site/app/Application/Bootstrap.php
@@ -90,7 +90,7 @@ class Bootstrap
 		$configurator->setDebugMode($debugMode);
 		$configurator->enableTracy(self::SITE_DIR . '/log');
 		$configurator->setTimeZone('Europe/Prague');
-		$configurator->setTempDirectory(ServerEnv::tryGetString('TEMP_DIR') ?? self::SITE_DIR . '/temp');
+		$configurator->setTempDirectory(self::SITE_DIR . '/temp');
 
 		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig, $finalConfig), function (?string $path) {
 			return $path && is_file($path);

--- a/site/composer.json
+++ b/site/composer.json
@@ -38,7 +38,7 @@
 		"spaze/mysql-session-handler": "^2.3",
 		"spaze/nonce-generator": "^4.0",
 		"spaze/phpinfo": "^1.0",
-		"spaze/sri-macros": "^2.0",
+		"spaze/sri-macros": "^2.2.2",
 		"spaze/svg-icons-latte": "^1.0",
 		"symfony/cache": "^7.0",
 		"texy/texy": "^3.1.7",

--- a/site/composer.lock
+++ b/site/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11d418a98f7cf120863f7eb64594e5cf",
+    "content-hash": "15098962bbec98ed24eb0c942bcf2a9b",
     "packages": [
         {
             "name": "contributte/translation",
@@ -2118,16 +2118,16 @@
         },
         {
             "name": "spaze/sri-macros",
-            "version": "v2.2.1",
+            "version": "v2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/sri-macros.git",
-                "reference": "efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c"
+                "reference": "b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/sri-macros/zipball/efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c",
-                "reference": "efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c",
+                "url": "https://api.github.com/repos/spaze/sri-macros/zipball/b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6",
+                "reference": "b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6",
                 "shasum": ""
             },
             "require": {
@@ -2167,9 +2167,9 @@
             "description": "Subresource Integrity macros for Latte template engine",
             "support": {
                 "issues": "https://github.com/spaze/sri-macros/issues",
-                "source": "https://github.com/spaze/sri-macros/tree/v2.2.1"
+                "source": "https://github.com/spaze/sri-macros/tree/v2.2.2"
             },
-            "time": "2023-09-20T01:00:06+00:00"
+            "time": "2024-01-13T19:39:38+00:00"
         },
         {
             "name": "spaze/svg-icons-latte",

--- a/site/tests/Application/BootstrapTest.phpt
+++ b/site/tests/Application/BootstrapTest.phpt
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application;
 
+use MichalSpacekCz\Application\Cli\NoCliArgs;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\DI\Container;
@@ -74,7 +75,7 @@ class BootstrapTest extends TestCase
 		}
 		$container = null;
 		Assert::noError(function () use (&$container): void {
-			$container = Bootstrap::boot();
+			$container = Bootstrap::bootCli(NoCliArgs::class);
 		});
 		Assert::type(Container::class, $container);
 	}

--- a/site/vendor/composer/installed.json
+++ b/site/vendor/composer/installed.json
@@ -3764,17 +3764,17 @@
         },
         {
             "name": "spaze/sri-macros",
-            "version": "v2.2.1",
-            "version_normalized": "2.2.1.0",
+            "version": "v2.2.2",
+            "version_normalized": "2.2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/sri-macros.git",
-                "reference": "efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c"
+                "reference": "b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/sri-macros/zipball/efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c",
-                "reference": "efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c",
+                "url": "https://api.github.com/repos/spaze/sri-macros/zipball/b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6",
+                "reference": "b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6",
                 "shasum": ""
             },
             "require": {
@@ -3794,7 +3794,7 @@
                 "spaze/csp-config": "Sends Content Security Policy header with nonces, if enabled",
                 "spaze/nonce-generator": "Allows to add nonce attribute to script tags automatically"
             },
-            "time": "2023-09-20T01:00:06+00:00",
+            "time": "2024-01-13T19:39:38+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {
@@ -3816,7 +3816,7 @@
             "description": "Subresource Integrity macros for Latte template engine",
             "support": {
                 "issues": "https://github.com/spaze/sri-macros/issues",
-                "source": "https://github.com/spaze/sri-macros/tree/v2.2.1"
+                "source": "https://github.com/spaze/sri-macros/tree/v2.2.2"
             },
             "install-path": "../spaze/sri-macros"
         },

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -1,9 +1,9 @@
 <?php return array(
     'root' => array(
         'name' => 'spaze/michalspacek.cz',
-        'pretty_version' => 'dev-main',
-        'version' => 'dev-main',
-        'reference' => '987a8941d1b068cef474b47f4bb962e18b5b947b',
+        'pretty_version' => '1.0.0+no-version-set',
+        'version' => '1.0.0.0',
+        'reference' => NULL,
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -451,9 +451,9 @@
             'dev_requirement' => false,
         ),
         'spaze/michalspacek.cz' => array(
-            'pretty_version' => 'dev-main',
-            'version' => 'dev-main',
-            'reference' => '987a8941d1b068cef474b47f4bb962e18b5b947b',
+            'pretty_version' => '1.0.0+no-version-set',
+            'version' => '1.0.0.0',
+            'reference' => NULL,
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
@@ -505,9 +505,9 @@
             'dev_requirement' => true,
         ),
         'spaze/sri-macros' => array(
-            'pretty_version' => 'v2.2.1',
-            'version' => '2.2.1.0',
-            'reference' => 'efad2b58af5699fa7e6e11e7ef34662f4d9d1f7c',
+            'pretty_version' => 'v2.2.2',
+            'version' => '2.2.2.0',
+            'reference' => 'b94f713ed4c2f1817f6f07f1ac6f7c3774c376d6',
             'type' => 'library',
             'install_path' => __DIR__ . '/../spaze/sri-macros',
             'aliases' => array(),

--- a/site/vendor/spaze/sri-macros/src/Config.php
+++ b/site/vendor/spaze/sri-macros/src/Config.php
@@ -62,6 +62,18 @@ class Config
 	}
 
 
+	public function setLocalBuildPrefix(string $prefix): void
+	{
+		$this->localPrefix['build'] = $prefix;
+	}
+
+
+	public function getLocalPathBuildPrefix(): string
+	{
+		return sprintf('%s/%s', rtrim($this->localPrefix['path'], '/'), trim($this->localPrefix['build'], '/'));
+	}
+
+
 	public function setLocalMode(LocalMode|string $localMode): void
 	{
 		$this->localMode = is_string($localMode) ? LocalMode::from($localMode) : $localMode;


### PR DESCRIPTION
Use and create extra temp dirs for CLI & tests to avoid permissions issues when some files in cache are created by the web server, and they'd need to be overwritten by tests for example.

Revert "Move temp dir to WSL filesystem because using `/mnt` is slow"
This basically reverts commit 2f41049 #88