### PR TITLE
Bump shivammathur/setup-php from 2.35.4 to 2.35.5

### DIFF
--- a/.github/workflows/php-tester-include-skipped.yml
+++ b/.github/workflows/php-tester-include-skipped.yml
@@ -17,7 +17,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: pcov
         php-version: ${{ matrix.php-version }}

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
     - name: OS info
       run: cat /etc/os-release
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -52,7 +52,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -72,7 +72,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -86,7 +86,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -100,7 +100,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -127,7 +127,7 @@ jobs:
       with:
         path: ${{ steps.phpcs-cache.outputs.file }}
         key: phpcs-cache-php${{ matrix.php-version }}
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -148,7 +148,7 @@ jobs:
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}
         key: phpstan-cache-php${{ matrix.php-version }}
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -169,7 +169,7 @@ jobs:
       with:
         path: ${{ steps.phpstan-cache.outputs.dir }}
         key: phpstan-vendor-cache-php${{ matrix.php-version }}
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}
@@ -183,7 +183,7 @@ jobs:
           - "8.4"
     steps:
     - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: pcov
         php-version: ${{ matrix.php-version }}
@@ -211,7 +211,7 @@ jobs:
           - "8.4"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+      - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
         with:
           coverage: none
           php-version: ${{ matrix.php-version }}
@@ -225,7 +225,7 @@ jobs:
           - "8.4"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+      - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
         with:
           coverage: none
           php-version: ${{ matrix.php-version }}

--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -21,7 +21,7 @@ jobs:
           - www.michalspacek.com
           - upcwifikeys.com
     steps:
-    - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+    - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
       with:
         coverage: none
         php-version: ${{ matrix.php-version }}

--- a/.github/workflows/tls.yml
+++ b/.github/workflows/tls.yml
@@ -57,7 +57,7 @@ jobs:
           - "8.4"
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-      - uses: shivammathur/setup-php@ec406be512d7077f68eed36e63f4d91bc006edc4 # v2
+      - uses: shivammathur/setup-php@bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f # v2
         with:
           coverage: none
           php-version: ${{ matrix.php-version }}


### PR DESCRIPTION
_Supersedes #574 where the bot seems unbothered._

Bumps [shivammathur/setup-php](https://github.com/shivammathur/setup-php) from 2.35.4 to 2.35.5.
- [Release notes](https://github.com/shivammathur/setup-php/releases)
- [Commits](https://github.com/shivammathur/setup-php/compare/ec406be512d7077f68eed36e63f4d91bc006edc4...bf6b4fbd49ca58e4608c9c89fba0b8d90bd2a39f)

---
updated-dependencies:
- dependency-name: shivammathur/setup-php dependency-version: 2.35.5 dependency-type: direct:production update-type: version-update:semver-patch ...