### PR TITLE
Can delete preliminary training applications

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -67,6 +67,7 @@ services:
 	- MichalSpacekCz\Form\TrainingFileFormFactory
 	- MichalSpacekCz\Form\TrainingInvoiceFormFactory
 	- MichalSpacekCz\Form\TrainingMailsOutboxFormFactory
+	- MichalSpacekCz\Form\TrainingPreliminaryApplicationsFormFactory
 	- MichalSpacekCz\Form\TrainingReviewFormFactory
 	- MichalSpacekCz\Form\UnprotectedFormFactory
 	- MichalSpacekCz\Form\UpcKeysSsidFormFactory

--- a/app/src/Form/TrainingPreliminaryApplicationsFormFactory.php
+++ b/app/src/Form/TrainingPreliminaryApplicationsFormFactory.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Form;
+
+use MichalSpacekCz\Training\Applications\TrainingApplications;
+use MichalSpacekCz\Training\ApplicationStatuses\TrainingApplicationStatusHistory;
+use MichalSpacekCz\Training\Preliminary\PreliminaryTraining;
+use MichalSpacekCz\Utils\Arrays;
+use Nette\Database\Explorer;
+use Throwable;
+use Tracy\Debugger;
+
+final readonly class TrainingPreliminaryApplicationsFormFactory
+{
+
+	public function __construct(
+		private Explorer $database,
+		private FormFactory $factory,
+		private TrainingApplications $trainingApplications,
+		private TrainingApplicationStatusHistory $statusHistory,
+	) {
+	}
+
+
+	/**
+	 * @param list<PreliminaryTraining> $trainings
+	 * @param callable(): void $onSuccess
+	 */
+	public function create(array $trainings, callable $onSuccess): UiForm
+	{
+		$form = $this->factory->create();
+		$container = $form->addContainer('applications');
+		foreach ($trainings as $training) {
+			foreach ($training->getApplications() as $application) {
+				$container->addCheckbox((string)$application->getId());
+			}
+		}
+		$form->addSubmit('delete', 'Delete');
+		$form->onSuccess[] = function () use ($form, $onSuccess): void {
+			$selected = array_keys(Arrays::filterEmpty((array)$form->getFormValues()->applications));
+			if ($selected !== []) {
+				$this->database->beginTransaction();
+				try {
+					$this->statusHistory->deleteAllHistoryRecordsMultiple($selected);
+					$this->trainingApplications->deleteMultiple($selected);
+					$this->database->commit();
+					$onSuccess();
+				} catch (Throwable $e) {
+					Debugger::log($e);
+					$this->database->rollBack();
+					$form->addError('Oops, something went wrong, please try again in a moment');
+				}
+			}
+		};
+		return $form;
+	}
+
+}

--- a/app/src/Presentation/Admin/Trainings/TrainingsPresenter.php
+++ b/app/src/Presentation/Admin/Trainings/TrainingsPresenter.php
@@ -10,6 +10,7 @@ use MichalSpacekCz\Form\TrainingApplicationAdminFormFactory;
 use MichalSpacekCz\Form\TrainingApplicationMultipleFormFactory;
 use MichalSpacekCz\Form\TrainingApplicationStatusesFormFactory;
 use MichalSpacekCz\Form\TrainingFileFormFactory;
+use MichalSpacekCz\Form\TrainingPreliminaryApplicationsFormFactory;
 use MichalSpacekCz\Form\UiForm;
 use MichalSpacekCz\Presentation\Admin\BasePresenter;
 use MichalSpacekCz\ShouldNotHappenException;
@@ -29,6 +30,7 @@ use MichalSpacekCz\Training\Dates\UpcomingTrainingDates;
 use MichalSpacekCz\Training\Exceptions\TrainingApplicationDoesNotExistException;
 use MichalSpacekCz\Training\Exceptions\TrainingDateDoesNotExistException;
 use MichalSpacekCz\Training\Exceptions\TrainingDateNotRemoteNoVenueException;
