### PR TITLE
Add hash of CSS added by netteForms.js to style the dialog element with form errors

### DIFF
--- a/site/config/contentsecuritypolicy.neon
+++ b/site/config/contentsecuritypolicy.neon
@@ -24,6 +24,7 @@ contentSecurityPolicy:
 				- "'report-sample'"
 			style-src:
 				- "'nonce'"
+				- "'sha256-I7m+VqBh+S5t75VVGkOHq12SfWTlXYaAeJSSaMfaqkc='"
 				- %domain.contentSecurityPolicySelf%
 				- "'report-sample'"
 			frame-ancestors: "'none'"


### PR DESCRIPTION
This doesn't seem to change much, and even if it would, it would still be the same as not having the hash here.

The CSS added here: https://github.com/nette/forms/blob/ec3c6598b9f27e8787961f2b02e12a477994bf3b/src/assets/netteForms.js#L319C22-L319C161