### PR TITLE
Display HTTPS certs' CN and SAN in admin

### DIFF
--- a/app/public/www.michalspacek.cz/i/css/screen.css
+++ b/app/public/www.michalspacek.cz/i/css/screen.css
@@ -309,10 +309,16 @@ td.nameCell { width: 200px; }
 tr.dateLine td, li.dateLine { border-top: 2px solid #EEE; }
 #pridat-ucastniky th, #pridat-ucastniky td { padding: 1px; }
 #statuses th, #statuses td, #applications th, #applications td, #certificates th, #certificates td { padding: 1px 5px; }
-#statuses tr.summary:hover, #certificates tbody tr:hover, #applications tbody tr:hover, #slides tbody:hover, table .row:hover { background-color: #F0F0F0; }
+#statuses tr.summary:hover, #applications tbody tr:hover, #slides tbody:hover, table .row:hover { background-color: #F0F0F0; }
 .discarded, #statuses .discarded, .lighter { opacity: 0.3; }
 .discarded:hover, #statuses .discarded:hover { opacity: 0.7; }
 #certificates thead th { text-align: left; }
+#certificates tbody tr:last-child td {
+	line-height: 0.75;
+	padding-top: 0;
+	padding-bottom: 3px;
+	font-size: smaller;
+}
 #frm-application th, #frm-application td,
 #frm-applicationPreliminary th, #frm-applicationPreliminary td {
 	width: 150px;

--- a/app/src/Admin/Presenters/templates/Homepage/default.latte
+++ b/app/src/Admin/Presenters/templates/Homepage/default.latte
@@ -16,7 +16,7 @@
 <tr n:foreach="$certificates as $cert">
 	<td><small>{$iterator->getCounter()}.</small></td>
 	<td title="{if $cert->isExpired()}Expiroval{else}Funkční{/if}" n:class="$cert->isExpired() ? error">{if $cert->isExpired()}{icon times-circle}{else}{icon check-circle}{/if}</td>
-	<td><strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()" n:class="$cert->isExpired() ? error">{$cert->getCertificateName()}<small n:if="$cert->getCertificateNameExt()">-{$cert->getCertificateNameExt()}</small></strong></td>
+	<td><strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()" n:class="$cert->isExpired() ? error">{$cert->getCertificateName()}<small n:if="$cert->getCertificateNameExtension()">-{$cert->getCertificateNameExtension()}</small></strong></td>
 	<td>{$cert->getNotBefore()|localeDay} <small>{$cert->getNotBefore()|date:'H:i'}</small></td>
 	<td>
 		<small>

--- a/app/src/Admin/Presenters/templates/Homepage/default.latte
+++ b/app/src/Admin/Presenters/templates/Homepage/default.latte
@@ -10,10 +10,10 @@
 </p>
 <table id="certificates" n:class="!$certificatesNeedAttention ? hidden">
 <thead>
-	<tr><td></td><td></td><th><small>Certifikát</small></th><th><small>Platnost</small></th><td></td><td></td><th><small>Expirace</small></th></tr>
+	<tr><td></td><td></td><th><small>Certifikát</small></th><th><small>Platnost</small></th><td></td><td></td><th><small>Expirace</small></th><td></td></tr>
 </thead>
-<tbody>
-<tr n:foreach="$certificates as $cert">
+<tbody class="row" n:foreach="$certificates as $cert">
+<tr>
 	<td><small>{$iterator->getCounter()}.</small></td>
 	<td title="{if $cert->isExpired()}Expiroval{else}Funkční{/if}" n:class="$cert->isExpired() ? error">{if $cert->isExpired()}{icon times-circle}{else}{icon check-circle}{/if}</td>
 	<td><strong n:tag-if="$cert->isExpiringSoon() || $cert->isExpired()" n:class="$cert->isExpired() ? error">{$cert->getCertificateName()}<small n:if="$cert->getCertificateNameExtension()">-{$cert->getCertificateNameExtension()}</small></strong></td>
@@ -42,6 +42,18 @@
 			</small>
 		</strong>
 	</td>
