### PR TITLE
Disallow the `do` URL signal params to stop bots getting 403s

### DIFF
--- a/app/public/www.michalspacek.com/robots.txt
+++ b/app/public/www.michalspacek.com/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /out/
+Disallow: /*?do=*
 Disallow: /admin
 Disallow: /info.php
 Disallow: /nette.micro

--- a/app/public/www.michalspacek.cz/robots.txt
+++ b/app/public/www.michalspacek.cz/robots.txt
@@ -1,5 +1,6 @@
 User-agent: *
 Disallow: /out/
+Disallow: /*?do=*
 Disallow: /admin
 Disallow: /info.php
 Disallow: /nette.micro


### PR DESCRIPTION
Originally added in commit 06c4314 and then removed in #381, now adding it back again.