### PR TITLE
Detect CRLF URL attempts and fight back with an attempted humor 

### DIFF
--- a/site/app/EasterEgg/CrLfUrlInjections.php
+++ b/site/app/EasterEgg/CrLfUrlInjections.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\EasterEgg;
+
+use DateTimeImmutable;
+use Nette\Http\IRequest;
+use Nette\Http\IResponse;
+use Nette\Utils\Strings;
+
+readonly class CrLfUrlInjections
+{
+
+	private const COOKIE_NAME = 'crlfinjection';
+
+
+	public function __construct(
+		private IRequest $httpRequest,
+		private IResponse $httpResponse,
+	) {
+	}
+
+
+	public function detectAttempt(): bool
+	{
+		$url = $this->httpRequest->getUrl()->getAbsoluteUrl();
+		if (!str_contains($url, "\r") && !str_contains($url, "\n")) {
+			return false;
+		}
+		$matches = Strings::matchAll($url, sprintf('/Set\-Cookie:%s=([a-z0-9]+)/i', self::COOKIE_NAME));
+		foreach ($matches as $match) {
+			// Don't use any cookie name from the request to avoid e.g. session fixation
+			$this->httpResponse->setCookie(
+				self::COOKIE_NAME,
+				$match[1],
+				new DateTimeImmutable('-3 years 1 month 3 days 3 hours 7 minutes'),
+				'/expired=3years/1month/3days/3hours/7minutes/ago',
+			);
+		}
+		$this->httpResponse->setCode(IResponse::S204_NoContent, 'U WOT M8');
+		$this->httpResponse->setHeader('Hack-the-Planet', 'https://youtu.be/u3CKgkyc7Qo?t=20');
+		return true;
+	}
+
+}

--- a/site/app/Test/Http/Response.php
+++ b/site/app/Test/Http/Response.php
@@ -11,6 +11,8 @@ class Response implements IResponse
 
 	private int $code = IResponse::S200_OK;
 
+	private ?string $reason = null;
+
 	/** @var array<string, string> */
 	private array $headers = [];
 
@@ -40,9 +42,10 @@ class Response implements IResponse
 
 
 	#[Override]
-	public function setCode(int $code, string $reason = null): self
+	public function setCode(int $code, ?string $reason = null): self
 	{
 		$this->code = $code;
+		$this->reason = $reason;
 		return $this;
 	}
 
@@ -51,6 +54,12 @@ class Response implements IResponse
 	public function getCode(): int
 	{
 		return $this->code;
+	}
+
+
+	public function getReason(): ?string
+	{
+		return $this->reason;
 	}
 
 
@@ -205,6 +214,14 @@ class Response implements IResponse
 	public function sent(bool $isSent): void
 	{
 		$this->isSent = $isSent;
+	}
+
+
+	public function reset(): void
+	{
+		$this->headers = [];
+		$this->allHeaders = [];
+		$this->cookies = [];
 	}
 
 }

--- a/site/app/Test/Http/Response.php
+++ b/site/app/Test/Http/Response.php
@@ -17,7 +17,7 @@ class Response implements IResponse
 	/** @var array<string, array<int, string>> */
 	private array $allHeaders = [];
 
-	/** @var array<string, Cookie> */
+	/** @var array<string, list<Cookie>> */
 	private array $cookies = [];
 
 	public string $cookieDomain = '';
