### PR TITLE
Update packages

### DIFF
--- a/app/composer.lock
+++ b/app/composer.lock
@@ -2432,12 +2432,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/security-txt.git",
-                "reference": "d6d3552c02969e7a0f3c3e7443da2ad046f005a0"
+                "reference": "01562512d74a05384b25f9b5c539d2e8eee5cd23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/security-txt/zipball/d6d3552c02969e7a0f3c3e7443da2ad046f005a0",
-                "reference": "d6d3552c02969e7a0f3c3e7443da2ad046f005a0",
+                "url": "https://api.github.com/repos/spaze/security-txt/zipball/01562512d74a05384b25f9b5c539d2e8eee5cd23",
+                "reference": "01562512d74a05384b25f9b5c539d2e8eee5cd23",
                 "shasum": ""
             },
             "require-dev": {
@@ -2480,7 +2480,7 @@
                 "issues": "https://github.com/spaze/security-txt/issues",
                 "source": "https://github.com/spaze/security-txt/tree/main"
             },
-            "time": "2025-09-25T23:33:20+00:00"
+            "time": "2025-09-27T01:00:35+00:00"
         },
         {
             "name": "spaze/sri-macros",
@@ -4101,21 +4101,21 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.6",
+            "version": "2.0.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094"
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/f9f77efa9de31992a832ff77ea52eb42d675b094",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0.4"
+                "phpstan/phpstan": "^2.1.29"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -4143,9 +4143,9 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
             },
-            "time": "2025-07-21T12:19:29+00:00"
+            "time": "2025-09-26T11:19:08+00:00"
         },
         {
             "name": "psalm/phar",

--- a/app/vendor/composer/installed.json
+++ b/app/vendor/composer/installed.json
@@ -2501,22 +2501,22 @@
         },
         {
             "name": "phpstan/phpstan-strict-rules",
-            "version": "2.0.6",
-            "version_normalized": "2.0.6.0",
+            "version": "2.0.7",
+            "version_normalized": "2.0.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-strict-rules.git",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094"
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/f9f77efa9de31992a832ff77ea52eb42d675b094",
-                "reference": "f9f77efa9de31992a832ff77ea52eb42d675b094",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/d6211c46213d4181054b3d77b10a5c5cb0d59538",
+                "reference": "d6211c46213d4181054b3d77b10a5c5cb0d59538",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0",
-                "phpstan/phpstan": "^2.0.4"
+                "phpstan/phpstan": "^2.1.29"
             },
             "require-dev": {
                 "php-parallel-lint/php-parallel-lint": "^1.2",
@@ -2524,7 +2524,7 @@
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpunit/phpunit": "^9.6"
             },
-            "time": "2025-07-21T12:19:29+00:00",
+            "time": "2025-09-26T11:19:08+00:00",
             "type": "phpstan-extension",
             "extra": {
                 "phpstan": {
@@ -2546,7 +2546,7 @@
             "description": "Extra strict and opinionated rules for PHPStan",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
-                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.6"
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/2.0.7"
             },
             "install-path": "../phpstan/phpstan-strict-rules"
         },
