### PR TITLE
Enable nette/di lazy mode

### DIFF
--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -32,6 +32,7 @@ di:
 	export:
 		parameters: false
 		tags: false
+	lazy: true
 
 latte:
 	strictParsing: true

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -8,6 +8,7 @@ services:
 	- MichalSpacekCz\Application\LinkGenerator
 	localeLinkGenerator: MichalSpacekCz\Application\Locale\LocaleLinkGenerator(languages: %locales.languages%)
 	- MichalSpacekCz\Application\Locale\Locales
+	- @MichalSpacekCz\Application\Routing\LocaleRouter::getRouteList
 	- MichalSpacekCz\Application\Routing\RouterFactory(supportedLocales: %locales.supported%, rootDomainMapping: %locales.rootDomainMapping%, translatedRoutes: %translatedRoutes.presenters%)
 	- @MichalSpacekCz\Application\Routing\RouterFactory::createRouter
 	- MichalSpacekCz\Application\SanitizedPhpInfo

--- a/app/psalm.xml
+++ b/app/psalm.xml
@@ -85,6 +85,7 @@
 		<UnusedClass>
 			<errorLevel type="suppress">
 				<referencedClass name="*Presenter" />
+				<referencedClass name="MichalSpacekCz\Application\Routing\RouterFactory" /> <!-- Used in services.neon -->
 				<referencedClass name="MichalSpacekCz\Formatter\Placeholders\*" /> <!-- An array of these is passed to MichalSpacekCz\Formatter\TexyFormatter::__construct() by the DIC -->
 				<referencedClass name="MichalSpacekCz\Test\*\Null*" /> <!-- Used in tests.neon -->
 				<referencedClass name="MichalSpacekCz\Tls\CertificateMonitor" /> <!-- Used in bin/certmonitor.php but can't analyze bin because https://github.com/vimeo/psalm/issues/10143 -->

--- a/app/src/Application/Locale/LocaleLinkGenerator.php
+++ b/app/src/Application/Locale/LocaleLinkGenerator.php
@@ -5,7 +5,7 @@ namespace MichalSpacekCz\Application\Locale;
 
 use Contributte\Translation\Translator;
 use MichalSpacekCz\Application\LinkGenerator;
-use MichalSpacekCz\Application\Routing\RouterFactory;
+use MichalSpacekCz\Application\Routing\LocaleRouter;
 use MichalSpacekCz\ShouldNotHappenException;
 use Nette\Application\IPresenterFactory;
 use Nette\Application\LinkGenerator as NetteLinkGenerator;
@@ -26,7 +26,7 @@ class LocaleLinkGenerator
 	 * @param array<string, array{code:string, name:string}> $languages
 	 */
 	public function __construct(
-		private readonly RouterFactory $routerFactory,
+		private readonly LocaleRouter $localeRouter,
 		private readonly IRequest $httpRequest,
 		private readonly IPresenterFactory $presenterFactory,
 		private readonly LinkGenerator $linkGenerator,
@@ -47,7 +47,7 @@ class LocaleLinkGenerator
 	public function links(string $destination, array $params = []): array
 	{
 		$links = [];
-		foreach ($this->routerFactory->getLocaleRouters() as $locale => $routers) {
+		foreach ($this->localeRouter->getLocaleRouters() as $locale => $routers) {
 			foreach ($routers->getRouters() as $router) {
 				if (!$router instanceof RouteList) {
 					throw new ShouldNotHappenException(sprintf("The presenter should be a '%s' but it's a %s", RouteList::class, get_debug_type($router)));

--- a/app/src/Application/Routing/LocaleRouter.php
+++ b/app/src/Application/Routing/LocaleRouter.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application\Routing;
+
+use Nette\Application\Routers\RouteList;
+
+readonly class LocaleRouter
+{
+
+	/**
+	 * @param array<string, RouteList> $localeRouters
+	 */
+	public function __construct(
+		private array $localeRouters,
+		private RouteList $routeList,
+	) {
+	}
+
+
+	/**
+	 * @return array<string, RouteList>
+	 */
+	public function getLocaleRouters(): array
+	{
+		return $this->localeRouters;
+	}
+
+
+	public function getRouteList(): RouteList
+	{
+		return $this->routeList;
+	}
+
+}

--- a/app/src/Application/Routing/RouterFactory.php
+++ b/app/src/Application/Routing/RouterFactory.php
@@ -102,7 +102,7 @@ class RouterFactory
 	/**
 	 * @noinspection RequiredAttributes Because <param> is not an HTML tag here
 	 */
-	public function createRouter(): RouteList
+	public function createRouter(): LocaleRouter
 	{
 		$router = new RouteList();
 		foreach ($this->availableLocales as $locale) {
@@ -147,7 +147,7 @@ class RouterFactory
 			new RouterFactoryRoute('<presenter>', 'Homepage', 'default'), // Intentionally no action, use presenter-specific route if you need actions
 		]);
 
-		return $router;
+		return new LocaleRouter($this->localeRouters, $router);
 	}
 
 

--- a/app/tests/Application/Locale/LocaleLinkGeneratorTest.phpt
+++ b/app/tests/Application/Locale/LocaleLinkGeneratorTest.phpt
@@ -5,7 +5,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Application\Locale;
 
 use MichalSpacekCz\Application\LinkGenerator;
-use MichalSpacekCz\Application\Routing\RouterFactory;
+use MichalSpacekCz\Application\Routing\LocaleRouter;
 use MichalSpacekCz\Test\NoOpTranslator;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\IPresenterFactory;
@@ -25,12 +25,12 @@ class LocaleLinkGeneratorTest extends TestCase
 
 	public function __construct(
 		private readonly NoOpTranslator $translator,
-		RouterFactory $routerFactory,
+		LocaleRouter $localeRouter,
 		IRequest $httpRequest,
 		IPresenterFactory $presenterFactory,
 		LinkGenerator $linkGenerator,
 	) {
-		$this->localeLinkGenerator = new LocaleLinkGenerator($routerFactory, $httpRequest, $presenterFactory, $linkGenerator, $translator, [
+		$this->localeLinkGenerator = new LocaleLinkGenerator($localeRouter, $httpRequest, $presenterFactory, $linkGenerator, $translator, [
 			'cs_CZ' => [
 				'code' => 'cs',
 				'name' => 'Česky',


### PR DESCRIPTION
See the [blog post](https://blog.nette.org/en/one-line-in-configuration-will-speed-up-your-nette-application-how-is-that-possible).

The speedup is tiny in my case, if any at all, as the database connection is already created on-demand only (since 7766444 #14) but it generally seems like a good idea.

Needed a bit of a refactoring because `RouterFactory::getLocaleRouters()` returned an empty list in tests when the lazy mode was enabled because `RouterFactory::createRouter()` has not been called yet.