### PR TITLE
Run `clean_sessions.php` from user `ubuntu` crontab

### DIFF
--- a/app/bin/clean_sessions.php
+++ b/app/bin/clean_sessions.php
@@ -3,8 +3,10 @@
 declare(strict_types = 1);
 
 /**
- * Deletes stale session database rows.
- * Run daily or so, depends on the session expiry times, using cron or systemd timers.
+ * Deletes stale session rows from the database.
+ *
+ * - Run daily or hourly via cron or a systemd timer (adjust the frequency to session expiry)
+ * - Execute as the web app user, e.g.: `sudo runuser --user www-data /path/to/clean_sessions.php`
  */
 
 namespace MichalSpacekCz\Bin;

--- a/conf/cron/clean_sessions_michalspacek_cz
+++ b/conf/cron/clean_sessions_michalspacek_cz
@@ -1,3 +1,0 @@
-# Look for and purge old database sessions every 30 minutes
-# Symlink this file to /etc/cron.d
-12,42 * * * * www-user /srv/www/michalspacek.cz/app/bin/clean_sessions.php


### PR DESCRIPTION
Running scripts from `/etc/cron.d` requires the script to be owned by `root`, which `clean_sessions.php` is obviously not. So it would require a tiny wrapper that would need to be set up manually anyway, and in that case, I can already go with setting the crontab manually, which is what I've went with. Another advantage is that everything is set up in ubuntu's home dir and not in `/etc`.

Follow-up to #567, partially supersedes #572.