### PR TITLE
Require the `security.txt` file also exist in the top-level path (or be redirected from it)

### DIFF
--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -36,4 +36,5 @@ jobs:
         10 \
         --colors \
         --no-ipv6 \
+        --require-top-level-location \
         --strict


### PR DESCRIPTION
spaze/security-txt doesn't check it by default now, the `--require-top-level-location` param must be used.
https://github.com/spaze/security-txt/commit/45d1e0006ed5614b4e9769a83de53cbef84363e1

Top-level path means `/security.txt`.