### PR TITLE
Update spaze/phpinfo to the re-released v1.1.0

### DIFF
--- a/site/composer.lock
+++ b/site/composer.lock
@@ -2073,12 +2073,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/phpinfo.git",
-                "reference": "e1b22185fc24264f943d9cbbd9a50b31db7d8728"
+                "reference": "5e8137dc67da697fab6463b94931805ff2a182db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/phpinfo/zipball/e1b22185fc24264f943d9cbbd9a50b31db7d8728",
-                "reference": "e1b22185fc24264f943d9cbbd9a50b31db7d8728",
+                "url": "https://api.github.com/repos/spaze/phpinfo/zipball/5e8137dc67da697fab6463b94931805ff2a182db",
+                "reference": "5e8137dc67da697fab6463b94931805ff2a182db",
                 "shasum": ""
             },
             "require": {
@@ -2117,7 +2117,7 @@
                 "issues": "https://github.com/spaze/phpinfo/issues",
                 "source": "https://github.com/spaze/phpinfo/tree/v1.1.0"
             },
-            "time": "2024-03-15T01:36:52+00:00"
+            "time": "2024-03-16T03:11:57+00:00"
         },
         {
             "name": "spaze/sri-macros",

--- a/site/vendor/composer/installed.json
+++ b/site/vendor/composer/installed.json
@@ -3699,12 +3699,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/phpinfo.git",
-                "reference": "e1b22185fc24264f943d9cbbd9a50b31db7d8728"
+                "reference": "5e8137dc67da697fab6463b94931805ff2a182db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/phpinfo/zipball/e1b22185fc24264f943d9cbbd9a50b31db7d8728",
-                "reference": "e1b22185fc24264f943d9cbbd9a50b31db7d8728",
+                "url": "https://api.github.com/repos/spaze/phpinfo/zipball/5e8137dc67da697fab6463b94931805ff2a182db",
+                "reference": "5e8137dc67da697fab6463b94931805ff2a182db",
                 "shasum": ""
             },
             "require": {
@@ -3717,7 +3717,7 @@
                 "phpstan/phpstan": "^1.9",
                 "spaze/coding-standard": "^1.3"
             },
-            "time": "2024-03-15T01:36:52+00:00",
+            "time": "2024-03-16T03:11:57+00:00",
             "type": "library",
             "installation-source": "dist",
             "autoload": {

--- a/site/vendor/composer/installed.php
+++ b/site/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '50e0516d26e3d9063aeb7c5255130191a568b324',
+        'reference' => 'fd5a76361c05157f7e853d465d3f8de212db7f0a',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -474,7 +474,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '50e0516d26e3d9063aeb7c5255130191a568b324',
+            'reference' => 'fd5a76361c05157f7e853d465d3f8de212db7f0a',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
@@ -510,7 +510,7 @@
         'spaze/phpinfo' => array(
             'pretty_version' => 'v1.1.0',
             'version' => '1.1.0.0',
-            'reference' => 'e1b22185fc24264f943d9cbbd9a50b31db7d8728',
+            'reference' => '5e8137dc67da697fab6463b94931805ff2a182db',
             'type' => 'library',
             'install_path' => __DIR__ . '/../spaze/phpinfo',
             'aliases' => array(),

--- a/site/vendor/spaze/phpinfo/src/PhpInfo.php
+++ b/site/vendor/spaze/phpinfo/src/PhpInfo.php
@@ -28,6 +28,7 @@ class PhpInfo
 		}
 		$sanitize = $this->sanitize + $sanitize;
 		foreach ($sanitize as $search => $replace) {
+			$search = (string)$search;
 			$replacements[$search] = $replace;
 			$replacements[urlencode($search)] = $replace;
 		}


### PR DESCRIPTION
To support pure numerical session ids in sanitization

Follow-up to #288 #289