+</tr>
+<tr>
+	<td colspan="2"></td>
+	<td colspan="6"><small>
+			CN: {if $cert->getCommonName() !== null}{$cert->getCommonName()}{else}<em>missing</em>{/if};
+			SAN:
+			{if $cert->getSubjectAlternativeNames() !== null}
+				{foreach $cert->getSubjectAlternativeNames() as $san}{$san}{sep}, {/sep}{else}<em>empty</em>{/foreach}
+			{else}
+				<em>unknown yet</em>
+			{/if}
+	</small></td>
 </tr>
 </tbody>
 </table>

--- a/app/src/Tls/Certificate.php
+++ b/app/src/Tls/Certificate.php
@@ -23,7 +23,7 @@ final readonly class Certificate implements JsonSerializable
 	 */
 	public function __construct(
 		private string $certificateName,
-		private ?string $certificateNameExt,
+		private ?string $certificateNameExtension,
 		private ?string $commonName,
 		private DateTimeImmutable $notBefore,
 		private DateTimeImmutable $notAfter,
@@ -53,9 +53,9 @@ final readonly class Certificate implements JsonSerializable
 	}
 
 
-	public function getCertificateNameExt(): ?string
+	public function getCertificateNameExtension(): ?string
 	{
-		return $this->certificateNameExt;
+		return $this->certificateNameExtension;
 	}
 
 