@@ -4433,12 +4433,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/spaze/security-txt.git",
-                "reference": "d6d3552c02969e7a0f3c3e7443da2ad046f005a0"
+                "reference": "01562512d74a05384b25f9b5c539d2e8eee5cd23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spaze/security-txt/zipball/d6d3552c02969e7a0f3c3e7443da2ad046f005a0",
-                "reference": "d6d3552c02969e7a0f3c3e7443da2ad046f005a0",
+                "url": "https://api.github.com/repos/spaze/security-txt/zipball/01562512d74a05384b25f9b5c539d2e8eee5cd23",
+                "reference": "01562512d74a05384b25f9b5c539d2e8eee5cd23",
                 "shasum": ""
             },
             "require-dev": {
@@ -4456,7 +4456,7 @@
             "suggest": {
                 "ext-gnupg": "Needed to verify and create signatures"
             },
-            "time": "2025-09-25T23:33:20+00:00",
+            "time": "2025-09-27T01:00:35+00:00",
             "default-branch": true,
             "bin": [
                 "bin/checksecuritytxt.php"

--- a/app/vendor/composer/installed.php
+++ b/app/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '47bf3f73dfe5accfe0c997a9969f0d741ea0ca8c',
+        'reference' => '4757ba299359c6cbe525816604d451e3be82b2c8',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -392,9 +392,9 @@
             'dev_requirement' => true,
         ),
         'phpstan/phpstan-strict-rules' => array(
-            'pretty_version' => '2.0.6',
-            'version' => '2.0.6.0',
-            'reference' => 'f9f77efa9de31992a832ff77ea52eb42d675b094',
+            'pretty_version' => '2.0.7',
+            'version' => '2.0.7.0',
+            'reference' => 'd6211c46213d4181054b3d77b10a5c5cb0d59538',
             'type' => 'phpstan-extension',
             'install_path' => __DIR__ . '/../phpstan/phpstan-strict-rules',
             'aliases' => array(),
@@ -522,7 +522,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '47bf3f73dfe5accfe0c997a9969f0d741ea0ca8c',
+            'reference' => '4757ba299359c6cbe525816604d451e3be82b2c8',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),
@@ -585,7 +585,7 @@
         'spaze/security-txt' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => 'd6d3552c02969e7a0f3c3e7443da2ad046f005a0',
+            'reference' => '01562512d74a05384b25f9b5c539d2e8eee5cd23',
             'type' => 'library',
             'install_path' => __DIR__ . '/../spaze/security-txt',
             'aliases' => array(

--- a/app/vendor/phpstan/phpstan-strict-rules/README.md
+++ b/app/vendor/phpstan/phpstan-strict-rules/README.md
@@ -13,14 +13,12 @@
 | `numericOperandsInArithmeticOperators` | Require numeric operand in `+$var`, `-$var`, `$var++`, `$var--`, `++$var` and `--$var`. |
 | `numericOperandsInArithmeticOperators` | Require numeric operand in `$var++`, `$var--`, `++$var`and `--$var`.                                    |
 | `strictFunctionCalls`                  | These functions contain a `$strict` parameter for better type safety, it must be set to `true`:<br>* `in_array` (3rd parameter)<br>* `array_search` (3rd parameter)<br>* `array_keys` (3rd parameter; only if the 2nd parameter `$search_value` is provided)<br>* `base64_decode` (2nd parameter). |
-| `overwriteVariablesWithLoop`           | Variables assigned in `while` loop condition and `for` loop initial assignment cannot be used after the loop.  |
-| `overwriteVariablesWithLoop`           | Variables set in foreach that's always looped thanks to non-empty arrays cannot be used after the loop. |
+| `overwriteVariablesWithLoop`           | * Disallow overwriting variables with `foreach` key and value variables.<br>* Disallow overwriting variables with `for` loop initial assignment.                                                                   |
 | `switchConditionsMatchingType`         | Types in `switch` condition and `case` value must match. PHP compares them loosely by default and that can lead to  unexpected results. |
 | `dynamicCallOnStaticMethod`            | Check that statically declared methods are called statically.                                           |
 | `disallowedEmpty`                      | Disallow `empty()` - it's a very loose comparison (see [manual](https://php.net/empty)), it's recommended to use more  strict one. |
 | `disallowedShortTernary`               | Disallow short ternary operator (`?:`) - implies weak comparison, it's recommended to use null coalesce operator (`??`)  or ternary operator with strict condition. |
 | `noVariableVariables`                  | Disallow variable variables (`$$foo`, `$this->$method()` etc.).                                         |
-| `overwriteVariablesWithLoop`           | Disallow overwriting variables with foreach key and value variables.                                    |
 | `checkAlwaysTrueInstanceof`, `checkAlwaysTrueCheckTypeFunctionCall`, `checkAlwaysTrueStrictComparison` | Always true `instanceof`, type-checking `is_*` functions and strict comparisons `===`/`!==`. These checks can be turned off by setting `checkAlwaysTrueInstanceof`, `checkAlwaysTrueCheckTypeFunctionCall` and `checkAlwaysTrueStrictComparison` to false. |
 |                                        | Correct case for referenced and called function names.                                                  |
 | `matchingInheritedMethodNames`         | Correct case for inherited and implemented method names.                                                |

--- a/app/vendor/phpstan/phpstan-strict-rules/composer.json
+++ b/app/vendor/phpstan/phpstan-strict-rules/composer.json
@@ -7,7 +7,7 @@
 	],
 	"require": {
 		"php": "^7.4 || ^8.0",
-		"phpstan/phpstan": "^2.0.4"
+		"phpstan/phpstan": "^2.1.29"
 	},
 	"require-dev": {
 		"php-parallel-lint/php-parallel-lint": "^1.2",

--- a/app/vendor/phpstan/phpstan-strict-rules/rules.neon
+++ b/app/vendor/phpstan/phpstan-strict-rules/rules.neon
@@ -11,6 +11,7 @@ parameters:
 	reportStaticMethodSignatures: true
 	reportMaybesInPropertyPhpDocTypes: true
 	reportWrongPhpDocTypeInVarTag: true
+	checkStrictPrintfPlaceholderTypes: true
 	strictRules:
 		allRules: true
 		disallowedLooseComparison: %strictRules.allRules%

--- a/app/vendor/phpstan/phpstan-strict-rules/src/Rules/Classes/RequireParentConstructCallRule.php
+++ b/app/vendor/phpstan/phpstan-strict-rules/src/Rules/Classes/RequireParentConstructCallRule.php
@@ -104,26 +104,27 @@ class RequireParentConstructCallRule implements Rule
 	 */
 	private function getParentConstructorClass($classReflection)
 	{
-		while ($classReflection->getParentClass() !== false) {
-			$constructor = $classReflection->getParentClass()->hasMethod('__construct') ? $classReflection->getParentClass()->getMethod('__construct') : null;
-			$constructorWithClassName = $classReflection->getParentClass()->hasMethod($classReflection->getParentClass()->getName()) ? $classReflection->getParentClass()->getMethod($classReflection->getParentClass()->getName()) : null;
+		$parentClass = $classReflection->getParentClass();
+		while ($parentClass !== false) {
+			$constructor = $parentClass->hasMethod('__construct') ? $parentClass->getMethod('__construct') : null;
+			$constructorWithClassName = $parentClass->hasMethod($parentClass->getName()) ? $parentClass->getMethod($parentClass->getName()) : null;
 			if (
 				(
 					$constructor !== null
-					&& $constructor->getDeclaringClass()->getName() === $classReflection->getParentClass()->getName()
+					&& $constructor->getDeclaringClass()->getName() === $parentClass->getName()
 					&& !$constructor->isAbstract()
 					&& !$constructor->isPrivate()
 					&& !$constructor->isDeprecated()
 				) || (
 					$constructorWithClassName !== null
-					&& $constructorWithClassName->getDeclaringClass()->getName() === $classReflection->getParentClass()->getName()
+					&& $constructorWithClassName->getDeclaringClass()->getName() === $parentClass->getName()
 					&& !$constructorWithClassName->isAbstract()
 				)
 			) {
-				return $classReflection->getParentClass();
+				return $parentClass;
 			}
 
-			$classReflection = $classReflection->getParentClass();
+			$parentClass = $parentClass->getParentClass();
 		}
 
 		return false;

--- a/app/vendor/spaze/security-txt/src/Fetcher/SecurityTxtFetcher.php
+++ b/app/vendor/spaze/security-txt/src/Fetcher/SecurityTxtFetcher.php
@@ -201,7 +201,9 @@ final class SecurityTxtFetcher
 			if ($topLevelContents === null) {
 				throw new LogicException('This should not happen');
 			}
-			$warnings[] = new SecurityTxtTopLevelDiffers($wellKnownContents, $topLevelContents);
+			if ($wellKnown->getFinalUrl() !== $topLevel->getFinalUrl()) {
+				$warnings[] = new SecurityTxtTopLevelDiffers($wellKnownContents, $topLevelContents);
+			}
 			$result = $wellKnown;
 			$contents = $wellKnownContents;
 		} else {


### PR DESCRIPTION
 - phpstan/phpstan-strict-rules updated from 2.0.6 to 2.0.7 patch
   See changes: https://github.com/phpstan/phpstan-strict-rules/compare/2.0.6...2.0.7
   Release notes: https://github.com/phpstan/phpstan-strict-rules/releases/tag/2.0.7

 - spaze/security-txt updated from dev-main@d6d3552 to dev-main@0156251
   See changes: https://github.com/spaze/security-txt/compare/d6d3552...0156251