+use MichalSpacekCz\Training\Preliminary\PreliminaryTraining;
 use MichalSpacekCz\Training\Preliminary\PreliminaryTrainings;
 use MichalSpacekCz\Training\Reviews\TrainingReview;
 use MichalSpacekCz\Training\Reviews\TrainingReviewInputs;
@@ -56,6 +58,9 @@ final class TrainingsPresenter extends BasePresenter
 	/** @var list<TrainingDate> */
 	private array $pastWithPersonalData = [];
 
+	/** @var list<PreliminaryTraining> */
+	private array $preliminaryTrainings = [];
+
 
 	public function __construct(
 		private readonly TrainingApplications $trainingApplications,
@@ -75,6 +80,7 @@ final class TrainingsPresenter extends BasePresenter
 		private readonly TrainingApplicationStatusesFormFactory $trainingApplicationStatusesFormFactory,
 		private readonly TrainingApplicationsListFactory $trainingApplicationsListFactory,
 		private readonly TrainingReviewInputsFactory $trainingReviewInputsFactory,
+		private readonly TrainingPreliminaryApplicationsFormFactory $trainingPreliminaryApplicationsFormFactory,
 	) {
 		parent::__construct();
 	}
@@ -203,7 +209,7 @@ final class TrainingsPresenter extends BasePresenter
 	public function actionPreliminary(): void
 	{
 		$this->template->pageTitle = 'Předběžné přihlášky';
-		$this->template->preliminaryApplications = $this->trainingPreliminaryApplications->getPreliminary();
+		$this->template->preliminaryApplications = $this->preliminaryTrainings = $this->trainingPreliminaryApplications->getPreliminary();
 		$this->template->upcoming = $this->upcomingTrainingDates->getPublicUpcoming();
 	}
 
@@ -359,6 +365,17 @@ final class TrainingsPresenter extends BasePresenter
 			throw new ShouldNotHappenException('actionDate() will be called first');
 		}
 		return $this->trainingReviewInputsFactory->create(true, $this->training->getId());
+	}
+
+
+	protected function createComponentPreliminaryApplications(): UiForm
+	{
+		return $this->trainingPreliminaryApplicationsFormFactory->create(
+			$this->preliminaryTrainings,
+			function (): never {
+				$this->redirect('this');
+			},
+		);
 	}
 
 }

--- a/app/src/Presentation/Admin/Trainings/application.latte
+++ b/app/src/Presentation/Admin/Trainings/application.latte
@@ -46,7 +46,7 @@
 				<tr class="row">
 					<td><code>{$status->value}</code></td>
 					<td><small>{$statusTime}</small></td>
-					<td n:if="($history|length) > 0"><small><a href="#historie" class="open-container">Historie</a> ({$history|length})</small></td>
+					<td>{if ($history|length) > 0}<small><a href="#historie" class="open-container">Historie</a> ({$history|length})</small>{/if}</td>
 				</tr>
 				<tbody id="historie-container" class="hidden">
 				{formContainer statusHistoryDelete}

