### PR TITLE
Update the `Expires` date in security.txt files

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-application-mapping check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester tester-include-skipped gitleaks composer-dependency-analyser
+.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-application-mapping check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-latte-templates phpstan-vendor psalm tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt
 
 test: composer-audit npm-audit check-file-patterns check-makefile check-application-mapping check-sri-macros-concat lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
@@ -65,3 +65,6 @@ gitleaks:
 
 composer-dependency-analyser:
 	vendor/bin/composer-dependency-analyser --verbose
+
+update-security-txt:
+	bin/update-security.txt.sh

--- a/app/bin/colors.sh
+++ b/app/bin/colors.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+COLOR_LIGHT_GRAY=$(tput setaf 7)
+COLOR_GREEN=$(tput setaf 2)
+COLOR_DARKER_GREEN=$(tput setaf 22)  # will only work with TERM=xterm-256color
+COLOR_RED=$(tput setaf 9)
+COLOR_NORMAL=$(tput sgr0)

--- a/app/bin/update-security.txt.sh
+++ b/app/bin/update-security.txt.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+source "$(dirname "$0")/colors.sh"
+
+# The new date is less than a year/365 days into the future because the spec says that it is recommended that the value be less
+# than a year https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5-1 so this would generate a warning if it would be more,
+# and when running my security.txt checker in strict mode, the warning would turn into an error.
+NEW_EXPIRES=$(php -r "echo (new DateTime('first day of this month +1 year midnight UTC'))->format(DATE_RFC3339);")
+
+function update() {
+	echo "[${COLOR_LIGHT_GRAY}Updating${COLOR_NORMAL}] $1"
+	if ! [ -f "$1" ]; then
+		echo "[${COLOR_RED}Error${COLOR_NORMAL}] $1 doesn't exist"
+		return
+	fi
+	UPDATED_NAME=$1-updated
+	SIGNED_NAME=$UPDATED_NAME-signed
+
+	# Update the date and remove the PGP headers and signature
+	sed "s/Expires: .*/Expires: $NEW_EXPIRES/" "$1" | head --lines=-16 | tail --lines=+4 > "$UPDATED_NAME"
+	echo "[${COLOR_GREEN}Updated${COLOR_NORMAL}] Expires in $1 updated to $NEW_EXPIRES"
+
+	gpg --clear-sign --output "$SIGNED_NAME" "$UPDATED_NAME"
+	mv "$SIGNED_NAME" "$1"
+	rm "$UPDATED_NAME"
+	echo "[${COLOR_GREEN}Signed${COLOR_NORMAL}] $1"
+}
+
+APP_DIR="$(dirname "$0")/.."
+update "$APP_DIR/public/upcwifikeys.com/.well-known/security.txt"
+update "$APP_DIR/public/www.michalspacek.com/.well-known/security.txt"
+update "$APP_DIR/public/www.michalspacek.cz/.well-known/security.txt"

--- a/app/public/upcwifikeys.com/.well-known/security.txt
+++ b/app/public/upcwifikeys.com/.well-known/security.txt
@@ -16,22 +16,22 @@ Contact: https://m.me/spaze
 Encryption: https://www.michalspacek.cz/key.asc
 Canonical: https://upcwifikeys.com/.well-known/security.txt
 Preferred-Languages: en, cs