@@ -115,7 +115,7 @@ final readonly class Certificate implements JsonSerializable
 	{
 		return [
 			'certificateName' => $this->certificateName,
-			'certificateNameExt' => $this->certificateNameExt,
+			'certificateNameExt' => $this->certificateNameExtension,
 			'cn' => $this->commonName,
 			'notBefore' => $this->notBefore->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			'notBeforeTz' => $this->notBefore->getTimezone()->getName(),

--- a/app/src/Tls/Certificate.php
+++ b/app/src/Tls/Certificate.php
@@ -19,12 +19,14 @@ final readonly class Certificate implements JsonSerializable
 
 
 	/**
+	 * @param list<string>|null $subjectAlternativeNames
 	 * @throws CertificateException
 	 */
 	public function __construct(
 		private string $certificateName,
 		private ?string $certificateNameExtension,
 		private ?string $commonName,
+		private ?array $subjectAlternativeNames,
 		private DateTimeImmutable $notBefore,
 		private DateTimeImmutable $notAfter,
 		private int $expiringThreshold,
@@ -62,6 +64,15 @@ final readonly class Certificate implements JsonSerializable
 	public function getCommonName(): ?string
 	{
 		return $this->commonName;
+	}
+
+
+	/**
+	 * @return list<string>|null
+	 */
+	public function getSubjectAlternativeNames(): ?array
+	{
+		return $this->subjectAlternativeNames;
 	}
 
 
@@ -108,7 +119,7 @@ final readonly class Certificate implements JsonSerializable
 
 
 	/**
-	 * @return array{certificateName:string, certificateNameExt:string|null, cn:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
+	 * @return array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
 	 */
 	#[Override]
 	public function jsonSerialize(): array
@@ -117,6 +128,7 @@ final readonly class Certificate implements JsonSerializable
 			'certificateName' => $this->certificateName,
 			'certificateNameExt' => $this->certificateNameExtension,
 			'cn' => $this->commonName,
+			'san' => $this->getSubjectAlternativeNames(),
 			'notBefore' => $this->notBefore->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			'notBeforeTz' => $this->notBefore->getTimezone()->getName(),
 			'notAfter' => $this->notAfter->format(DateTimeFormat::RFC3339_MICROSECONDS),

--- a/app/src/Tls/Certificate.php
+++ b/app/src/Tls/Certificate.php
@@ -24,6 +24,7 @@ final readonly class Certificate implements JsonSerializable
 	public function __construct(
 		private string $certificateName,
 		private ?string $certificateNameExt,
+		private ?string $commonName,
 		private DateTimeImmutable $notBefore,
 		private DateTimeImmutable $notAfter,
 		private int $expiringThreshold,
@@ -55,6 +56,12 @@ final readonly class Certificate implements JsonSerializable
 	public function getCertificateNameExt(): ?string
 	{
 		return $this->certificateNameExt;
+	}
+
+
+	public function getCommonName(): ?string
+	{
+		return $this->commonName;
 	}
 
 
@@ -101,7 +108,7 @@ final readonly class Certificate implements JsonSerializable
 
 
 	/**
-	 * @return array{certificateName:string, certificateNameExt:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
+	 * @return array{certificateName:string, certificateNameExt:string|null, cn:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
 	 */
 	#[Override]
 	public function jsonSerialize(): array
@@ -109,6 +116,7 @@ final readonly class Certificate implements JsonSerializable
 		return [
 			'certificateName' => $this->certificateName,
 			'certificateNameExt' => $this->certificateNameExt,
+			'cn' => $this->commonName,
 			'notBefore' => $this->notBefore->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			'notBeforeTz' => $this->notBefore->getTimezone()->getName(),
 			'notAfter' => $this->notAfter->format(DateTimeFormat::RFC3339_MICROSECONDS),

--- a/app/src/Tls/CertificateFactory.php
+++ b/app/src/Tls/CertificateFactory.php
@@ -106,7 +106,7 @@ final readonly class CertificateFactory
 	 */
 	public function get(
 		string $certificateName,
-		?string $certificateNameExt,
+		?string $certificateNameExtension,
 		?string $commonName,
 		string $notBefore,
 		string $notBeforeTz,
@@ -119,7 +119,7 @@ final readonly class CertificateFactory
 	): Certificate {
 		return new Certificate(
 			$certificateName,
-			$certificateNameExt,
+			$certificateNameExtension,
 			$commonName,
 			$this->createDateTimeImmutable($notBefore, $notBeforeTz),
 			$this->createDateTimeImmutable($notAfter, $notAfterTz),

--- a/app/src/Tls/CertificateFactory.php
+++ b/app/src/Tls/CertificateFactory.php
@@ -34,16 +34,18 @@ final readonly class CertificateFactory
 	 */
 	public function fromDatabaseRow(Row $row): Certificate
 	{
-		assert(is_string($row->cn));
-		assert($row->ext === null || is_string($row->ext));
+		assert(is_string($row->certificateName));
+		assert($row->certificateNameExt === null || is_string($row->certificateNameExt));
+		assert($row->cn === null || is_string($row->cn));
 		assert($row->notBefore instanceof DateTime);
 		assert(is_string($row->notBeforeTimezone));
 		assert($row->notAfter instanceof DateTime);
 		assert(is_string($row->notAfterTimezone));
 
 		return new Certificate(
+			$row->certificateName,
+			$row->certificateNameExt,
 			$row->cn,
-			$row->ext,
 			$this->dateTimeFactory->createFrom($row->notBefore, $row->notBeforeTimezone),
 			$this->dateTimeFactory->createFrom($row->notAfter, $row->notAfterTimezone),
 			$this->expiringThreshold,
@@ -88,6 +90,7 @@ final readonly class CertificateFactory
 		return new Certificate(
 			$certificateName,
 			null,
+			$details->getCommonName(),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidFromTimeT()),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidToTimeT()),
 			$this->expiringThreshold,
@@ -104,6 +107,7 @@ final readonly class CertificateFactory
 	public function get(
 		string $certificateName,
 		?string $certificateNameExt,
+		?string $commonName,
 		string $notBefore,
 		string $notBeforeTz,
 		string $notAfter,
@@ -116,6 +120,7 @@ final readonly class CertificateFactory
 		return new Certificate(
 			$certificateName,
 			$certificateNameExt,
+			$commonName,
 			$this->createDateTimeImmutable($notBefore, $notBeforeTz),
 			$this->createDateTimeImmutable($notAfter, $notAfterTz),
 			$expiringThreshold,

--- a/app/src/Tls/CertificateFactory.php
+++ b/app/src/Tls/CertificateFactory.php
@@ -15,6 +15,9 @@ use MichalSpacekCz\Tls\Exceptions\CertificateException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslX509ParseException;
 use Nette\Database\Row;
+use Nette\Schema\Expect;
+use Nette\Schema\Processor;
+use Nette\Utils\Json;
 use OpenSSLCertificate;
 
 final readonly class CertificateFactory
@@ -23,6 +26,7 @@ final readonly class CertificateFactory
 	public function __construct(
 		private DateTimeZoneFactory $dateTimeZoneFactory,
 		private DateTimeFactory $dateTimeFactory,
+		private Processor $schemaProcessor,
 		private int $expiringThreshold,
 	) {
 	}
@@ -37,15 +41,19 @@ final readonly class CertificateFactory
 		assert(is_string($row->certificateName));
 		assert($row->certificateNameExt === null || is_string($row->certificateNameExt));
 		assert($row->cn === null || is_string($row->cn));
+		assert($row->san === null || is_string($row->san));
 		assert($row->notBefore instanceof DateTime);
 		assert(is_string($row->notBeforeTimezone));
 		assert($row->notAfter instanceof DateTime);
 		assert(is_string($row->notAfterTimezone));
 
+		/** @var list<string>|null $san */
+		$san = $row->san !== null ? $this->schemaProcessor->process(Expect::listOf(Expect::string()), Json::decode($row->san)) : null;
 		return new Certificate(
 			$row->certificateName,
 			$row->certificateNameExt,
 			$row->cn,
+			$san,
 			$this->dateTimeFactory->createFrom($row->notBefore, $row->notBeforeTimezone),
 			$this->dateTimeFactory->createFrom($row->notAfter, $row->notAfterTimezone),
 			$this->expiringThreshold,
@@ -91,6 +99,7 @@ final readonly class CertificateFactory
 			$certificateName,
 			null,
 			$details->getCommonName(),
+			$details->getSubjectAlternativeNames(),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidFromTimeT()),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidToTimeT()),
 			$this->expiringThreshold,
@@ -100,6 +109,7 @@ final readonly class CertificateFactory
 
 
 	/**
+	 * @param list<string>|null $subjectAlternativeNames
 	 * @throws CannotParseDateTimeException
 	 * @throws CertificateException
 	 * @throws InvalidTimezoneException
@@ -108,6 +118,7 @@ final readonly class CertificateFactory
 		string $certificateName,
 		?string $certificateNameExtension,
 		?string $commonName,
+		?array $subjectAlternativeNames,
 		string $notBefore,
 		string $notBeforeTz,
 		string $notAfter,
@@ -121,6 +132,7 @@ final readonly class CertificateFactory
 			$certificateName,
 			$certificateNameExtension,
 			$commonName,
+			$subjectAlternativeNames,
 			$this->createDateTimeImmutable($notBefore, $notBeforeTz),
 			$this->createDateTimeImmutable($notAfter, $notAfterTz),
 			$expiringThreshold,

--- a/app/src/Tls/Certificates.php
+++ b/app/src/Tls/Certificates.php
@@ -58,8 +58,9 @@ final readonly class Certificates
 	public function getNewest(): array
 	{
 		$query = 'SELECT
+			cr.certificate_name AS certificateName,
+			cr.certificate_name_ext AS certificateNameExt,
 			cr.cn,
-			cr.ext,
 			c.not_before AS notBefore,
 			c.not_before_timezone AS notBeforeTimezone,
 			c.not_after AS notAfter,
@@ -70,9 +71,9 @@ final readonly class Certificates
 				SELECT MAX(c.id_certificate)
 				FROM certificates c JOIN certificate_requests cr ON c.key_certificate_request = cr.id_certificate_request
 				WHERE NOT c.hidden
-				GROUP BY cr.cn, cr.ext
+				GROUP BY cr.certificate_name, cr.certificate_name_ext
 			)
-			ORDER BY cr.cn, cr.ext';
+			ORDER BY cr.certificate_name, cr.certificate_name_ext';
 		$certificates = [];
 		foreach ($this->typedDatabase->fetchAll($query) as $data) {
 			$certificate = $this->certificateFactory->fromDatabaseRow($data);
@@ -122,8 +123,9 @@ final readonly class Certificates
 	{
 		$now = new DateTimeImmutable();
 		$this->database->query('INSERT INTO certificate_requests', [
-			'cn' => $certificate->getCertificateName(),
-			'ext' => $certificate->getCertificateNameExt(),
+			'certificate_name' => $certificate->getCertificateName(),
+			'certificate_name_ext' => $certificate->getCertificateNameExt(),
+			'cn' => $certificate->getCommonName(),
 			'time' => $now,
 			'time_timezone' => $now->getTimezone()->getName(),
 			'success' => true,

--- a/app/src/Tls/Certificates.php
+++ b/app/src/Tls/Certificates.php
@@ -107,7 +107,7 @@ final readonly class Certificates
 			Debugger::log(sprintf(
 				'OK %s%s from %s to %s',
 				$cert->getCertificateName(),
-				$cert->getCertificateNameExt() ?? '',
+				$cert->getCertificateNameExtension() ?? '',
 				$cert->getNotBefore()->format(DateTimeFormat::RFC3339_MICROSECONDS),
 				$cert->getNotAfter()->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			), 'cert');
@@ -124,7 +124,7 @@ final readonly class Certificates
 		$now = new DateTimeImmutable();
 		$this->database->query('INSERT INTO certificate_requests', [
 			'certificate_name' => $certificate->getCertificateName(),
-			'certificate_name_ext' => $certificate->getCertificateNameExt(),
+			'certificate_name_ext' => $certificate->getCertificateNameExtension(),
 			'cn' => $certificate->getCommonName(),
 			'time' => $now,
 			'time_timezone' => $now->getTimezone()->getName(),

--- a/app/src/Tls/Certificates.php
+++ b/app/src/Tls/Certificates.php
@@ -13,6 +13,7 @@ use Nette\Database\DriverException;
 use Nette\Database\Explorer;
 use Nette\Security\AuthenticationException;
 use Nette\Security\Authenticator;
+use Nette\Utils\Json;
 use Tracy\Debugger;
 
 final readonly class Certificates
@@ -61,6 +62,7 @@ final readonly class Certificates
 			cr.certificate_name AS certificateName,
 			cr.certificate_name_ext AS certificateNameExt,
 			cr.cn,
+			cr.san,
 			c.not_before AS notBefore,
 			c.not_before_timezone AS notBeforeTimezone,
 			c.not_after AS notAfter,
@@ -126,6 +128,7 @@ final readonly class Certificates
 			'certificate_name' => $certificate->getCertificateName(),
 			'certificate_name_ext' => $certificate->getCertificateNameExtension(),
 			'cn' => $certificate->getCommonName(),
+			'san' => Json::encode($certificate->getSubjectAlternativeNames()),
 			'time' => $now,
 			'time_timezone' => $now->getTimezone()->getName(),
 			'success' => true,

--- a/app/src/Tls/CertificatesApiClient.php
+++ b/app/src/Tls/CertificatesApiClient.php
@@ -58,6 +58,7 @@ final readonly class CertificatesApiClient
 				Expect::structure([
 					'certificateName' => Expect::string()->required(),
 					'certificateNameExt' => Expect::string()->required()->nullable(),
+					'cn' => Expect::string()->required()->nullable(),
 					'notBefore' => Expect::string()->required(),
 					'notBeforeTz' => Expect::string()->required(),
 					'notAfter' => Expect::string()->required(),
@@ -70,7 +71,7 @@ final readonly class CertificatesApiClient
 			),
 		]);
 		try {
-			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}>} $data */
+			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, cn:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}>} $data */
 			$data = $this->schemaProcessor->process($schema, $decoded);
 		} catch (ValidationException $e) {
 			throw new CertificatesApiException(sprintf('Cannot validate response from %s (`%s`): %s', $request->getUrl(), $json, implode(', ', $e->getMessages())), previous: $e);
@@ -82,6 +83,7 @@ final readonly class CertificatesApiClient
 			$certificates[] = $this->certificateFactory->get(
 				$details->certificateName,
 				$details->certificateNameExt,
+				$details->cn,
 				$details->notBefore,
 				$details->notBeforeTz,
 				$details->notAfter,

--- a/app/src/Tls/CertificatesApiClient.php
+++ b/app/src/Tls/CertificatesApiClient.php
@@ -59,6 +59,7 @@ final readonly class CertificatesApiClient
 					'certificateName' => Expect::string()->required(),
 					'certificateNameExt' => Expect::string()->required()->nullable(),
 					'cn' => Expect::string()->required()->nullable(),
+					'san' => Expect::listOf(Expect::string())->required()->nullable(),
 					'notBefore' => Expect::string()->required(),
 					'notBeforeTz' => Expect::string()->required(),
 					'notAfter' => Expect::string()->required(),
@@ -71,7 +72,7 @@ final readonly class CertificatesApiClient
 			),
 		]);
 		try {
-			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, cn:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}>} $data */
+			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}>} $data */
 			$data = $this->schemaProcessor->process($schema, $decoded);
 		} catch (ValidationException $e) {
 			throw new CertificatesApiException(sprintf('Cannot validate response from %s (`%s`): %s', $request->getUrl(), $json, implode(', ', $e->getMessages())), previous: $e);
@@ -84,6 +85,7 @@ final readonly class CertificatesApiClient
 				$details->certificateName,
 				$details->certificateNameExt,
 				$details->cn,
+				$details->san,
 				$details->notBefore,
 				$details->notBeforeTz,
 				$details->notAfter,

--- a/app/src/Tls/OpenSsl.php
+++ b/app/src/Tls/OpenSsl.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Tls;
 
+use Composer\Pcre\Preg;
 use MichalSpacekCz\Tls\Exceptions\OpenSslException;
 use MichalSpacekCz\Tls\Exceptions\OpenSslX509ParseException;
 use OpenSSLCertificate;
@@ -31,7 +32,16 @@ final class OpenSsl
 		) {
 			throw new OpenSslX509ParseException(serialize($info));
 		}
-		return new OpenSslX509ParseResult($commonName, $info['validFrom_time_t'], $info['validTo_time_t'], $info['serialNumberHex']);
+		$subjectAltNames = [];
+		if (isset($info['extensions']) && is_array($info['extensions']) && is_string($info['extensions']['subjectAltName'])) {
+			foreach (Preg::split('/[\s,]+/', $info['extensions']['subjectAltName']) as $subjectAltName) {
+				$parts = explode(':', $subjectAltName, 2);
+				if (isset($parts[1])) {
+					$subjectAltNames[] = $parts[1];
+				}
+			}
+		}
+		return new OpenSslX509ParseResult($commonName, $subjectAltNames, $info['validFrom_time_t'], $info['validTo_time_t'], $info['serialNumberHex']);
 	}
 
 }

