### PR TITLE
Correct spaze/sri-macros concatenations

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -76,6 +76,12 @@ jobs:
         php-version: ${{ matrix.php-version }}
     - run: make --directory=site check-application-mapping
 
+  check-sri-macros-concat:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+    - run: make --directory=site check-sri-macros-concat
+
   lint-php:
     runs-on: ubuntu-latest
     strategy:

--- a/site/Makefile
+++ b/site/Makefile
@@ -1,6 +1,6 @@
-.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-application-mapping lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester tester-include-skipped gitleaks composer-dependency-analyser
+.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-application-mapping check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester tester-include-skipped gitleaks composer-dependency-analyser
 
-test: composer-audit npm-audit check-file-patterns check-makefile check-application-mapping lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
+test: composer-audit npm-audit check-file-patterns check-makefile check-application-mapping check-sri-macros-concat lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
 composer-audit:
 	composer audit
@@ -19,6 +19,9 @@ check-makefile:
 
 check-application-mapping:
 	bin/check-application-mapping.php
+
+check-sri-macros-concat:
+	bin/check-sri-macros-concat.sh
 
 lint-php:
 	vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors -e php,phtml,phpt,phpstub app/ public/ stubs/ tests/

--- a/site/app/Admin/Presenters/templates/@layout.latte
+++ b/site/app/Admin/Presenters/templates/@layout.latte
@@ -4,6 +4,6 @@
 {var $robots = 'noindex, nofollow'}
 {define #feeds}{/define}
 {define #scriptsReplace}
-{script app+admin async, defer}
+{script app + admin async, defer}
 {script netteForms async, defer}
 {/define}

--- a/site/app/Pulse/Presenters/templates/@layout.latte
+++ b/site/app/Pulse/Presenters/templates/@layout.latte
@@ -6,8 +6,8 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>{if isset($pageTitle)}{$pageTitle} | {/if}Pulse</title>
 	{control criticalCss}
-	{styleSheet screen-pulse+rating}
-	{script app+pulse async, defer}
+	{styleSheet screen-pulse + rating}
+	{script app + pulse async, defer}
 	{script remove-fbclid async, defer}
 	{ifset #metas}{include #metas}{/ifset}
 	{ifset $canonicalLink}

--- a/site/app/UpcKeys/Presenters/templates/Homepage/default.latte
+++ b/site/app/UpcKeys/Presenters/templates/Homepage/default.latte
@@ -6,7 +6,7 @@
 	<meta name="viewport" content="width=device-width, initial-scale=1">
 	<title>UPC Wi-Fi Keys{if isset($ssid)} for {$ssid}{/if}</title>
 	{styleSheet screen-upc}
-	{script app+upckeys async, defer}
+	{script app + upckeys async, defer}
 	{script remove-fbclid async, defer}
 	<meta property="og:image" content="{='upc/screenshot.jpg'|staticImageUrl}">
 	<meta property="og:title" content="UPC Wi-Fi Keys{if isset($ssid)} for {$ssid}{/if}">

--- a/site/app/Www/Presenters/templates/@layout.latte
+++ b/site/app/Www/Presenters/templates/@layout.latte
@@ -13,9 +13,9 @@
 	<title>{if isset($pageTitle)}{$pageTitle} | {/if}Michal Špaček</title>
 	{control criticalCss}
 	{if $darkMode === null}
-		{styleSheet screen-main+'@media (prefers-color-scheme: dark) {'+screen-main-dark+'}'}
+		{styleSheet screen-main + '@media (prefers-color-scheme: dark) {' + screen-main-dark + '}'}
 	{elseif $darkMode}
-		{styleSheet screen-main+screen-main-dark}
+		{styleSheet screen-main + screen-main-dark}
 	{else}
 		{styleSheet screen-main}
 	{/if}
@@ -23,7 +23,7 @@
 	{ifset #scriptsReplace}
 		{include #scriptsReplace}
 	{else}
-		{script app+scripts async, defer}
+		{script app + scripts async, defer}
 		{script netteForms async, defer}
 		{script remove-fbclid async, defer}
 	{/ifset}

--- a/site/app/Www/Presenters/templates/Pgp/default.latte
+++ b/site/app/Www/Presenters/templates/Pgp/default.latte
@@ -32,5 +32,5 @@
 {/define}
 
 {define #footerScripts}
-	{script openpgp+encryption id => "encryption-js"}
+	{script openpgp + encryption id => "encryption-js"}
 {/define}

--- a/site/bin/check-sri-macros-concat.sh
+++ b/site/bin/check-sri-macros-concat.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+echo "Wrong spaze/sri-macros concatenations (without spaces, e.g. {script foo+bar}):"
+
+BAD_LINES=$(grep --recursive --perl-regexp --ignore-case --line-number "{(script|stylesheet)" app/ | grep --perl-regexp "[^\s]\+|\+[^\s]")
+if [ "$BAD_LINES" ]; then
+	echo "$BAD_LINES" | grep --color ".+."
+	exit 1
+else
+	echo "None, all have spaces around the plus sign (foo + bar, not foo+bar)"
+	exit 0
+fi


### PR DESCRIPTION
Check and make sure that spaze/sri-macros concatenated resources (e.g. `{script foo + bar}`) use spaces around the plus sign.

This is needed because in [Latte 3.0.17](https://github.com/nette/latte/releases/tag/v3.0.17), unquoted strings can contain `+` but if it's specified as ` + `, with spaces, then the previous behavior works too.

I've added tests in spaze/sri-macros#26, otherwise no change wasn't needed in that package.

Follow-up to #365