### PR TITLE
Disable Gitleaks artifact upload because of a bug in Gitleaks

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,3 +23,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Used to comment on PRs
           GITLEAKS_VERSION: latest
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false # Can re-enable when https://github.com/gitleaks/gitleaks/pull/1673 is released


### PR DESCRIPTION
The bugfix has been merged but wasn't included in the [8.22.0 release](https://github.com/gitleaks/gitleaks/releases/tag/v8.22.0), waiting for the new version, then this can be reverted.