### PR TITLE
Revert "Add CSP integrity reports to CSS/style-src as well"

### DIFF
--- a/app/config/contentsecuritypolicy.neon
+++ b/app/config/contentsecuritypolicy.neon
@@ -31,7 +31,6 @@ contentSecurityPolicy:
 				- "'sha256-I7m+VqBh+S5t75VVGkOHq12SfWTlXYaAeJSSaMfaqkc='"
 				- %domain.contentSecurityPolicySelf%
 				- "'report-sample'"
-				- "'report-sha256'"
 			frame-ancestors: "'none'"
 			form-action: "'self'"
 			base-uri: "'none'"


### PR DESCRIPTION
The CSP integrity reporting feature seems to be available only for scripts, see https://chromestatus.com/feature/6337535507431424

This reverts commit 989c9bef7e096429fcdf972705cbaf51b13045b0 of #593