--- a/app/src/Tls/OpenSslX509ParseResult.php
+++ b/app/src/Tls/OpenSslX509ParseResult.php
@@ -6,8 +6,12 @@ namespace MichalSpacekCz\Tls;
 final readonly class OpenSslX509ParseResult
 {
 
+	/**
+	 * @param list<string>|null $subjectAlternativeNames
+	 */
 	public function __construct(
 		private ?string $commonName,
+		private ?array $subjectAlternativeNames,
 		private int $validFromTimeT,
 		private int $validToTimeT,
 		private string $serialNumberHex,
@@ -18,6 +22,15 @@ final readonly class OpenSslX509ParseResult
 	public function getCommonName(): ?string
 	{
 		return $this->commonName;
+	}
+
+
+	/**
+	 * @return list<string>|null
+	 */
+	public function getSubjectAlternativeNames(): ?array
+	{
+		return $this->subjectAlternativeNames;
 	}
 
 

--- a/app/tests/Tls/CertificateFactoryTest.phpt
+++ b/app/tests/Tls/CertificateFactoryTest.phpt
@@ -81,7 +81,7 @@ final class CertificateFactoryTest extends TestCase
 		$certificate = $this->certificateFactory->fromDatabaseRow($row);
 		Assert::same('foo.example', $certificate->getCertificateName());
 		Assert::same('cn.example', $certificate->getCommonName());
-		Assert::same('ec', $certificate->getCertificateNameExt());
+		Assert::same('ec', $certificate->getCertificateNameExtension());
 		Assert::same(1601870582, $certificate->getNotBefore()->getTimestamp());
 		Assert::same('UTC', $certificate->getNotBefore()->getTimezone()->getName());
 		Assert::same(1636204392, $certificate->getNotAfter()->getTimestamp());

--- a/app/tests/Tls/CertificateFactoryTest.phpt
+++ b/app/tests/Tls/CertificateFactoryTest.phpt
@@ -30,17 +30,19 @@ final class CertificateFactoryTest extends TestCase
 			'certificate_name',
 			'certificate_name-ext',
 			null,
+			['cert.example', 'www.cert.example'],
 			new DateTimeImmutable('-2 weeks'),
 			new DateTimeImmutable('+3 weeks'),
 			3,
 			'CafeCe37',
 		);
-		/** @var array{certificateName:string, certificateNameExt:string|null, cn:string|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string} $array */
+		/** @var array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string} $array */
 		$array = Json::decode(Json::encode($expected), forceArrays: true);
 		$certificate = $this->certificateFactory->get(
 			$array['certificateName'],
 			$array['certificateNameExt'],
 			$array['cn'],
+			$array['san'],
 			$array['notBefore'],
 			$array['notBeforeTz'],
 			$array['notAfter'],
@@ -73,6 +75,7 @@ final class CertificateFactoryTest extends TestCase
 		$row->certificateName = 'foo.example';
 		$row->certificateNameExt = 'ec';
 		$row->cn = 'cn.example';
+		$row->san = '["foo.example","www.foo.example"]';
 		$row->notBefore = new DateTime('2020-10-05 04:03:02');
 		$row->notBeforeTimezone = 'UTC';
 		$row->notAfter = new DateTime('2021-11-06 14:13:12');
@@ -81,6 +84,7 @@ final class CertificateFactoryTest extends TestCase
 		$certificate = $this->certificateFactory->fromDatabaseRow($row);
 		Assert::same('foo.example', $certificate->getCertificateName());
 		Assert::same('cn.example', $certificate->getCommonName());
+		Assert::same(['foo.example', 'www.foo.example'], $certificate->getSubjectAlternativeNames());
 		Assert::same('ec', $certificate->getCertificateNameExtension());
 		Assert::same(1601870582, $certificate->getNotBefore()->getTimestamp());
 		Assert::same('UTC', $certificate->getNotBefore()->getTimezone()->getName());
@@ -88,8 +92,14 @@ final class CertificateFactoryTest extends TestCase
 		Assert::same('Europe/Prague', $certificate->getNotAfter()->getTimezone()->getName());
 
 		$row->cn = null;
+		$row->san = '[]';
 		$certificate = $this->certificateFactory->fromDatabaseRow($row);
 		Assert::null($certificate->getCommonName());
+		Assert::same([], $certificate->getSubjectAlternativeNames());
+
+		$row->san = null;
+		$certificate = $this->certificateFactory->fromDatabaseRow($row);
+		Assert::null($certificate->getSubjectAlternativeNames());
 	}
 
 }