@@ -135,7 +135,7 @@ class Response implements IResponse
 	#[Override]
 	public function setCookie(string $name, string $value, $expire, string $path = null, string $domain = null, bool $secure = null, bool $httpOnly = null, string $sameSite = null): self
 	{
-		$this->cookies[$name] = new Cookie(
+		$this->cookies[$name][] = new Cookie(
 			$name,
 			$value,
 			$expire,
@@ -154,9 +154,12 @@ class Response implements IResponse
 	}
 
 
-	public function getCookie(string $name): ?Cookie
+	/**
+	 * @return list<Cookie>
+	 */
+	public function getCookie(string $name): array
 	{
-		return $this->cookies[$name] ?? null;
+		return $this->cookies[$name] ?? [];
 	}
 
 

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -29,6 +29,7 @@ services:
 	- MichalSpacekCz\DateTime\DateTimeFactory
 	- MichalSpacekCz\DateTime\DateTimeFormatter(@translation.translator::getDefaultLocale())
 	- MichalSpacekCz\DateTime\DateTimeZoneFactory
+	- MichalSpacekCz\EasterEgg\CrLfUrlInjections
 	- MichalSpacekCz\EasterEgg\FourOhFourButFound
 	- MichalSpacekCz\EasterEgg\NetteCve202015227
 	- MichalSpacekCz\EasterEgg\WinterIsComing

--- a/site/disallowed-calls.neon
+++ b/site/disallowed-calls.neon
@@ -32,6 +32,7 @@ parameters:
 				- 'MichalSpacekCz\Http\Cookies\Cookies::getString()'
 				- 'MichalSpacekCz\Http\Cookies\Cookies::set()'
 				- 'MichalSpacekCz\Http\Cookies\Cookies::deleteCookie()'
+				- 'MichalSpacekCz\EasterEgg\CrLfUrlInjections::detectAttempt()' # Bot trolling, not for humans, the cookie is always expired
 		-
 			method:
 				- 'Nette\Application\Request::getPost()'

--- a/site/tests/Application/ThemeTest.phpt
+++ b/site/tests/Application/ThemeTest.phpt
@@ -29,14 +29,14 @@ class ThemeTest extends TestCase
 	public function testSetDarkMode(): void
 	{
 		$this->theme->setDarkMode();
-		Assert::same('dark', $this->response->getCookie('future')?->getValue());
+		Assert::same('dark', $this->response->getCookie('future')[0]->getValue());
 	}
 
 
 	public function testSetLightMode(): void
 	{
 		$this->theme->setLightMode();
-		Assert::same('bright', $this->response->getCookie('future')?->getValue());
+		Assert::same('bright', $this->response->getCookie('future')[0]->getValue());
 	}
 
 

--- a/site/tests/EasterEgg/CrLfUrlInjectionsTest.phpt
+++ b/site/tests/EasterEgg/CrLfUrlInjectionsTest.phpt
@@ -1,0 +1,80 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\EasterEgg;
+
+use MichalSpacekCz\Test\Http\Request;
+use MichalSpacekCz\Test\Http\Response;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Http\IResponse;
+use Nette\Http\UrlScript;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class CrLfUrlInjectionsTest extends TestCase
+{
+
+	public function __construct(
+		private readonly CrLfUrlInjections $crLfUrlInjections,
+		private readonly Request $request,
+		private readonly Response $response,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown()
+	{
+		$this->response->reset();
+	}
+
+
+	/**
+	 * @return non-empty-list<array{0:string, 1:bool, 2:int}>
+	 */
+	public function getUrls(): array
+	{
+		return [
+			['/foo', false, 0],
+			['/foo/Set-Cookie:crlfinjection=1337', false, 0],
+			['/foo%0A', true, 0],
+			['/foo%0ASetCookie:crlfinjection=1337', true, 0],
+			['/foo%0ASet-Cookie:crlfinjection=1337', true, 1],
+			['/foo%0D', true, 0],
+			['/foo%0DSetCookie:crlfinjection=1337', true, 0],
+			['/foo%0DSet-Cookie:crlfinjection=1337', true, 1],
+			['/foo%0D%0A', true, 0],
+			['/foo%0D%0ASetCookie:crlfinjection=1337', true, 0],
+			['/foo%0D%0ASet-Cookie:crlfinjection=1337', true, 1],
+			['/foo%0D%0ASet-Cookie:PHPSESSID=1338', true, 0],
+		];
+	}
+
+
+	/** @dataProvider getUrls */
+	public function testDetectAttempt(string $path, bool $attempt, int $cookies): void
+	{
+		$this->request->setUrl((new UrlScript())->withPath(urldecode($path)));
+		if ($attempt) {
+			Assert::same($attempt, $this->crLfUrlInjections->detectAttempt());
+			Assert::same(IResponse::S204_NoContent, $this->response->getCode());
+			Assert::same('U WOT M8', $this->response->getReason());
+			Assert::count($cookies, $this->response->getCookie('crlfinjection'));
+			if ($cookies > 1) {
+				Assert::same('1337', $this->response->getCookie('crlfinjection')[0]->getValue());
+			}
+		} else {
+			Assert::false($this->crLfUrlInjections->detectAttempt());
+			Assert::same(IResponse::S200_OK, $this->response->getCode());
+			Assert::null($this->response->getReason());
+			Assert::same([], $this->response->getCookie('crlfinjection'));
+		}
+	}
+
+}
+
+TestCaseRunner::run(CrLfUrlInjectionsTest::class);


### PR DESCRIPTION
URLs like `/%0DSet-Cookie:...` would throw

> PHP Warning: Header may not contain more than a single header, new line detected in [...]Http/Response.php:98

because of the `IResponse::redirect()` call in `WebApplication::redirectToSecure()`:

https://github.com/spaze/michalspacek.cz/blob/73b82f274771460ab6252d4c0b2961a226a5423d/site/app/Application/WebApplication.php#L40

Let's detect such attempts and stop them in their tracks.