### PR TITLE
Revert "FLoC opt-out"

### DIFF
--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -60,7 +60,6 @@ parameters:
 		midi: none
 		payment: none
 		usb: none
-		interest-cohort: none
 
 	# Added/changed in local.neon
 	contact:


### PR DESCRIPTION
Google has decided to kill Federated Learning of Cohorts (FLoC).

> This incubation is not longer being pursued. See Topics API instead.
https://github.com/patcg-individual-drafts/topics

> The development of FLoC has stopped. Topics is the new proposal in Privacy Sandbox to preserve privacy while showing relevant content and ads.
https://privacysandbox.com/proposals/floc/

This reverts commit 7b917537c57c144fa5dcfda5bb0f44f627d20bff.