### PR TITLE
Unwrap the `text-decoration` CSS shorthand

### DIFF
--- a/app/public/www.michalspacek.cz/i/css/screen.css
+++ b/app/public/www.michalspacek.cz/i/css/screen.css
@@ -76,7 +76,8 @@ img { border: none; }
 abbr.dtstart, abbr.dtend { text-decoration: none !important; }
 abbr[data-title] {
 	position: relative;
-	text-decoration: underline dotted;
+	text-decoration-line: underline;
+	text-decoration-style: dotted;
 }
 abbr[data-title]:hover::after, abbr[data-title]:focus::after {
 	content: attr(data-title);


### PR DESCRIPTION
Because Safari 15.8 doesn't support it and while newer ones do, this is easy to change.

Introduced in #265