### PR TITLE
Run Dependabot updates monthly for NPM and Composer, as a last resort 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,6 @@ updates:
 
   - package-ecosystem: "composer"
     directory: "/site"
-    vendor: true
     schedule:
       interval: "daily"
     allow:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,22 +8,22 @@ updates:
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
-      interval: "daily"
+      interval: "monthly"
 
   - package-ecosystem: "npm"
     directory: "/site/vendor/nette/forms"
     schedule:
-      interval: "daily"
+      interval: "monthly"
 
   - package-ecosystem: "npm"
     directory: "/site/vendor/tracy/tracy"
     schedule:
-      interval: "daily"
+      interval: "monthly"
 
   - package-ecosystem: "composer"
     directory: "/site"
     schedule:
-      interval: "daily"
+      interval: "monthly"
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"


### PR DESCRIPTION
Revert "Tell Dependabot to vendor dependencies when updating them" 

It doesn't seem to do what I thought it would do, at least for Composer, it doesn't actually download the changed files.

This reverts commit cf3d5dc #318

I check NPM and Composer usually manually (`npm outdated`, `composer outdated`), often weekly, sometimes more often.

Keep GitHub actions weekly, as that I don't check manually because I don't if that's even possible.