### PR TITLE
Split the cert to smaller certs

### DIFF
--- a/conf/nginx/prod-https-admin.michalspacek.cz.conf
+++ b/conf/nginx/prod-https-admin.michalspacek.cz.conf
@@ -1,0 +1,6 @@
+include /srv/www/michalspacek.cz/conf/nginx/common-https.conf;
+ssl_certificate /etc/letsencrypt/live/admin.michalspacek.cz/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/admin.michalspacek.cz/privkey.pem;
+
+ssl_stapling on;
+resolver 8.8.8.8 8.8.4.4;

--- a/conf/nginx/prod-https-upc.michalspacek.cz.conf
+++ b/conf/nginx/prod-https-upc.michalspacek.cz.conf
@@ -1,0 +1,6 @@
+include /srv/www/michalspacek.cz/conf/nginx/common-https.conf;
+ssl_certificate /etc/letsencrypt/live/upc.michalspacek.cz/fullchain.pem;
+ssl_certificate_key /etc/letsencrypt/live/upc.michalspacek.cz/privkey.pem;
+
+ssl_stapling on;
+resolver 8.8.8.8 8.8.4.4;

--- a/conf/nginx/prod-michalspacek.cz.conf
+++ b/conf/nginx/prod-michalspacek.cz.conf
@@ -151,7 +151,7 @@ server {
     listen [::]:443 ssl;
     http2 on;
     server_name admin.michalspacek.cz;
-    include /srv/www/michalspacek.cz/conf/nginx/prod-https-michalspacek.cz.conf;
+    include /srv/www/michalspacek.cz/conf/nginx/prod-https-admin.michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-admin.michalspacek.cz.conf;
     location = /app.php {
         include /srv/www/michalspacek.cz/conf/nginx/prod-php.conf;
@@ -175,7 +175,7 @@ server {
     listen [::]:443 ssl;
     http2 on;
     server_name heartbleed.michalspacek.cz;
-    include /srv/www/michalspacek.cz/conf/nginx/prod-https-michalspacek.cz.conf;
+    include /srv/www/michalspacek.cz/conf/nginx/prod-https-upc.michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-heartbleed.michalspacek.cz.conf;
     location = /app.php {
         include /srv/www/michalspacek.cz/conf/nginx/prod-php.conf;
@@ -213,7 +213,7 @@ server {
     listen [::]:443 ssl;
     http2 on;
     server_name upc.michalspacek.cz;
-    include /srv/www/michalspacek.cz/conf/nginx/prod-https-michalspacek.cz.conf;
+    include /srv/www/michalspacek.cz/conf/nginx/prod-https-upc.michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-upcwifikeys.com.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
     return 301 https://upcwifikeys.com$request_uri;


### PR DESCRIPTION
The idea is to have a certificate that covers `admin.m(ichalspacek).c(z)`, another one that covers `www.m.c`, and another one that's used for the old redirected subdomains (like `upc.m.c` and `heartbleed.m.c`). Some subdomains are duplicated across multiple certificates to leverage HTTP/2's certificate validation that's skipped if the cert covers the target subdomain and the DNS resolves to the same IP as the currently loaded URL.