### PR TITLE
Use the new Certbot's live certs path

### DIFF
--- a/conf/nginx/prod-michalspacek.cz.conf
+++ b/conf/nginx/prod-michalspacek.cz.conf
@@ -188,8 +188,8 @@ server {
     http2 on;
     server_name mta-sts.michalspacek.cz;
     include /srv/www/michalspacek.cz/conf/nginx/common-https.conf;
-    ssl_certificate /etc/nginx/certs/mta-sts.michalspacek.cz.fullchain.pem;
-    ssl_certificate_key /etc/nginx/certs/mta-sts.michalspacek.cz.privkey.pem;
+    ssl_certificate /etc/letsencrypt/live/mta-sts.michalspacek.cz/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/mta-sts.michalspacek.cz/privkey.pem;
     include /srv/www/michalspacek.cz/conf/nginx/common-mta-sts.michalspacek.cz.conf;
     location = /app.php {
         return 301 https://www.michalspacek.cz/;


### PR DESCRIPTION
For the certs that are expiring for now only.

Follow-ups:
- #555
- #583
- #584
