### PR TITLE
CodeQL reports a rest element but that's a spread syntax in the `dumper.js` file

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -68,6 +68,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
+          config: |
+            paths-ignore:
+              - site/vendor/tracy/tracy/src/Tracy/Dumper/assets/dumper.js
           # If you wish to specify custom queries, you can do so here or in a config file.
           # By default, queries listed here will override any specified in a config file.
           # Prefix the list here with "+" to use these queries and those in the config file.


### PR DESCRIPTION
> * site/vendor/tracy/tracy/src/Tracy/Dumper/assets/dumper.js#L354C86:86: A parse error occurred: `Comma is not permitted after the rest element`. Check the syntax of the file. If the file is invalid, correct the error or [exclude](https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/customizing-code-scanning) the file from analysis.

https://github.com/spaze/michalspacek.cz/actions/runs/8996895829/job/24714088773#step:5:918

CodeQL config added in #311