### PR TITLE
A script to clean old stale session rows

### DIFF
--- a/app/bin/clean_sessions.php
+++ b/app/bin/clean_sessions.php
@@ -1,0 +1,25 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types = 1);
+
+/**
+ * Deletes stale session database rows.
+ * Run daily or so, depends on the session expiry times, using cron or systemd timers.
+ */
+
+namespace MichalSpacekCz\Bin;
+
+use MichalSpacekCz\Application\Bootstrap;
+use MichalSpacekCz\Application\Cli\NoCliArgs;
+use Spaze\Session\MysqlSessionHandler;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$sessionHandler = Bootstrap::bootCli(NoCliArgs::class)->getByType(MysqlSessionHandler::class);
+$rows = $sessionHandler->gc(24 * 60 * 60);
+if ($rows === false) {
+	echo "Oops, something went wrong\n";
+	exit(1);
+}
+echo "Number of stale sessions deleted: {$rows}\n";
+exit(0);


### PR DESCRIPTION
Due to the database session handler, this has to be handled manually, the session cleaner which comes prepackaged with the PHP packages won't handle it.