### PR TITLE
Don't use CSRF protection for the light/dark mode switch form

### DIFF
--- a/app/src/Form/ThemeFormFactory.php
+++ b/app/src/Form/ThemeFormFactory.php
@@ -10,7 +10,7 @@ final readonly class ThemeFormFactory
 {
 
 	public function __construct(
-		private FormFactory $factory,
+		private UnprotectedFormFactory $factory,
 		private Theme $theme,
 	) {
 	}


### PR DESCRIPTION
The CSRF protection requires session so session was started for each and every website visit, which added a row in the sessions table. That's unnecessary.

Follow-up to #381