### PR TITLE
Don't cache blog post previews

### DIFF
--- a/site/app/Articles/Articles.php
+++ b/site/app/Articles/Articles.php
@@ -287,17 +287,16 @@ class Articles
 	}
 
 
-	public function buildArticle(Row $row): ArticlePublishedElsewhere
+	private function buildArticle(Row $row): ArticlePublishedElsewhere
 	{
-		$texy = $this->texyFormatter->getTexy();
 		$this->texyFormatter->setTopHeading(2);
 		return new ArticlePublishedElsewhere(
 			$row->id,
-			$this->texyFormatter->format($row->titleTexy, $texy),
+			$this->texyFormatter->format($row->titleTexy),
 			$row->titleTexy,
 			$row->href,
 			$row->published,
-			$this->texyFormatter->format($row->leadTexy, $texy),
+			$this->texyFormatter->format($row->leadTexy),
 			$row->leadTexy,
 			$row->sourceName,
 			$row->sourceHref,

--- a/site/app/Articles/Blog/BlogPostFactory.php
+++ b/site/app/Articles/Blog/BlogPostFactory.php
@@ -71,6 +71,8 @@ readonly class BlogPostFactory
 		bool $omitExports,
 	): BlogPost {
 		$texy = $this->texyFormatter->getTexy();
+		$texyFormatter = $this->texyFormatter->withTexy($texy);
+
 		if ($allowedTagsGroups) {
 			$allowedTags = [];
 			foreach ($allowedTagsGroups as $allowedTagsGroup) {
@@ -78,7 +80,7 @@ readonly class BlogPostFactory
 			}
 			$texy->allowedTags = $allowedTags;
 		}
-		$this->texyFormatter->setTopHeading(2);
+		$texyFormatter->setTopHeading(2);
 
 		$needsPreviewKey = $published === null || $published > new DateTime();
 		return new BlogPost(
@@ -87,16 +89,16 @@ readonly class BlogPostFactory
 			$localeId,
 			$locale,
 			$translationGroupId,
-			$this->texyFormatter->format($titleTexy, $texy),
+			$texyFormatter->format($titleTexy),
 			$titleTexy,
-			$leadTexy !== null ? $this->texyFormatter->formatBlock($leadTexy, $texy) : null,
+			$leadTexy !== null ? $texyFormatter->formatBlock($leadTexy) : null,
 			$leadTexy,
-			$this->texyFormatter->formatBlock($textTexy, $texy),
+			$texyFormatter->formatBlock($textTexy),
 			$textTexy,
 			$published,
 			$needsPreviewKey,
 			$previewKey,
-			$originallyTexy !== null ? $this->texyFormatter->formatBlock($originallyTexy, $texy) : null,
+			$originallyTexy !== null ? $texyFormatter->formatBlock($originallyTexy) : null,
 			$originallyTexy,
 			$ogImage,
 			$tags,

--- a/site/app/Articles/Blog/BlogPostPreview.php
+++ b/site/app/Articles/Blog/BlogPostPreview.php
@@ -21,11 +21,13 @@ readonly class BlogPostPreview
 
 
 	/**
+	 * @param callable(): BlogPost $createPost
 	 * @param callable(?DefaultTemplate): void $sendTemplate
 	 */
-	public function sendPreview(BlogPost $post, DefaultTemplate $template, callable $sendTemplate): void
+	public function sendPreview(callable $createPost, DefaultTemplate $template, callable $sendTemplate): void
 	{
 		$this->texyFormatter->disableCache();
+		$post = $createPost();
 		$template->setFile(__DIR__ . '/../../Www/Presenters/templates/Post/default.latte');
 		$template->post = $post;
 		$template->edits = $post->hasId() ? $post->getEdits() : [];

--- a/site/app/Formatter/TexyFormatter.php
+++ b/site/app/Formatter/TexyFormatter.php
@@ -146,9 +146,9 @@ class TexyFormatter
 	 *
 	 * Suitable for "inline" strings like headers.
 	 */
-	public function format(string $text, ?Texy $texy = null): Html
+	public function format(string $text): Html
 	{
-		$texy = $texy ?? $this->getTexy();
+		$texy = $this->texy ?? $this->getTexy();
 		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
 			return Strings::replace($texy->process($text), '~^\s*<p[^>]*>(.*)</p>\s*$~s', '$1');
 		});
@@ -158,9 +158,9 @@ class TexyFormatter
 	/**
 	 * Format string.
 	 */
-	public function formatBlock(string $text, ?Texy $texy = null): Html
+	public function formatBlock(string $text): Html
 	{
-		$texy = $texy ?? $this->getTexy();
+		$texy = $this->texy ?? $this->getTexy();
 		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
 			return $texy->process($text);
 		});
@@ -211,6 +211,14 @@ class TexyFormatter
 	{
 		$this->cacheResult = false;
 		return $this;
+	}
+
+
+	public function withTexy(Texy $texy): self
+	{
+		$texyFormatter = clone $this;
+		$texyFormatter->texy = $texy;
+		return $texyFormatter;
 	}
 
 }

--- a/site/app/Formatter/TexyFormatter.php
+++ b/site/app/Formatter/TexyFormatter.php
@@ -16,6 +16,8 @@ use Texy\Texy;
 class TexyFormatter
 {
 
+	private const string CACHE_KEY_DELIMITER = '|';
+
 	private ?Texy $texy = null;
 
 	private bool $cacheResult = true;
@@ -146,8 +148,9 @@ class TexyFormatter
 	 */
 	public function format(string $text, ?Texy $texy = null): Html
 	{
-		return $this->replace("{$text}|" . __FUNCTION__, function () use ($text, $texy): string {
-			return Strings::replace(($texy ?? $this->getTexy())->process($text), '~^\s*<p[^>]*>(.*)</p>\s*$~s', '$1');
+		$texy = $texy ?? $this->getTexy();
+		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
+			return Strings::replace($texy->process($text), '~^\s*<p[^>]*>(.*)</p>\s*$~s', '$1');
 		});
 	}
 
@@ -157,8 +160,9 @@ class TexyFormatter
 	 */
 	public function formatBlock(string $text, ?Texy $texy = null): Html
 	{
-		return $this->replace("{$text}|" . __FUNCTION__, function () use ($text, $texy): string {
-			return ($texy ?? $this->getTexy())->process($text);
+		$texy = $texy ?? $this->getTexy();
+		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
+			return $texy->process($text);
 		});
 	}
 
@@ -166,10 +170,10 @@ class TexyFormatter
 	/**
 	 * @param callable(): string $callback
 	 */
-	private function replace(string $key, callable $callback): Html
+	private function replace(string $key, Texy $texy, callable $callback): Html
 	{
 		if ($this->cacheResult) {
-			$result = $this->cache->get($this->getCacheKey($key), function (ItemInterface $item, bool &$save) use ($callback): string {
+			$result = $this->cache->get($this->getCacheKey($key, $texy), function (ItemInterface $item, bool &$save) use ($callback): string {
 				$item->expiresAt(null);
 				$save = true;
 				return $callback();
@@ -194,11 +198,12 @@ class TexyFormatter
 	}
 
 
-	public function getCacheKey(string $text): string
+	public function getCacheKey(string $text, Texy $texy): string
 	{
+		$key = "{$text}|" . serialize($texy->allowedTags);
 		// Make the key shorter because Symfony Cache stores it in comments in cache files
 		// Don't hash the locale to make it visible inside cache files
-		return Hash::nonCryptographic($text) . '.' . $this->translator->getDefaultLocale();
+		return Hash::nonCryptographic($key) . '.' . $this->translator->getDefaultLocale();
 	}
 
 

--- a/site/tests/Articles/ArticlesTest.phpt
+++ b/site/tests/Articles/ArticlesTest.phpt
@@ -64,7 +64,7 @@ class ArticlesTest extends TestCase
 				'slug' => null,
 				'href' => 'https://example.com/article-1',
 				'published' => new DateTime('3 years ago'),
-				'leadTexy' => 'Excerpt 1',
+				'leadTexy' => "Excerpt 1\n#########\nFoo",
 				'textTexy' => null,
 				'sourceName' => 'Source 1',
 				'sourceHref' => 'https://source1.example/',
@@ -155,6 +155,7 @@ class ArticlesTest extends TestCase
 		$this->database->addFetchAllResult($fetchResult);
 		$articles = $this->articles->getAll();
 		Assert::type(ArticlePublishedElsewhere::class, $articles[0]);
+		Assert::same("<h2 id=\"excerpt-1\">Excerpt 1</h2>\n\n<p>Foo</p>\n", $articles[0]->getSummary()?->render());
 		Assert::type(BlogPost::class, $articles[1]);
 		Assert::type(ArticlePublishedElsewhere::class, $articles[2]);
 		Assert::type(BlogPost::class, $articles[3]);

--- a/site/tests/Articles/Blog/BlogPostPreviewTest.phpt
+++ b/site/tests/Articles/Blog/BlogPostPreviewTest.phpt
@@ -73,9 +73,15 @@ class BlogPostPreviewTest extends TestCase
 		$template = $this->templateFactory->createTemplate($presenter);
 		$rendered = '';
 		Assert::noError(function () use ($post, $template, &$rendered): void {
-			$this->blogPostPreview->sendPreview($post, $template, function (?DefaultTemplate $template) use (&$rendered): void {
-				$rendered = $template?->renderToString() ?? '';
-			});
+			$this->blogPostPreview->sendPreview(
+				function () use ($post): BlogPost {
+					return $post;
+				},
+				$template,
+				function (?DefaultTemplate $template) use (&$rendered): void {
+					$rendered = $template?->renderToString() ?? '';
+				},
+			);
 		});
 		Assert::contains('<p>Text <strong>something</strong></p>', $rendered);
 	}

--- a/site/tests/Formatter/TexyFormatterTest.phpt
+++ b/site/tests/Formatter/TexyFormatterTest.phpt
@@ -128,7 +128,7 @@ class TexyFormatterTest extends TestCase
 		$text = '**anoff**';
 		$expected = '<strong>anoff</strong>';
 
-		$key = $this->texyFormatter->getCacheKey("{$text}|format");
+		$key = $this->texyFormatter->getCacheKey("{$text}|format", $this->texyFormatter->getTexy());
 		Assert::same($expected, $this->texyFormatter->format($text)->toHtml());
 		Assert::true($this->cacheInterface->getItem($key)->isHit());
 


### PR DESCRIPTION
It's been cached when the `BlogPost` object was created before it was sent to `sendPreview()` (where caching was disabled a little bit too late), and also in `onValidate` where we still want the data to be validated (so can't call `setValidationScope([])`). The original `BlogPost` object is still cached in `actionEdit()`, but that's the original one. not the previewed one.