### PR TITLE
Get all classes for the dependency analyzer statically

### DIFF
--- a/site/app/DependencyInjection/DiServices.php
+++ b/site/app/DependencyInjection/DiServices.php
@@ -10,8 +10,8 @@ use Nette\Neon\Neon;
 class DiServices
 {
 
-	/** @var array<non-empty-string, non-empty-lowercase-string> */
-	private array $configFiles = [
+	/** @var array<string, non-empty-lowercase-string> */
+	protected static array $configFiles = [
 		__DIR__ . '/../../config/services.neon' => 'services',
 		__DIR__ . '/../../config/extensions.neon' => 'extensions',
 	];
@@ -20,10 +20,10 @@ class DiServices
 	/**
 	 * @return list<class-string>
 	 */
-	public function getAllClasses(): array
+	public static function getAllClasses(): array
 	{
 		$allServices = [];
-		foreach ($this->configFiles as $file => $section) {
+		foreach (self::$configFiles as $file => $section) {
 			$decoded = Neon::decodeFile($file);
 			if (!is_array($decoded)) {
 				throw new DiServicesConfigInvalidException($file, null, 'not an array');
@@ -39,7 +39,7 @@ class DiServices
 				return is_string($value) || is_array($value) || $value instanceof Entity;
 			});
 			foreach ($services as $service) {
-				$classString = $this->getString($service, $file, $section);
+				$classString = self::getString($service, $file, $section);
 				if (str_starts_with($classString, '@')) {
 					continue;
 				}
@@ -57,7 +57,7 @@ class DiServices
 	/**
 	 * @param string|Entity|array<array-key, mixed> $item
 	 */
-	private function getString(string|Entity|array $item, string $file, string $section): string
+	private static function getString(string|Entity|array $item, string $file, string $section): string
 	{
 		if (is_string($item)) {
 			return $item;

--- a/site/composer-dependency-analyser.php
+++ b/site/composer-dependency-analyser.php
@@ -16,5 +16,5 @@ return (new Configuration())
 	->ignoreErrorsOnPackage('latte/latte', [ErrorType::UNUSED_DEPENDENCY])
 
 	// TestCaseRunner is used only in tests
-	->ignoreErrorsOnPackageAndPath('nette/tester', __DIR__ . '/app/Test/TestCaseRunner.php', [ErrorType::DEV_DEPENDENCY_IN_PROD]);
+	->ignoreErrorsOnPackageAndPath('nette/tester', __DIR__ . '/app/Test/TestCaseRunner.php', [ErrorType::DEV_DEPENDENCY_IN_PROD])
 ;

--- a/site/composer-dependency-analyser.php
+++ b/site/composer-dependency-analyser.php
@@ -1,17 +1,13 @@
 <?php
 declare(strict_types = 1);
 
-use MichalSpacekCz\Application\Bootstrap;
-use MichalSpacekCz\Application\Cli\NoCliArgs;
 use MichalSpacekCz\DependencyInjection\DiServices;
 use ShipMonk\ComposerDependencyAnalyser\Config\Configuration;
 use ShipMonk\ComposerDependencyAnalyser\Config\ErrorType;
 
-$allClasses = Bootstrap::bootCli(NoCliArgs::class)->getByType(DiServices::class)->getAllClasses();
-
 return (new Configuration())
 	// Add classes from services.neon and extensions.neon
-	->addForceUsedSymbols($allClasses)
+	->addForceUsedSymbols(DiServices::getAllClasses())
 
 	// Attributes used for development only
 	->ignoreErrorsOnPackage('jetbrains/phpstorm-attributes', [ErrorType::DEV_DEPENDENCY_IN_PROD])

--- a/site/config/services.neon
+++ b/site/config/services.neon
@@ -34,7 +34,6 @@ services:
 	- MichalSpacekCz\DateTime\DateTimeFactory
 	- MichalSpacekCz\DateTime\DateTimeFormatter(@translation.translator::getDefaultLocale())
 	- MichalSpacekCz\DateTime\DateTimeZoneFactory
-	- MichalSpacekCz\DependencyInjection\DiServices
 	- MichalSpacekCz\EasterEgg\CrLfUrlInjections
 	- MichalSpacekCz\EasterEgg\FourOhFourButFound
 	- MichalSpacekCz\EasterEgg\NetteCve202015227

--- a/site/tests/DependencyInjection/DiServicesTest.phpt
+++ b/site/tests/DependencyInjection/DiServicesTest.phpt
@@ -4,7 +4,6 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\DependencyInjection;
 
 use MichalSpacekCz\DependencyInjection\Exceptions\DiServicesConfigInvalidException;
-use MichalSpacekCz\Test\PrivateProperty;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\FileMock;
@@ -16,16 +15,10 @@ require __DIR__ . '/../bootstrap.php';
 class DiServicesTest extends TestCase
 {
 
-	public function __construct(
-		private readonly DiServices $diServices,
-	) {
-	}
-
-
 	public function testGetAllServices(): void
 	{
 		Assert::noError(function (): void {
-			$this->diServices->getAllClasses();
+			DiServices::getAllClasses();
 		});
 	}
 
@@ -71,17 +64,25 @@ class DiServicesTest extends TestCase
 	/** @dataProvider getConfigFile */
 	public function testGetAllServicesNotClassStrings(string $config, ?string $exceptionMessage): void
 	{
-		$diServices = clone $this->diServices;
-
 		$configFile = FileMock::create($config, 'neon');
-		PrivateProperty::setValue($diServices, 'configFiles', [$configFile => 'bar']);
+		$diServices = new class ([$configFile => 'bar']) extends DiServices {
+
+			/**
+			 * @param array<string, non-empty-lowercase-string> $configFiles
+			 */
+			public function __construct(array $configFiles)
+			{
+				self::$configFiles = $configFiles;
+			}
+
+		};
 		if ($exceptionMessage === null) {
 			Assert::noError(function () use ($diServices): void {
-				$diServices->getAllClasses();
+				$diServices::getAllClasses();
 			});
 		} else {
 			Assert::exception(function () use ($diServices): void {
-				$diServices->getAllClasses();
+				$diServices::getAllClasses();
 			}, DiServicesConfigInvalidException::class, "{$configFile}{$exceptionMessage}");
 		}
 //		Assert::fail('e');

--- a/site/tests/DependencyInjection/DiServicesTest.phpt
+++ b/site/tests/DependencyInjection/DiServicesTest.phpt
@@ -85,7 +85,6 @@ class DiServicesTest extends TestCase
 				$diServices::getAllClasses();
 			}, DiServicesConfigInvalidException::class, "{$configFile}{$exceptionMessage}");
 		}
-//		Assert::fail('e');
 	}
 
 }


### PR DESCRIPTION
Otherwise if the service is created by the DI container, the analyzer logs "headers already sent" because it echoes that it's using the config file, and then in the config file, the DI container would try to set the `zlib.output_compression` to yes when created, which emits a header, or tries to in CLI, which generates the error.

Follow-up to #286