--- a/app/tests/Tls/CertificatesTest.phpt
+++ b/app/tests/Tls/CertificatesTest.phpt
@@ -47,14 +47,15 @@ final class CertificatesTest extends TestCase
 	public function testLog(): void
 	{
 		$this->database->setDefaultInsertId('42');
-		$certificate = new Certificate('foo.example', null, $this->notBefore, $this->notAfter, 0, null);
+		$certificate = new Certificate('foo.example', null, 'cn.example', $this->notBefore, $this->notAfter, 0, null);
 		$this->certificates->log($certificate);
 		$params = $this->database->getParamsArrayForQuery('INSERT INTO certificate_requests');
 		Assert::count(1, $params);
-		Assert::same('foo.example', $params[0]['cn']);
+		Assert::same('foo.example', $params[0]['certificate_name']);
+		Assert::same('cn.example', $params[0]['cn']);
 		Assert::true($params[0]['success']);
 		foreach ($params as $values) {
-			Assert::null($values['ext']);
+			Assert::null($values['certificate_name_ext']);
 			Assert::hasKey('time', $values);
 			Assert::hasKey('time_timezone', $values);
 		}
@@ -73,7 +74,7 @@ final class CertificatesTest extends TestCase
 	{
 		$exception = new DriverException();
 		$this->database->willThrow($exception);
-		$certificate = new Certificate('foo.example', null, $this->notBefore, $this->notAfter, 0, null);
+		$certificate = new Certificate('foo.example', null, null, $this->notBefore, $this->notAfter, 0, null);
 		Assert::exception(function () use ($certificate): void {
 			$this->certificates->log($certificate);
 		}, SomeCertificatesLoggedToFileException::class, 'Error logging to database, some certificates logged to file instead');

--- a/app/tests/Tls/CertificatesTest.phpt
+++ b/app/tests/Tls/CertificatesTest.phpt
@@ -47,7 +47,7 @@ final class CertificatesTest extends TestCase
 	public function testLog(): void
 	{
 		$this->database->setDefaultInsertId('42');
-		$certificate = new Certificate('foo.example', null, 'cn.example', $this->notBefore, $this->notAfter, 0, null);
+		$certificate = new Certificate('foo.example', null, 'cn.example', [], $this->notBefore, $this->notAfter, 0, null);
 		$this->certificates->log($certificate);
 		$params = $this->database->getParamsArrayForQuery('INSERT INTO certificate_requests');
 		Assert::count(1, $params);
@@ -74,7 +74,7 @@ final class CertificatesTest extends TestCase
 	{
 		$exception = new DriverException();
 		$this->database->willThrow($exception);
-		$certificate = new Certificate('foo.example', null, null, $this->notBefore, $this->notAfter, 0, null);
+		$certificate = new Certificate('foo.example', null, null, null, $this->notBefore, $this->notAfter, 0, null);
 		Assert::exception(function () use ($certificate): void {
 			$this->certificates->log($certificate);
 		}, SomeCertificatesLoggedToFileException::class, 'Error logging to database, some certificates logged to file instead');

--- a/app/tests/Tls/OpenSslTest.phpt
+++ b/app/tests/Tls/OpenSslTest.phpt
@@ -22,7 +22,13 @@ final class OpenSslTest extends TestCase
 		if ($certificate === false) {
 			Assert::fail('Cannot read ' . $file);
 		} else {
-			$expected = new OpenSslX509ParseResult('michalspacek.cz', 1682947521, 1690723520, '03F3ABC4EB1C13E0D4447CA61298423C0F02');
+			$expected = new OpenSslX509ParseResult(
+				'michalspacek.cz',
+				['admin.michalspacek.cz', 'api.michalspacek.cz', 'heartbleed.michalspacek.cz', 'michalspacek.com', 'michalspacek.cz', 'pulse.michalspacek.cz', 'upc.michalspacek.cz', 'www.michalspacek.com', 'www.michalspacek.cz'],
+				1682947521,
+				1690723520,
+				'03F3ABC4EB1C13E0D4447CA61298423C0F02',
+			);
 			Assert::equal($expected, OpenSsl::x509parse($certificate));
 		}
 	}
@@ -32,7 +38,7 @@ final class OpenSslTest extends TestCase
 	{
 		$certificate = file_get_contents(__DIR__ . '/certificate-no-cn.pem');
 		assert(is_string($certificate));
-		$expected = new OpenSslX509ParseResult(null, 1755987576, 1763763575, '06A43647CC3124AC82F42FA8957F5D9972B6');
+		$expected = new OpenSslX509ParseResult(null, ['snafu.cz', 'www.snafu.cz'], 1755987576, 1763763575, '06A43647CC3124AC82F42FA8957F5D9972B6');
 		Assert::equal($expected, OpenSsl::x509parse($certificate));
 	}
 


### PR DESCRIPTION
Some certs may be missing the CN field (when issued with for example the Let's Encrypt's tlsserver [profile](https://letsencrypt.org/docs/profiles/)) so it's nice if I could tell which certificate is which.

The SAN field will be populated gradually as the Certbot hook (#542) reports them over the next few months.