### PR TITLE
Run Psalm on PHP 8.3

### DIFF
--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-vendor psalm tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt
+.PHONY: test composer-audit npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt
 
 test: composer-audit npm-audit check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
@@ -46,6 +46,9 @@ phpstan-vendor:
 
 psalm:
 	php8.3 vendor/bin/psalm.phar
+
+psalm-clear-cache:
+	php8.3 vendor/bin/psalm.phar --clear-cache
 
 tester:
 	vendor/nette/tester/src/tester -s -c tests/php-unix.ini -d zend.assertions=1 --colors 1 --coverage temp/coverage.html --coverage-src src/ tests/

--- a/app/Makefile
+++ b/app/Makefile
@@ -45,7 +45,7 @@ phpstan-vendor:
 	vendor/phpstan/phpstan/phpstan -vvv --ansi analyse --configuration phpstan-vendor.neon
 
 psalm:
-	vendor/bin/psalm.phar
+	php8.3 vendor/bin/psalm.phar
 
 tester:
 	vendor/nette/tester/src/tester -s -c tests/php-unix.ini -d zend.assertions=1 --colors 1 --coverage temp/coverage.html --coverage-src src/ tests/


### PR DESCRIPTION
This requires me to keep the following packages in my dev, some are for Psalm itself, others allow it to analyze the code base:

php8.3-cli
php8.3-common
php8.3-intl
php8.3-mbstring
php8.3-opcache
php8.3-readline
php8.3-xml

They can be removed once Psalm supports PHP 8.4 (#439), or when I stop using it.