-Expires: 2024-11-01T00:00:00+00:00
+Expires: 2025-10-01T00:00:00+00:00
 Rick: <img/src=//xss.sk>
 Rolling: <script/src=//xss.sk></script>
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmVdLJcACgkQtkvdbkZK
-tSnY9RAAkPS2j2MldI8mMIAW6D/92p0+SdmdhmaEDVMlepyBWVyntoT1xF6WVq+P
-3dorQDK5yOqfaoSo5RBD3mqd4rYTgjgqGSFbTrPgeKZ/M6VKMfITkm9MXV00UjuT
-sXQ0buRZVOOehtj2yBt8T1Asu5rqIzv4SIt1SbusfxOuP4OYr91C9Y5bN1hrL/7Z
-FuzSgbZu/Ta3olWYj/YmV4ZxqVAfRMD8pbaFz0A+l+OTrI+wH6vcJkkcg3ex51sN
-H++zl6ziFHClRhZi0O0YxRORC66K1VvTb8n0XYMX1qXrqTuDQ2DW2hLEaNNYBkd/
-AQDBfI0uRA3aTknov+NYOCgx3e2N5MZScWVbv8sNrjYU6eA7hLCREbM0qsYyaE4D
-j/OfLohWg3LpJ8+CVevyBaKz5CA51pERs0P9Y0qKRyEk9A2x0Rl46NonXs6CwDqr
-9bZJQeh+HlIQO5pP07WjRPeHPbRp1oJe3VNPV14dt171vPKaU3rnczjwJKmyjWlB
-qfN4fM2zJUnutzic452GRUibmnBr7XSLQFW47s8OfdgQSBJ7Kq0Ghz5uhyEbgRRC
-kDPGqDD64d5AOFBnqv+4iOEu3ZhBmWMuagshEc0BB6Imi1yM7E+ZZav9mlBipi/Y
-SK1gTeKbX2JPju5Zd3dnwrGjipsUHtLU0THR/RvkMXW/sJiKRZI=
-=GOqs
+iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmcb2nYACgkQtkvdbkZK
+tSkzJA/5ARYn6uOAod2CiFTdonoXEgEg9PIE3vO7xem9sDsuNNHKbkYDPKw5E2H/
+8g5CQBS6M6TEqi9LktItuAFGEcA6hjmg4eYV6YetEZZ6Owy0FPc+JBJES/eLjAHz
+XOnTSgUu9KAyeyAkBuNfgaJ0NO5axupQhIc1X4rmnTzKO9kBbv1k3cK3gOcZj9rk
+KeXPIH6hKb/C9JBrcYlL3i5QBaUkgf4A4gLlacUC3X+yYnmOiOb0PRQ9U4ToQWFu
+Z/b6UNChzc+OAaCBYwQUM8hk/u2P9Z6URatgD89FNxUZ1sdTDbcZBWw6QsnjBRg6
+fsuaT9x79g/WszyUUaNdE5tGN8+X6kj29SNb/UkqLyOY4MurmCQiQQ6lkFBUgxSn
+hWKMPkaXxQhppUmkDI8BUOiVFf7wyMpJUBrLH3lcg+19BbmA1ZeM9qrbcaZ3c2nw
+mLTuCYGtQxr2pGNQ/kXz/J/Zl/R3DrRuB9xEe4hnqvQixYPfg+gx3jMIB9SE7K5g
+3tRJCgB27rJycGJ4xvW7gzXFZzouo/AV5bfjCZVyehmDJCO9ybhlD+A3H/s3//Dn
+pSGikOvG2C9dIBsN4zmOnycBk7C5ZAe0/4FRcmRg5dW1KO7kSf6GSgj7qMRl5g93
+O00LiV25ZjsPAVxCpO5KxPQuysz78TcPV3llMZW8iOg+rY+OaFk=
+=XQUN
 -----END PGP SIGNATURE-----

--- a/app/public/www.michalspacek.com/.well-known/security.txt
+++ b/app/public/www.michalspacek.com/.well-known/security.txt
@@ -16,22 +16,22 @@ Contact: https://m.me/spaze
 Encryption: https://www.michalspacek.cz/key.asc
 Canonical: https://www.michalspacek.com/.well-known/security.txt
 Preferred-Languages: en, cs
