### PR TITLE
Send all output from `clean_sessions.php` to logger

### DIFF
--- a/app/bin/clean_sessions.php
+++ b/app/bin/clean_sessions.php
@@ -12,14 +12,20 @@ namespace MichalSpacekCz\Bin;
 use MichalSpacekCz\Application\Bootstrap;
 use MichalSpacekCz\Application\Cli\NoCliArgs;
 use Spaze\Session\MysqlSessionHandler;
+use Throwable;
+use Tracy\Debugger;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$sessionHandler = Bootstrap::bootCli(NoCliArgs::class)->getByType(MysqlSessionHandler::class);
-$rows = $sessionHandler->gc(24 * 60 * 60);
-if ($rows === false) {
-	echo "Oops, something went wrong\n";
-	exit(1);
+try {
+	$sessionHandler = Bootstrap::bootCli(NoCliArgs::class)->getByType(MysqlSessionHandler::class);
+	$rows = $sessionHandler->gc(24 * 60 * 60);
+	if ($rows === false) {
+		Debugger::log(sprintf('Something went wrong, %s::gc() returned false', $sessionHandler::class), Debugger::ERROR);
+		exit(1);
+	}
+	exit(0);
+} catch (Throwable $e) {
+	Debugger::log($e);
+	exit(2);
 }
-echo "Number of stale sessions deleted: {$rows}\n";
-exit(0);


### PR DESCRIPTION
Cron doesn't log output, tries to send it via email and I have no MTAs installed on the servers, and even if I would have, or when cron would create logs, I think the app logs are a better place.

Follow-up to #567.