### PR TITLE
Handle empty certificates in the HTTPS certificate logger

### DIFF
--- a/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
+++ b/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
@@ -46,7 +46,7 @@ final class CertificatesPresenter extends BasePresenter
 	public function actionLogIssued(): void
 	{
 		$string = $this->httpInput->getPostString('certificate');
-		if ($string === null) {
+		if ($string === null || $string === '') {
 			$this->sendJson(['status' => 'error', 'statusMessage' => 'No certificate sent']);
 		}
 		$name = $this->httpInput->getPostString('name');

--- a/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
+++ b/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
@@ -10,6 +10,8 @@ use MichalSpacekCz\Tls\Certificates;
 use MichalSpacekCz\Tls\Exceptions\SomeCertificatesLoggedToFileException;
 use Nette\Security\AuthenticationException;
 use Override;
+use Throwable;
+use Tracy\Debugger;
 
 final class CertificatesPresenter extends BasePresenter
 {
@@ -55,13 +57,16 @@ final class CertificatesPresenter extends BasePresenter
 		try {
 			$cert = $this->certificateFactory->fromString($name, $string);
 			$this->certificates->log($cert);
-			$this->sendJson([
-				'status' => 'ok',
-				'statusMessage' => 'Certificate reported successfully',
-			]);
 		} catch (SomeCertificatesLoggedToFileException) {
 			$this->sendJson(['status' => 'error', 'statusMessage' => 'Some certs logged to file']);
+		} catch (Throwable $e) {
+			Debugger::log($e, Debugger::EXCEPTION);
+			$this->sendJson(['status' => 'error', 'statusMessage' => 'Certificate processing failed']);
 		}
+		$this->sendJson([
+			'status' => 'ok',
+			'statusMessage' => 'Certificate reported successfully',
+		]);
 	}
 
 }


### PR DESCRIPTION
This may happen for example when the certificate file reported with the hook doesn't exist because I've made a typo when calling the hook manually, or something like that.