### PR TITLE
Revert "loading" caption on blog preview error

### DIFF
--- a/site/app/Form/PostFormFactory.php
+++ b/site/app/Form/PostFormFactory.php
@@ -125,8 +125,10 @@ readonly class PostFormFactory
 		$form->addCheckbox('omitExports', 'Vynechat z RSS');
 
 		$submitButton = $form->addSubmit('submit', 'Přidat');
-		$form->addSubmit('preview', $this->translator->translate('messages.label.preview'))
+		$caption = $this->translator->translate('messages.label.preview');
+		$form->addSubmit('preview', $caption)
 			->setHtmlAttribute('data-loading-value', 'Moment…')
+			->setHtmlAttribute('data-original-value', $caption)
 			->onClick[] = function () use ($form, $post, $template, $sendTemplate): void {
 				$newPost = $this->buildPost($form->getFormValues(), $post?->getId());
 				$this->blogPostPreview->sendPreview($newPost, $template, $sendTemplate);

--- a/site/public/www.michalspacek.cz/i/js/admin.js
+++ b/site/public/www.michalspacek.cz/i/js/admin.js
@@ -323,6 +323,14 @@ App.ready(document, function () {
 			button.value = button.dataset.originalValue;
 		};
 		App.onLoad('#preview-frame', resetCaption);
+		const observer = new MutationObserver(function(){
+			if (document.getElementsByClassName('netteFormsModal').length !== 0){
+				resetCaption();
+			}
+		});
+		observer.observe(document.body, {
+			childList: true,
+		});
 		setTimeout(resetCaption, 5000);
 	});
 });

--- a/site/public/www.michalspacek.cz/i/js/admin.js
+++ b/site/public/www.michalspacek.cz/i/js/admin.js
@@ -318,10 +318,11 @@ App.ready(document, function () {
 	App.onClick('#preview-button', function () {
 		document.querySelector('#preview').classList.remove('hidden');
 		const button = this;
-		const originalValue = button.value;
 		button.value = button.dataset.loadingValue;
-		App.onLoad('#preview-frame', function () {
-			button.value = originalValue;
-		});
+		const resetCaption = function () {
+			button.value = button.dataset.originalValue;
+		};
+		App.onLoad('#preview-frame', resetCaption);
+		setTimeout(resetCaption, 5000);
 	});
 });


### PR DESCRIPTION
The Nette JS validation is triggered on form submit but at that moment, the button caption is already changed to "loading" by the click event handler. But because the preview frame never loads then, the "loading" caption would stay.

So we'll observe any child list changes of the BODY element and see if there's a form validation DIALOG element, and if yes, revert the caption.

Also revert it after 5 secs, just in case.