### PR TITLE
Revert "Disable Gitleaks artifact upload because of a bug in Gitleaks"

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -23,4 +23,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Used to comment on PRs
           GITLEAKS_VERSION: latest
-          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: false # Can re-enable when https://github.com/gitleaks/gitleaks/pull/1673 is released


### PR DESCRIPTION
Gitleaks [8.22.1](https://github.com/gitleaks/gitleaks/releases/tag/v8.22.1) release contains the fix ("generate report file even if no findings") so this can be reverted.

Reverts spaze/michalspacek.cz#450