-Expires: 2024-11-01T00:00:00+00:00
+Expires: 2025-10-01T00:00:00+00:00
 Rick: <img/src=//xss.sk>
 Rolling: <script/src=//xss.sk></script>
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmVdLHwACgkQtkvdbkZK
-tSkiYA/9GCS0XB4cIJSBbRwnHkbg5KS1iyeqvZ8BXjWQSNZc/rIOfi9H/TuVae0J
-lLu9bdqRmWRvdFiMS2lXfOLloAzJ4UB8cYNNGf4+8HIXL6kHxaU5i0v0bl6Fahtb
-hFvZeEnGPtLv0ptf6CrUbl0PcUTiRtroq/GaxHylYQvtW/vFOWGQccMwDSNvm+is
-GR7xuMClxQhV31lVXtpzY0VkiRNeYdP3/Gpz581gTdFyezmr15D+MFOhLjQTVh2R
-bKHq7cXXvjXKAZJoEkyf2R5TBiSxMnNx/rVk1HdQEm8gqSwOfsEQUyW/IjZRAwSv
-0/ONEhXAyfyrzl7JK1GFL0jhi9ybZ0wWPfKADlGylxbOgb5UTUAHMj6Wxea8ZJxR
-Us6crHDQHeWlLfWdBJaHBM1b45Fl80o4oQWxHcfv/K/s1isrfoMWfpOSZMHBWUnZ
-5pJTfqTGH2mgTg0yzfS7nVkIhiEZf06tmKKgSyHyak7AVQXlzuqSvydqg9dcrHir
-HWnrXPFJswkpBnzbx1mwUcFZ8cDcx1yttGP5/QlEpcdMnPOIdu6oG+nw61HqDKm4
-M9tVDUe2vwGNSDSBu2i/ctjzHjxn1jTI3oeBwyqRJCCjgyZ4RlUluHwho+ZN5CEs
-mUGXPH6V7DK/E38mIMVYdTs4aeizQ2QRAdcnn2F2UxkKtMXTdrQ=
-=X1gU
+iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmcb2n4ACgkQtkvdbkZK
+tSkmYQ/+JokENGizYrDc/jQjblSCJo4ZsAToYkBGSKknW6Wrjx1SpRvA4Yt9SKk7
+kN00Qs5o+tQ8tMir79xF6YbcLG9rYQCmbLQvI2i/BUHiy//zscjqDe9dHl/fYium
+aldaK3E0kimdJV8bcKvz/+NQLiATx2DNaugm0Ymj3ApXRZyaX6qFo0nw+Lkx7vyO
+67VvN9t4qebjBHFT10N+AMbd2AIwERHw4jRBy8NG81avhqVtPNINEEjbuWxuFIfv
+jLCWjn7AgFrEsabR9umfyqRz1vWiIMLUh64vNCGaJU3SlxmS5aDu3mOEtTLPakxM
+EG+PRZbhHqYz8N6JsSt3csyVfyuyXr8H/9h7lYVX5yRtPngtmv0vcu+8Z+eoonHP
+POEp+SgMV9/MKprdPt29Kt7sB75imWytuqvQiNaMExQPu20lFemfNacEX3gIng1d
+sTieTLuVnSgybk1ARIXucTSnrjE1U5JEddFRaUsE2Yqp410jLusKSw32S382FdIL
+jEGigWTK/A1YUpQ6T774Xp4+oPwyqBxqxaub4RUFvSpTMwGgTa6Pd3FqJvtxJkbL
+oDTikEGca+PbcFcBY5KDZtrZFKEqGu+vtlDOSh/XDXpi/3glhEKkwkFnCoLHZkTp
+eue+9CMJEJPg6AP+yiwrKGy9Mahe1aXVfntNWQw0drWl0z+qVIE=
+=BRRd
 -----END PGP SIGNATURE-----

--- a/app/public/www.michalspacek.cz/.well-known/security.txt
+++ b/app/public/www.michalspacek.cz/.well-known/security.txt
@@ -16,22 +16,22 @@ Contact: https://m.me/spaze
 Encryption: https://www.michalspacek.cz/key.asc
 Canonical: https://www.michalspacek.cz/.well-known/security.txt
 Preferred-Languages: cs, en
-Expires: 2024-11-01T00:00:00+00:00
+Expires: 2025-10-01T00:00:00+00:00
 Rick: <img/src=//xss.sk>
 Rolling: <script/src=//xss.sk></script>
 -----BEGIN PGP SIGNATURE-----
 
-iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmVdK6EACgkQtkvdbkZK
-tSnk5w/9ERnAi1pZoxbnYKd2p60BV17Io4RfsEP/Su5zmY6eHP4Mf4vmi8Z6i/GD
-jdawJGqM6GWAXMRVGp2BfNs+vRFgaeg9WW8Roc1pqGNF4LQj/o/znJWiR3L3TvBM
-h3YDUBoa73pvF/iwi+FZf5M0dcPQhaYXUfGt1SSsXOsod7HIUV/GFinrMMmYU6uC
-pe+aW4wHzqHDbtm+yAhXUKnJIdGuc049PFUOD2Jjbxp2Z+s0VMXc/OZ5mMeeBQ6k
-UdvuD2rDkUnSKLOAjRr1ss6c5pOC04CeQsG3uJ5fxwZRDhd3AqQN2WMLdaBW6VwV
-mcjP8C0PF6+CQHs6//sQc1NKXxDep0WH7cYxsp/jT7kfCSSs5AGvGnD64XYIt94m
-Wtu/iPsJC32Hg/SXPL5RTaoCEzs2hHoRTC8suxmg6Ux7EPn+pYZ3STMfAqUa1W8C
-fV+D1o0MGdZDVSD4e+F38m8GfV52CKovWceHlnIKzMlUNW06qQRhWd7PI7gemNZx
-ip18PiHtPfIcFeQ5tIQ4Xtk91LMwBjAkPx76jA+uRtvMSBLmYzTTbq+KIuhj1m6q
-USJmuEfbFYRKkHsb+SoSW1yRYm2DQRdhc5KpuzTvXZ5JVh7ECPnMf/E4mon87ffc
-MOrE9YK30Vxi6f8cySVklG/IK2oKWHCL61sEP8al6ErpQKg9Us8=
-=UzWm
+iQIzBAEBCgAdFiEES9TEA68vn8yxUf5htkvdbkZKtSkFAmcb2n8ACgkQtkvdbkZK
+tSl5gw//fU3UcREtTdnTtus6JSylP9zsBUohScH36WPBNK4iQ5/foye1VUs3GIQW
+jDrg5Jh38XAQiiPoObPaH7uBZJ+8Rw3kzYRiLrEJQ/KMp3eTjVLQ1hHvkEb6aHV1
+emXFtrXffGJEO+etrSOS24QAyQXFsaV7FQjufc+fGR4fl6tEf3oHU4e0xzBY4C3Q
+EN8mWaytnz+oOkqzamSJbpfJuoXnkZFY/CfYsLbSYZqI/Uvg3LZPHIlZU6Tmdonp
+fFNk95vmXJZbtzMfpTbshWjXofqLe3CLMdt5pxAVgWhI7gTp8KMy9Vppu5gWfcaO
+6iYkMl34iiCel94QKS/NxXc0FHUjZCcOggAAcx5fG2alAx2WoJXdqL8x/GvMrhsU
+l6NScrxLmAUIglvegsymIx5ftcWeiqQi+/Cyqqcc+/CGtF29WWB6Wi+aTU4lC8Hd
+RJjo9je/mYRkSXpFHQiAf6CMhIt7ZI1yXinWrOmlaz2d40IdWvz/wTwMDcmLq8Zr
+ry+DGd+v+/ZCJn5blx/d87KQmOPu7Bzd7yCfhj+bIfGJ0WMQtHtxsN3qccfuPXFM
+w6q0lLQLSu1vqJOJwNzxwfRmfgkOL8j85NBKvMu/1MhdkSq63oKAKLXiHW6zzSj1
+kAY+64UbfuLczkM1MRrVbAJu/BRaXdke9K//Gnj+xD/5PtQZUS8=
+=MRVr
 -----END PGP SIGNATURE-----


### PR DESCRIPTION
Using `make update-security-txt` because now I have a script for that!

Just to restate, the new date is less than a year/365 days into the future because the spec says that it is recommended that the value be [less than a year](https://www.rfc-editor.org/rfc/rfc9116#section-2.5.5-1) so this would generate a warning if it would be more, and when running my `security.txt` checker in strict mode, the warning would turn into an error.