### PR TITLE
Tell Dependabot to vendor dependencies when updating them

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,5 +22,6 @@ updates:
 
   - package-ecosystem: "composer"
     directory: "/site"
+    vendor: true
     schedule:
       interval: "daily"


### PR DESCRIPTION
Hopefully it does what it says on the tin, and that's also updating the files in the vendor folder.

Dependabot composer updates config added in #315