### PR TITLE
Validate slug/action/alias name

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -48,6 +48,7 @@ services:
 	- MichalSpacekCz\Form\Controls\TrainingControlsFactory
 	- MichalSpacekCz\Form\DeletePersonalDataFormFactory
 	- MichalSpacekCz\Form\FormFactory
+	- MichalSpacekCz\Form\FormValidators
 	- MichalSpacekCz\Form\InterviewFormFactory(videoThumbnails: @interviewVideoThumbnails)
 	- MichalSpacekCz\Form\PostFormFactory
 	- MichalSpacekCz\Form\Pulse\PasswordsStorageAlgorithmFormFactory

--- a/app/src/Form/FormValidators.php
+++ b/app/src/Form/FormValidators.php
@@ -1,0 +1,24 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Form;
+
+use Contributte\Translation\Translator;
+use Nette\Forms\Controls\TextInput;
+use Nette\Forms\Form;
+
+readonly class FormValidators
+{
+
+	public function __construct(
+		private Translator $translator,
+	) {
+	}
+
+
+	public function addValidateSlugRules(TextInput $input): void
+	{
+		$input->addRule(Form::Pattern, $this->translator->translate('messages.forms.validateSlugParamsError'), '[a-z0-9.,_-]+');
+	}
+
+}

--- a/app/src/Form/PostFormFactory.php
+++ b/app/src/Form/PostFormFactory.php
@@ -36,6 +36,7 @@ readonly class PostFormFactory
 
 	public function __construct(
 		private FormFactory $factory,
+		private FormValidators $validators,
 		private Translator $translator,
 		private BlogPosts $blogPosts,
 		private BlogPostFactory $blogPostFactory,
@@ -62,8 +63,9 @@ readonly class PostFormFactory
 		$form->addText('title', 'Titulek:')
 			->setRequired('Zadejte prosím titulek')
 			->addRule(Form::MinLength, 'Titulek musí mít alespoň %d znaky', 3);
-		$form->addText('slug', 'Slug:')
+		$slugInput = $form->addText('slug', 'Slug:')
 			->addRule(Form::MinLength, 'Slug musí mít alespoň %d znaky', 3);
+		$this->validators->addValidateSlugRules($slugInput);
 		$this->addPublishedDate($form->addText('published', 'Vydáno:'))
 			->setDefaultValue(date('Y-m-d') . ' HH:MM');
 		$previewKeyInput = $form->addText('previewKey', 'Klíč pro náhled:')

--- a/app/src/Form/PostFormFactory.php
+++ b/app/src/Form/PostFormFactory.php
@@ -152,8 +152,9 @@ readonly class PostFormFactory
 			$newPost = $this->buildPost($values, $post?->getId());
 			try {
 				if ($post) {
-					assert(is_string($values->editSummary));
-					$this->blogPosts->update($newPost, $values->editSummary === '' ? null : $values->editSummary, $post->getSlugTags());
+					$editSummary = $values->editSummary ?? null;
+					assert($editSummary === null || is_string($editSummary));
+					$this->blogPosts->update($newPost, $editSummary, $post->getSlugTags());
 					$onSuccessEdit($newPost);
 				} else {
 					$onSuccessAdd($this->blogPosts->add($newPost));

--- a/app/src/Form/TalkFormFactory.php
+++ b/app/src/Form/TalkFormFactory.php
@@ -20,6 +20,7 @@ readonly class TalkFormFactory
 
 	public function __construct(
 		private FormFactory $factory,
+		private FormValidators $validators,
 		private TrainingControlsFactory $trainingControlsFactory,
 		private Talks $talks,
 		private LinkGenerator $linkGenerator,
@@ -42,9 +43,10 @@ readonly class TalkFormFactory
 		$form->addSelect('locale', 'Jazyk:', $this->locales->getAllLocales())
 			->setRequired('Zadejte prosím jazyk')
 			->setPrompt('- vyberte -');
-		$form->addText('action', 'Akce:')
+		$actionInput = $form->addText('action', 'Akce:')
 			->setRequired(false)
 			->addRule(Form::MaxLength, 'Maximální délka akce je %d znaků', 200);
+		$this->validators->addValidateSlugRules($actionInput);
 		$form->addText('title', 'Název:')
 			->setRequired('Zadejte prosím název')
 			->addRule(Form::MaxLength, 'Maximální délka názvu je %d znaků', 200);

--- a/app/src/Form/TalkSlidesFormFactory.php
+++ b/app/src/Form/TalkSlidesFormFactory.php
@@ -19,6 +19,7 @@ readonly class TalkSlidesFormFactory
 
 	public function __construct(
 		private FormFactory $factory,
+		private FormValidators $validators,
 		private TalkSlides $talkSlides,
 		private TexyFormatter $texyFormatter,
 		private SupportedImageFileFormats $supportedImageFileFormats,
@@ -96,9 +97,9 @@ readonly class TalkSlidesFormFactory
 		$supportedImages = '*.' . implode(', *.', $this->supportedImageFileFormats->getMainExtensions());
 		$supportedAlternativeImages = '*.' . implode(', *.', $this->supportedImageFileFormats->getAlternativeExtensions());
 		$disableSlideUploads = (bool)$filenamesTalkId;
-		$container->addText('alias', 'Alias:')
-			->setRequired('Zadejte prosím alias')
-			->addRule(Form::Pattern, 'Alias musí být ve formátu [_.,a-z0-9-]+', '[_.,a-z0-9-]+');
+		$aliasInput = $container->addText('alias', 'Alias:')
+			->setRequired('Zadejte prosím alias');
+		$this->validators->addValidateSlugRules($aliasInput);
 		$container->addInteger('number', 'Slajd:')
 			->setDefaultValue(1)
 			->setHtmlAttribute('class', 'right slide-nr')

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -396,3 +396,5 @@ cookies:
 		netteSameSiteCheck: "Používá se pro detekci \"//same-site//\":[blog:co-znamena-origin-site-etld-etld-plus-1-public-suffix-a-psl#same-site] požadavků."
 httpHeaders:
 	headerNotSent: "hlavička neposlána"
+forms:
+	validateSlugParamsError: "%label musí odpovídat formátu %d"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -396,3 +396,5 @@ cookies:
 		netteSameSiteCheck: "Used to detect \"//same-site//\":[blog:origin-site-etld-etld-plus-one-public-suffix-psl-what-are-they#same-site] requests."
 httpHeaders:
 	headerNotSent: "header not sent"
+forms:
+	validateSlugParamsError: "%label must match %d"

--- a/app/tests/Form/FormValidatorsTest.phpt
+++ b/app/tests/Form/FormValidatorsTest.phpt
@@ -1,0 +1,55 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Form;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Forms\Controls\TextInput;
+use Nette\Forms\Form;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+class FormValidatorsTest extends TestCase
+{
+
+	public function __construct(
+		private readonly FormValidators $validators,
+	) {
+	}
+
+
+	/**
+	 * @return list<array{0:string, 1:bool}>
+	 */
+	public function getSlugs(): array
+	{
+		return [
+			['foo', true],
+			['foo-bar', true],
+			['foo-bar.baz', true],
+			['foo-bar,baz', true],
+			['foo-bar_baz', true],
+			['foo-bar-1337', true],
+			['foo/bar', false],
+		];
+	}
+
+
+	/** @dataProvider getSlugs */
+	public function testAddValidateSlugRules(string $slug, bool $result): void
+	{
+		$input = new TextInput();
+		$input->value = $slug;
+		$this->validators->addValidateSlugRules($input);
+		/** @noinspection PhpInternalEntityUsedInspection */
+		$input->setParent(new Form());
+		$input->validate();
+		Assert::same($result ? [] : ['messages.forms.validateSlugParamsError'], $input->getErrors());
+	}
+
+}
+
+TestCaseRunner::run(FormValidatorsTest::class);


### PR DESCRIPTION
Validation rules added using the `addRule(Form::Pattern, ...)` call, not using any custom validation callback because I want the JS validation to be also used and don't want to add a custom one.