### PR TITLE
RSS/Atom exports can also be requested cross-site

### DIFF
--- a/site/app/Www/Presenters/ExportsPresenter.php
+++ b/site/app/Www/Presenters/ExportsPresenter.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Www\Presenters;
 
 use MichalSpacekCz\Feed\Exports;
+use MichalSpacekCz\Http\FetchMetadata\ResourceIsolationPolicyCrossSite;
 use MichalSpacekCz\Utils\Hash;
 use Spaze\Exports\Bridges\Nette\Atom\Response;
 
@@ -17,6 +18,7 @@ class ExportsPresenter extends BasePresenter
 	}
 
 
+	#[ResourceIsolationPolicyCrossSite]
 	public function actionArticles(?string $param = null): never
 	{
 		$feed = $this->exports->getArticles($this->link('//this'), $param);


### PR DESCRIPTION
Some RSS readers also send `Sec-Fetch-*` headers, I think Thunderbird is one of them.

Follow-up to #371