--- a/app/src/Presentation/Admin/Trainings/preliminary.latte
+++ b/app/src/Presentation/Admin/Trainings/preliminary.latte
@@ -8,10 +8,18 @@
 {define #content}
 <p n:if="!$preliminaryApplications">Žádné předběžné přihlášky, hurá!</p>
 {if $preliminaryApplications}
-<p></p>
+{form preliminaryApplications}
+<fieldset id="{_html.id.errors}" n:if="$form->hasErrors()">
+	<legend><strong>{_messages.label.errors}</strong></legend>
+	<ul>
+		<li n:foreach="$form->errors as $error"><strong>{$error}</strong></li>
+	</ul>
+</fieldset>
+{formContainer applications}
 <table id="applications">
 	<thead>
 		<tr>
+			<th></th>
 			<th></th>
 			<th><small>Jméno</small></th>
 			<th><small>E-mail</small></th>
@@ -29,7 +37,8 @@
 			</td>
 		</tr>
 		<tr n:foreach="$training->getApplications() as $application">
-			<td><small>{$iterator->getCounter()}.</small></td>
+			<td>{input (string)$application->getId():}</td>
+			<td><label n:name="(string)$application->getId()"><small>{$iterator->getCounter()}.</small></label></td>
 			<td><small n:tag-if="$application->getName() === null"><a n:href="Trainings:application $application->getId()">{$application->getName() ?? smazáno}</a></small></td>
 			<td><small>{$application->getEmail() ?? smazáno}</small></td>
 			<td><small><code title="{$application->getStatusTime()|localeDay} {$application->getStatusTime()|date:'H:i:s'}">{$application->getStatus()->value}</code></small></td>
@@ -37,5 +46,8 @@
 		{/foreach}
 	</tbody>
 </table>
+{/formContainer}
+{input delete class => confirm-click, data-confirm => 'Opravdu smazat?'}
+{/form}
 {/if}
 {/define}

--- a/app/src/Test/Database/Database.php
+++ b/app/src/Test/Database/Database.php
@@ -63,6 +63,8 @@ final class Database extends Explorer
 
 	private ?ResultSet $resultSet = null;
 
+	private(set) DatabaseTransactionStatus $transactionStatus = DatabaseTransactionStatus::None;
+
 
 	public function reset(): void
 	{
@@ -85,24 +87,28 @@ final class Database extends Explorer
 		$this->fetchAllResultsPosition = 0;
 		$this->resultSet = null;
 		$this->wontThrow();
+		$this->transactionStatus = DatabaseTransactionStatus::None;
 	}
 
 
 	#[Override]
 	public function beginTransaction(): void
 	{
+		$this->transactionStatus = DatabaseTransactionStatus::Started;
 	}
 
 
 	#[Override]
 	public function commit(): void
 	{
+		$this->transactionStatus = DatabaseTransactionStatus::Committed;
 	}
 
 
 	#[Override]
 	public function rollBack(): void
 	{
+		$this->transactionStatus = DatabaseTransactionStatus::RolledBack;
 	}
 
 

--- a/app/src/Test/Database/DatabaseTransactionStatus.php
+++ b/app/src/Test/Database/DatabaseTransactionStatus.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Test\Database;
+
+enum DatabaseTransactionStatus
+{
+
+	case None;
+	case Started;
+	case Committed;
+	case RolledBack;
+
+}

--- a/app/src/Training/ApplicationStatuses/TrainingApplicationStatusHistory.php
+++ b/app/src/Training/ApplicationStatuses/TrainingApplicationStatusHistory.php
@@ -114,4 +114,17 @@ final class TrainingApplicationStatusHistory
 		);
 	}
 
+
+	/**
+	 * @param non-empty-list<int> $applicationIds
+	 */
+	public function deleteAllHistoryRecordsMultiple(array $applicationIds): void
+	{
+		Debugger::log('Deleting all status history records for applications: ' . implode(' ', $applicationIds));
+		$this->database->query(
+			'DELETE FROM training_application_status_history WHERE key_application IN (?)',
+			$applicationIds,
+		);
+	}
+
 }

--- a/app/src/Training/Applications/TrainingApplications.php
+++ b/app/src/Training/Applications/TrainingApplications.php
@@ -12,6 +12,7 @@ use MichalSpacekCz\Training\Exceptions\TrainingApplicationDoesNotExistException;
 use Nette\Database\Explorer;
 use ParagonIE\Halite\Alerts\HaliteAlert;
 use SodiumException;
+use Tracy\Debugger;
 
 final class TrainingApplications
 {
@@ -413,6 +414,19 @@ final class TrainingApplications
 	public function setFamiliar(int $applicationId): void
 	{
 		$this->database->query('UPDATE training_applications SET familiar = TRUE WHERE id_application = ?', $applicationId);
+	}
+
+
+	/**
+	 * @param non-empty-list<int> $applicationIds
+	 */
+	public function deleteMultiple(array $applicationIds): void
+	{
+		Debugger::log('Deleting applications: ' . implode(' ', $applicationIds));
+		$this->database->query(
+			'DELETE FROM training_applications WHERE id_application IN (?)',
+			$applicationIds,
+		);
 	}
 
 }

