### PR TITLE
Canceling a JS `confirm` window should prevent the action

### DIFF
--- a/app/public/www.michalspacek.cz/i/js/admin.js
+++ b/app/public/www.michalspacek.cz/i/js/admin.js
@@ -69,7 +69,6 @@ App.ready(document, function () {
 		for (const item of document.querySelectorAll('#statuses #date-' + this.dataset.date)) {
 			item.classList.toggle('hidden');
 		}
-		return false;
 	});
 
 	App.onClick('#statusesShow', function () {


### PR DESCRIPTION
Clicking on *Cancel* in a `confirm()` dialogue should cancel the action.
Probably a regression introduced in #113 when removing jQuery from admin.

Also remove one hopefully useless `return false`.

