### PR TITLE
Set the session handler additional data (i.e. user id) whenever available

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -164,6 +164,7 @@ services:
 	- MichalSpacekCz\UpcKeys\UpcKeys(routers: [@MichalSpacekCz\UpcKeys\Technicolor, @MichalSpacekCz\UpcKeys\Ubee])
 	- MichalSpacekCz\UpcKeys\UpcKeysStorageConversions
 	- MichalSpacekCz\User\Manager(passwordEncryption: @passwordEncryption, permanentLoginInterval: %permanentLogin.interval%)
+	- MichalSpacekCz\User\UserSessionAdditionalData
 	- MichalSpacekCz\Utils\Strings
 	- MichalSpacekCz\Utils\JsonUtils
 	- Nette\Bridges\ApplicationLatte\TemplateFactory

--- a/app/src/Application/WebApplication.php
+++ b/app/src/Application/WebApplication.php
@@ -7,11 +7,10 @@ use MichalSpacekCz\EasterEgg\CrLfUrlInjections;
 use MichalSpacekCz\Http\ContentSecurityPolicy\CspValues;
 use MichalSpacekCz\Http\FetchMetadata\ResourceIsolationPolicy;
 use MichalSpacekCz\Http\SecurityHeaders;
+use MichalSpacekCz\User\UserSessionAdditionalData;
 use Nette\Application\Application;
 use Nette\Http\IRequest;
 use Nette\Http\IResponse;
-use Nette\Security\User;
-use Spaze\Session\MysqlSessionHandler;
 
 final readonly class WebApplication
 {
@@ -23,8 +22,7 @@ final readonly class WebApplication
 		private Application $application,
 		private CrLfUrlInjections $crLfUrlInjections,
 		private ResourceIsolationPolicy $resourceIsolationPolicy,
-		private User $user,
-		private MysqlSessionHandler $sessionHandler,
+		private UserSessionAdditionalData $userSessionAdditionalData,
 		private string $fqdn,
 	) {
 	}
@@ -38,18 +36,7 @@ final readonly class WebApplication
 		$this->application->onResponse[] = function (): void {
 			$this->securityHeaders->sendHeaders();
 		};
-
-		$this->user->onLoggedIn[] = function (User $user): void {
-			$identity = $user->getIdentity();
-			if ($identity !== null) {
-				$this->sessionHandler->setAdditionalData('key_user', $identity->getId());
-			}
-		};
-		$this->user->onLoggedOut[] = function (): void {
-			$this->sessionHandler->setAdditionalData('key_user', null);
-		};
-
-
+		$this->userSessionAdditionalData->init();
 		$this->application->run();
 	}
 

--- a/app/src/User/UserSessionAdditionalData.php
+++ b/app/src/User/UserSessionAdditionalData.php
@@ -1,0 +1,36 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User;
+
+use Nette\Security\User;
+use Spaze\Session\MysqlSessionHandler;
+
+final readonly class UserSessionAdditionalData
+{
+
+	public function __construct(
+		private User $user,
+		private MysqlSessionHandler $sessionHandler,
+	) {
+	}
+
+
+	public function init(): void
+	{
+		$identity = $this->user->getIdentity();
+		if ($identity !== null) {
+			$this->sessionHandler->setAdditionalData('key_user', $identity->getId());
+		}
+		$this->user->onLoggedIn[] = function (User $user): void {
+			$identity = $user->getIdentity();
+			if ($identity !== null) {
+				$this->sessionHandler->setAdditionalData('key_user', $identity->getId());
+			}
+		};
+		$this->user->onLoggedOut[] = function (): void {
+			$this->sessionHandler->setAdditionalData('key_user', null);
+		};
+	}
+
+}

--- a/app/tests/User/UserSessionAdditionalDataTest.phpt
+++ b/app/tests/User/UserSessionAdditionalDataTest.phpt
@@ -1,0 +1,72 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+/** @noinspection PhpDynamicFieldDeclarationInspection */
+/** @noinspection PhpUndefinedFieldInspection */
+declare(strict_types = 1);
+
+namespace User;
+
+use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\Security\NullUserStorage;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\UserSessionAdditionalData;
+use Nette\Security\SimpleIdentity;
+use Nette\Security\User;
+use Override;
+use Spaze\Session\MysqlSessionHandler;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class UserSessionAdditionalDataTest extends TestCase
+{
+
+	public function __construct(
+		private readonly UserSessionAdditionalData $userSessionAdditionalData,
+		private readonly User $user,
+		private readonly MysqlSessionHandler $sessionHandler,
+		private readonly NullUserStorage $userStorage,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->user->refreshStorage();
+		$this->userStorage->clearAuthentication(true);
+		PrivateProperty::setValue($this->sessionHandler, 'additionalData', []);
+	}
+
+
+	public function testInit(): void
+	{
+		$this->userSessionAdditionalData->init();
+		Assert::same([], PrivateProperty::getValue($this->sessionHandler, 'additionalData'));
+	}
+
+
+	public function testInitOnLoggedInOnLoggedOut(): void
+	{
+		$this->userSessionAdditionalData->init();
+		$this->user->login(new SimpleIdentity(1337));
+		Assert::same(['key_user' => 1337], PrivateProperty::getValue($this->sessionHandler, 'additionalData'));
+
+		$this->user->logout();
+		Assert::same(['key_user' => null], PrivateProperty::getValue($this->sessionHandler, 'additionalData'));
+	}
+
+
+	public function testInitAlreadyLoggedIn(): void
+	{
+		PrivateProperty::setValue($this->user, 'identity', new SimpleIdentity(1336));
+		PrivateProperty::setValue($this->user, 'authenticated', true);
+		$this->userSessionAdditionalData->init();
+		Assert::same(['key_user' => 1336], PrivateProperty::getValue($this->sessionHandler, 'additionalData'));
+	}
+
+}
+
+TestCaseRunner::run(UserSessionAdditionalDataTest::class);


### PR DESCRIPTION
Because when the session is regenerated, the old one is deleted in `Nette\Http\Session::regenerateId()`, which means the whole row is deleted in `Spaze\Session\MysqlSessionHandler::destroy()` and then when a new row is inserted again, it doesn't have the user id, because it was set only in logged in/out event handlers.

Follow-up to #549