--- a/app/src/Utils/Arrays.php
+++ b/app/src/Utils/Arrays.php
@@ -10,13 +10,13 @@ final readonly class Arrays
 
 	/**
 	 * @template K of int|string
-	 * @template V of string|int|bool|null|array<array-key, mixed>
+	 * @template V
 	 * @param array<K, V> $array
 	 * @return array<K, V>
 	 */
 	public static function filterEmpty(array $array): array
 	{
-		$filter = function (string|int|bool|null|array $value): bool {
+		$filter = function (mixed $value): bool {
 			if (is_string($value)) {
 				return $value !== '';
 			} elseif (is_int($value)) {

--- a/app/tests/Form/TrainingPreliminaryApplicationsFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingPreliminaryApplicationsFormFactoryTest.phpt
@@ -1,0 +1,134 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace Form;
+
+use MichalSpacekCz\Form\TrainingPreliminaryApplicationsFormFactory;
+use MichalSpacekCz\Form\UiForm;
+use MichalSpacekCz\Test\Application\ApplicationPresenter;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\DatabaseTransactionStatus;
+use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\Test\Training\TrainingTestDataFactory;
+use MichalSpacekCz\Training\Preliminary\PreliminaryTraining;
+use Nette\Utils\Arrays;
+use Override;
+use PDOException;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class TrainingPreliminaryApplicationsFormFactoryTest extends TestCase
+{
+
+	private ?bool $result = null;
+
+	private UiForm $form;
+
+
+	public function __construct(
+		private readonly Database $database,
+		private readonly NullLogger $logger,
+		TrainingPreliminaryApplicationsFormFactory $formFactory,
+		ApplicationPresenter $applicationPresenter,
+		TrainingTestDataFactory $dataFactory,
+	) {
+		$training1 = new PreliminaryTraining(303, 'action-303', 'Training 303');
+		$training1->addApplication($dataFactory->getTrainingApplication(3031));
+		$training1->addApplication($dataFactory->getTrainingApplication(3032));
+		$training2 = new PreliminaryTraining(808, 'action-808', 'Training 808');
+		$training2->addApplication($dataFactory->getTrainingApplication(8081));
+		$training2->addApplication($dataFactory->getTrainingApplication(8082));
+		$trainings = [
+			$training1,
+			$training2,
+		];
+		$this->form = $formFactory->create(
+			$trainings,
+			function (): void {
+				$this->result = true;
+			},
+		);
+		$applicationPresenter->anchorForm($this->form);
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->result = null;
+		$this->database->reset();
+		$this->logger->reset();
+	}
+
+
+	public function testCreateOnSuccessNoApplications(): void
+	{
+		$this->form->setDefaults(['applications' => []]);
+		Arrays::invoke($this->form->onSuccess, $this->form);
+		Assert::null($this->result);
+		Assert::same(DatabaseTransactionStatus::None, $this->database->transactionStatus);
+		Assert::same([], $this->logger->getLogged());
+	}
+
+
+	public function testCreateOnSuccessNoneSelected(): void
+	{
+		$this->form->setDefaults([
+			'applications' => [
+				'3031' => false,
+				'3032' => false,
+				'8081' => false,
+				'8082' => false,
+			],
+		]);
+		Arrays::invoke($this->form->onSuccess, $this->form);
+		Assert::null($this->result);
+		Assert::same(DatabaseTransactionStatus::None, $this->database->transactionStatus);
+		Assert::same([], $this->logger->getLogged());
+	}
+
+
+	public function testCreateOnSuccess(): void
+	{
+		$this->form->setDefaults([
+			'applications' => [
+				'3031' => true,
+				'3032' => false,
+				'8081' => false,
+				'8082' => true,
+			],
+		]);
+		Arrays::invoke($this->form->onSuccess, $this->form);
+		Assert::true($this->result);
+		Assert::same(DatabaseTransactionStatus::Committed, $this->database->transactionStatus);
+		Assert::same(['Deleting all status history records for applications: 3031 8082', 'Deleting applications: 3031 8082'], $this->logger->getLogged());
+	}
+
+
+	public function testCreateOnSuccessDatabaseFailure(): void
+	{
+		$this->database->willThrow(new PDOException());
+		$this->form->setDefaults([
+			'applications' => [
+				'3031' => true,
+				'3032' => false,
+				'8081' => false,
+				'8082' => false,
+			],
+		]);
+		Arrays::invoke($this->form->onSuccess, $this->form);
+		Assert::null($this->result);
+		Assert::same(DatabaseTransactionStatus::RolledBack, $this->database->transactionStatus);
+		$logged = $this->logger->getLogged();
+		Assert::same('Deleting all status history records for applications: 3031', $logged[0]);
+		Assert::type(PDOException::class, $logged[1]);
+	}
+
+}
+
+TestCaseRunner::run(TrainingPreliminaryApplicationsFormFactoryTest::class);

--- a/app/tests/Training/ApplicationStatuses/TrainingApplicationStatusHistoryTest.phpt
+++ b/app/tests/Training/ApplicationStatuses/TrainingApplicationStatusHistoryTest.phpt
@@ -7,7 +7,9 @@ namespace MichalSpacekCz\Training\ApplicationStatuses;
 use DateTime;
 use DateTimeInterface;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -20,7 +22,16 @@ final class TrainingApplicationStatusHistoryTest extends TestCase
 	public function __construct(
 		private readonly Database $database,
 		private readonly TrainingApplicationStatusHistory $statusHistory,
+		private readonly NullLogger $logger,
 	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->logger->reset();
 	}
 
 
@@ -51,6 +62,14 @@ final class TrainingApplicationStatusHistoryTest extends TestCase
 		Assert::same(4, $all[1]->getStatusId());
 		Assert::same(TrainingApplicationStatus::Spam, $all[1]->getStatus());
 		Assert::equal('2023-10-20T10:20:30+02:00', $all[1]->getStatusTime()->format(DateTimeInterface::RFC3339));
+	}
+
+
+	public function testDeleteAllHistoryRecordsMultiple(): void
+	{
+		$this->statusHistory->deleteAllHistoryRecordsMultiple([1, 2]);
+		Assert::same([[1, 2]], $this->database->getParamsArrayForQuery('DELETE FROM training_application_status_history WHERE key_application IN (?)'));
+		Assert::same(['Deleting all status history records for applications: 1 2'], $this->logger->getLogged());
 	}
 
 }

--- a/app/tests/Training/Applications/TrainingApplicationsTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationsTest.phpt
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Applications;
 
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
@@ -17,6 +18,7 @@ final class TrainingApplicationsTest extends TestCase
 	public function __construct(
 		private readonly TrainingApplications $trainingApplications,
 		private readonly Database $database,
+		private readonly NullLogger $logger,
 	) {
 	}
 
@@ -25,6 +27,14 @@ final class TrainingApplicationsTest extends TestCase
 	{
 		$this->database->setFetchFieldDefaultResult(909);
 		Assert::same(909, $this->trainingApplications->getValidUnpaidCount());
+	}
+
+
+	public function testDeleteMultiple(): void
+	{
+		$this->trainingApplications->deleteMultiple([1, 2]);
+		Assert::same([[1, 2]], $this->database->getParamsArrayForQuery('DELETE FROM training_applications WHERE id_application IN (?)'));
+		Assert::same(['Deleting applications: 1 2'], $this->logger->getLogged());
 	}
 
 }


### PR DESCRIPTION
Because some _über cool_ scanners submit forms and I don't like those submissions. Regular applications can be marked as _spam_, but preliminary can now be deleted.

Follow-ups:
- #647