### PR TITLE
Don't use cache for the Symfony security check

### DIFF
--- a/.github/workflows/composer-vulns.yml
+++ b/.github/workflows/composer-vulns.yml
@@ -11,11 +11,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/cache@v4
-      id: cache-db
-      with:
-          path: ~/.symfony/cache
-          key: db
     - uses: symfonycorp/security-checker-action@v5
       with:
           lock: site/composer.lock


### PR DESCRIPTION
The file is created in `/tmp` but anyway, I think the cache action cannot access the file inside the Docker container.

See my comment here https://github.com/symfonycorp/security-checker-action/issues/11#issuecomment-1939390503