### PR TITLE
Gitleaks has added `[[rules.allowlists]]`

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,7 +23,7 @@ keywords = [
   "prod",
 ]
 
-[rules.allowlist]
+[[rules.allowlists]]
 stopwords = [
   # Database column names
   '''_talk''',


### PR DESCRIPTION
And uses it instead of `[rules.allowlist]` which still works.

https://github.com/gitleaks/gitleaks/releases/tag/v8.23.0