### PR TITLE
Resource Isolation Policy logging

### DIFF
--- a/app/src/Http/FetchMetadata/ResourceIsolationPolicy.php
+++ b/app/src/Http/FetchMetadata/ResourceIsolationPolicy.php
@@ -95,17 +95,19 @@ final readonly class ResourceIsolationPolicy
 
 	private function logRequest(Presenter $presenter): void
 	{
+		$placeholder = '[not sent]';
 		$headers = [];
 		foreach ($this->fetchMetadata->getAllHeaders() as $header => $value) {
-			$headers[] = sprintf('%s: %s', $header, $value ?? '[not sent]');
+			$headers[] = sprintf('%s: %s', $header, $value ?? $placeholder);
 		}
 		$message = sprintf(
-			'%s %s; action: %s; param names: %s; headers: %s',
+			'%s %s; action: %s; param names: %s; headers: %s; user agent: %s',
 			$this->httpRequest->getMethod(),
 			$this->httpRequest->getUrl()->getAbsoluteUrl(),
 			$presenter->getAction(true),
 			implode(', ', array_keys($presenter->getParameters())),
 			implode(', ', $headers),
+			$this->httpRequest->getHeader('User-Agent') ?? $placeholder,
 		);
 		Debugger::log($message, 'cross-site');
 	}

--- a/app/src/Test/Http/Request.php
+++ b/app/src/Test/Http/Request.php
@@ -239,4 +239,10 @@ final class Request implements IRequest
 		$this->sameSite = $sameSite;
 	}
 
+
+	public function resetHeaders(): void
+	{
+		$this->headers = [];
+	}
+
 }

--- a/app/tests/Http/FetchMetadata/ResourceIsolationPolicyTest.phpt
+++ b/app/tests/Http/FetchMetadata/ResourceIsolationPolicyTest.phpt
@@ -63,6 +63,7 @@ final class ResourceIsolationPolicyTest extends TestCase
 	{
 		$this->logger->reset();
 		$this->application->onPresenter = [];
+		$this->httpRequest->resetHeaders();
 	}
 
 
@@ -79,8 +80,9 @@ final class ResourceIsolationPolicyTest extends TestCase
 	{
 		$this->installPolicy(true);
 		$this->httpRequest->setHeader(FetchMetadataHeader::Site->value, 'cross-site');
+		$this->httpRequest->setHeader('User-Agent', 'Chrome/123');
 		$this->callPresenterAction();
-		Assert::same(['GET /; action: :Www:Homepage:default; param names: foo, waldo; headers: Sec-Fetch-Dest: [not sent], Sec-Fetch-Mode: [not sent], Sec-Fetch-Site: cross-site, Sec-Fetch-User: [not sent]'], $this->logger->getLogged());
+		Assert::same(['GET /; action: :Www:Homepage:default; param names: foo, waldo; headers: Sec-Fetch-Dest: [not sent], Sec-Fetch-Mode: [not sent], Sec-Fetch-Site: cross-site, Sec-Fetch-User: [not sent]; user agent: Chrome/123'], $this->logger->getLogged());
 		Assert::same(IResponse::S200_OK, $this->httpResponse->getCode());
 	}
 
@@ -113,7 +115,7 @@ final class ResourceIsolationPolicyTest extends TestCase
 		$content = $this->callPresenterAction();
 		Assert::notContains('messages.homepage.aboutme', $content);
 		Assert::contains('messages.forbidden.crossSite', $content);
-		Assert::same(['GET /; action: :Www:Homepage:default; param names: foo, waldo; headers: Sec-Fetch-Dest: [not sent], Sec-Fetch-Mode: [not sent], Sec-Fetch-Site: cross-site, Sec-Fetch-User: [not sent]',], $this->logger->getLogged());
+		Assert::same(['GET /; action: :Www:Homepage:default; param names: foo, waldo; headers: Sec-Fetch-Dest: [not sent], Sec-Fetch-Mode: [not sent], Sec-Fetch-Site: cross-site, Sec-Fetch-User: [not sent]; user agent: [not sent]'], $this->logger->getLogged());
 		Assert::same(IResponse::S403_Forbidden, $this->httpResponse->getCode());
 	}
 


### PR DESCRIPTION
Log requests in the resource isolation policy even in the enforcing mode and log user agents too.

Follow-up to #371 and #373
