### PR TITLE
Always send 404 in this Easter egg

### DIFF
--- a/app/src/EasterEgg/FourOhFourButFound.php
+++ b/app/src/EasterEgg/FourOhFourButFound.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Http\Robots\Robots;
 use MichalSpacekCz\Http\Robots\RobotsRule;
 use Nette\Application\Responses\TextResponse;
 use Nette\Application\UI\Presenter;
+use Nette\Http\IResponse;
 
 final readonly class FourOhFourButFound
 {
@@ -20,6 +21,7 @@ final readonly class FourOhFourButFound
 
 	public function __construct(
 		private Robots $robots,
+		private IResponse $httpResponse,
 	) {
 	}
 
@@ -32,6 +34,7 @@ final readonly class FourOhFourButFound
 		}
 		foreach (self::TEMPLATES as $request => $template) {
 			if (str_contains($url, $request) || str_contains(urldecode($url), $request)) {
+				$this->httpResponse->setCode(IResponse::S404_NotFound, 'This is a not found page source trust me bro');
 				$this->robots->setHeader([RobotsRule::NoIndex, RobotsRule::NoFollow]);
 				$presenter->sendResponse(new TextResponse(file_get_contents($template)));
 			}

--- a/app/tests/EasterEgg/FourOhFourButFoundTest.phpt
+++ b/app/tests/EasterEgg/FourOhFourButFoundTest.phpt
@@ -7,6 +7,7 @@ namespace MichalSpacekCz\EasterEgg;
 
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Application\UiPresenterMock;
+use MichalSpacekCz\Test\Http\Response;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Responses\TextResponse;
 use Tester\Assert;
@@ -21,6 +22,7 @@ final class FourOhFourButFoundTest extends TestCase
 	public function __construct(
 		private readonly FourOhFourButFound $fourOhFourButFound,
 		private readonly ApplicationPresenter $applicationPresenter,
+		private readonly Response $httpResponse,
 	) {
 	}
 
@@ -60,6 +62,10 @@ final class FourOhFourButFoundTest extends TestCase
 			}));
 			$response = $presenter->getResponse();
 			assert($response instanceof TextResponse && is_string($response->getSource()));
+			Assert::same(404, $this->httpResponse->getCode());
+			$reason = $this->httpResponse->getReason();
+			assert(is_string($reason));
+			Assert::contains('not found page', $reason);
 			Assert::contains($contains, $response->getSource());
 		}
 	}


### PR DESCRIPTION
In #471 I have added support to show Easter eggs also on URLs like `/?file=/etc/passwd` but that "inherited" the status code of the `/` page, didn't show 404.

Also in the Pulse module, due to the URL routing, even `/etc/passwd` returned 200, this will "fix" it.