### PR TITLE
Use the PHP 8.5's Uri extension for parsing URLs instead of `parse_url()`

### DIFF
--- a/app/composer.json
+++ b/app/composer.json
@@ -13,6 +13,7 @@
 		"ext-openssl": "*",
 		"ext-pcntl": "*",
 		"ext-pdo": "*",
+		"ext-uri": "*",
 		"async-aws/lambda": "^2.10",
 		"composer/pcre": "^3.3.1",
 		"contributte/translation": "^2.0",

--- a/app/composer.lock
+++ b/app/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "61e9b8ebb29d05c8b4f1cc35515f446e",
+    "content-hash": "7f156e27a9e52a0b1fa01e6459b5be96",
     "packages": [
         {
             "name": "async-aws/core",
@@ -5569,7 +5569,8 @@
         "ext-mbstring": "*",
         "ext-openssl": "*",
         "ext-pcntl": "*",
-        "ext-pdo": "*"
+        "ext-pdo": "*",
+        "ext-uri": "*"
     },
     "platform-dev": {
         "ext-simplexml": "*"

--- a/app/disallowed-calls.neon
+++ b/app/disallowed-calls.neon
@@ -28,6 +28,9 @@ parameters:
 					position: 2
 					name: callback
 					typeString: 'callable'
+		-
+			function: 'parse_url()'
+			message: 'use the Uri\WhatWg\Url class for standards-compliant URL parsing'
 	disallowedStaticCalls:
 		-
 			method: 'Tester\Environment::skip()'
@@ -91,6 +94,10 @@ parameters:
 			message: 'use MichalSpacekCz\Application\SanitizedPhpInfo with additional sanitization'
 			allowIn:
 				- src/Application/SanitizedPhpInfo.php
+		-
+			class: 'Uri\Rfc3986\Uri'
+			message: 'instead use the Uri\WhatWg\Url class for standards-compliant URL parsing'
+			errorTip: 'The WHATWG URL Living Standard is followed by web browsers, unlike RFC 3986 which is used by Uri\Rfc3986\Url'
 
 includes:
 	- vendor/spaze/phpstan-disallowed-calls/extension.neon

--- a/app/phpstan-vendor.neon
+++ b/app/phpstan-vendor.neon
@@ -56,6 +56,10 @@ parameters:
 			function: 'array_filter()'
 			allowIn:
 				- vendor/*.php
+		-
+			function: 'parse_url()'
+			allowIn:
+				- vendor/*.php
 		# bundled disallowed-dangerous-calls.neon
 		-
 			function: 'eval()'

--- a/app/src/Http/Client/HttpClientResponse.php
+++ b/app/src/Http/Client/HttpClientResponse.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Http\Client;
 use MichalSpacekCz\Http\Exceptions\HttpClientTlsCertificateNotAvailableException;
 use MichalSpacekCz\Http\Exceptions\HttpClientTlsCertificateNotCapturedException;
 use OpenSSLCertificate;
+use Uri\WhatWg\Url;
 
 final readonly class HttpClientResponse
 {
@@ -30,8 +31,8 @@ final readonly class HttpClientResponse
 	 */
 	public function getTlsCertificate(): OpenSSLCertificate
 	{
-		$scheme = parse_url($this->request->getUrl(), PHP_URL_SCHEME);
-		if (!is_string($scheme) || strtolower($scheme) !== 'https') {
+		$scheme = Url::parse($this->request->getUrl())?->getScheme();
+		if ($scheme !== 'https') {
 			throw new HttpClientTlsCertificateNotAvailableException($this->request->getUrl());
 		}
 		if ($this->request->getTlsCaptureCertificate() !== true || $this->tlsCertificate === null) {

--- a/app/src/Http/Redirections.php
+++ b/app/src/Http/Redirections.php
@@ -6,6 +6,8 @@ namespace MichalSpacekCz\Http;
 use MichalSpacekCz\Database\TypedDatabase;
 use MichalSpacekCz\Http\Exceptions\HttpRedirectDestinationUrlMalformedException;
 use Nette\Http\UrlScript;
+use Uri\WhatWg\InvalidUrlException;
+use Uri\WhatWg\Url;
 
 final readonly class Redirections
 {
@@ -22,14 +24,12 @@ final readonly class Redirections
 		if ($destination === null) {
 			return null;
 		}
-		$destinationUrl = parse_url($destination);
-		if ($destinationUrl === false) {
-			throw new HttpRedirectDestinationUrlMalformedException($destination);
+		try {
+			$destinationUrl = new Url($destination, Url::parse($sourceUrl->getAbsoluteUrl()));
+		} catch (InvalidUrlException $e) {
+			throw new HttpRedirectDestinationUrlMalformedException($destination, $e);
 		}
-		if (!isset($destinationUrl['host'])) {
-			$destination = $sourceUrl->withPath($destination)->getAbsoluteUrl();
-		}
-		return $destination;
+		return $destinationUrl->toUnicodeString();
 	}
 
 }

--- a/app/src/Media/SlidesPlatform.php
+++ b/app/src/Media/SlidesPlatform.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Media;
 
+use Uri\WhatWg\Url;
+
 enum SlidesPlatform: string
 {
 
@@ -12,7 +14,7 @@ enum SlidesPlatform: string
 
 	public static function tryFromUrl(string $url): ?self
 	{
-		return match (parse_url($url, PHP_URL_HOST)) {
+		return match (Url::parse($url)?->getUnicodeHost()) {
 			'slideshare.net', 'www.slideshare.net' => self::SlideShare,
 			'speakerdeck.com', 'www.speakerdeck.com' => self::SpeakerDeck,
 			default => null,

--- a/app/src/Media/VideoPlatform.php
+++ b/app/src/Media/VideoPlatform.php
@@ -3,6 +3,8 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Media;
 
+use Uri\WhatWg\Url;
+
 enum VideoPlatform: string
 {
 
@@ -13,7 +15,7 @@ enum VideoPlatform: string
 
 	public static function tryFromUrl(string $url): ?self
 	{
-		return match (parse_url($url, PHP_URL_HOST)) {
+		return match (Url::parse($url)?->getUnicodeHost()) {
 			'youtube.com', 'www.youtube.com', 'youtu.be' => self::YouTube,
 			'vimeo.com', 'www.vimeo.com' => self::Vimeo,
 			'slideslive.com', 'www.slideslive.com' => self::SlidesLive,

--- a/app/tests/Http/Client/HttpClientResponseTest.phpt
+++ b/app/tests/Http/Client/HttpClientResponseTest.phpt
@@ -1,0 +1,54 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\Client;
+
+use MichalSpacekCz\Http\Exceptions\HttpClientTlsCertificateNotAvailableException;
+use MichalSpacekCz\Http\Exceptions\HttpClientTlsCertificateNotCapturedException;
+use MichalSpacekCz\Test\TestCaseRunner;
+use OpenSSLCertificate;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class HttpClientResponseTest extends TestCase
+{
+
+	public function testGetTlsCertificate(): void
+	{
+		$string = file_get_contents(__DIR__ . '/../../Tls/certificate.pem');
+		assert(is_string($string));
+		$certificate = openssl_x509_read($string);
+		assert($certificate instanceof OpenSSLCertificate);
+
+		Assert::exception(function () use (&$certificate): void {
+			new HttpClientResponse(new HttpClientRequest(':-/'), 'body', $certificate)->getTlsCertificate();
+		}, HttpClientTlsCertificateNotAvailableException::class);
+
+		Assert::exception(function () use (&$certificate): void {
+			new HttpClientResponse(new HttpClientRequest('http://not.secure.example'), 'body', $certificate)->getTlsCertificate();
+		}, HttpClientTlsCertificateNotAvailableException::class);
+
+		Assert::exception(function () use (&$certificate): void {
+			new HttpClientResponse(new HttpClientRequest('https://www.example'), 'body', $certificate)->getTlsCertificate();
+		}, HttpClientTlsCertificateNotCapturedException::class);
+
+		Assert::exception(function (): void {
+			new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', null)->getTlsCertificate();
+		}, HttpClientTlsCertificateNotCapturedException::class);
+
+		Assert::type(OpenSSLCertificate::class, new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', $certificate)->getTlsCertificate());
+	}
+
+
+	public function testGetBody(): void
+	{
+		$body = 'a response body';
+		Assert::same($body, new HttpClientResponse(new HttpClientRequest('https://www.example'), $body, null)->getBody());
+	}
+
+}
+
+TestCaseRunner::run(HttpClientResponseTest::class);

--- a/app/tests/Media/SlidesPlatformTest.phpt
+++ b/app/tests/Media/SlidesPlatformTest.phpt
@@ -1,0 +1,38 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace Media;
+
+use MichalSpacekCz\Media\SlidesPlatform;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class SlidesPlatformTest extends TestCase
+{
+
+	public function testTryFromUrl(): void
+	{
+		Assert::same(SlidesPlatform::SlideShare, SlidesPlatform::tryFromUrl('https://slideshare.net/foo'));
+		Assert::same(SlidesPlatform::SlideShare, SlidesPlatform::tryFromUrl('https://www.slideshare.net/foo'));
+		Assert::same(SlidesPlatform::SpeakerDeck, SlidesPlatform::tryFromUrl('https://speakerdeck.com/foo'));
+		Assert::same(SlidesPlatform::SpeakerDeck, SlidesPlatform::tryFromUrl('https://www.speakerdeck.com/foo'));
+		Assert::null(SlidesPlatform::tryFromUrl('https://bar.slideshare.net/foo'));
+		Assert::null(SlidesPlatform::tryFromUrl('https://bar.speakerdeck.com/foo'));
+		Assert::null(SlidesPlatform::tryFromUrl('https://whatever.example'));
+		Assert::null(SlidesPlatform::tryFromUrl(':-/'));
+	}
+
+
+	public function testGetName(): void
+	{
+		Assert::same(SlidesPlatform::SlideShare->value, SlidesPlatform::SlideShare->getName());
+	}
+
+}
+
+TestCaseRunner::run(SlidesPlatformTest::class);

--- a/app/tests/Media/VideoPlatformTest.phpt
+++ b/app/tests/Media/VideoPlatformTest.phpt
@@ -1,0 +1,42 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace Media;
+
+use MichalSpacekCz\Media\VideoPlatform;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class VideoPlatformTest extends TestCase
+{
+
+	public function testTryFromUrl(): void
+	{
+		Assert::same(VideoPlatform::YouTube, VideoPlatform::tryFromUrl('https://youtube.com/foo'));
+		Assert::same(VideoPlatform::YouTube, VideoPlatform::tryFromUrl('https://www.youtube.com/foo'));
+		Assert::same(VideoPlatform::YouTube, VideoPlatform::tryFromUrl('https://youtu.be/foo'));
+		Assert::same(VideoPlatform::Vimeo, VideoPlatform::tryFromUrl('https://vimeo.com/foo'));
+		Assert::same(VideoPlatform::Vimeo, VideoPlatform::tryFromUrl('https://www.vimeo.com/foo'));
+		Assert::same(VideoPlatform::SlidesLive, VideoPlatform::tryFromUrl('https://slideslive.com/foo'));
+		Assert::same(VideoPlatform::SlidesLive, VideoPlatform::tryFromUrl('https://www.slideslive.com/foo'));
+		Assert::null(VideoPlatform::tryFromUrl('https://bar.youtube.com/foo'));
+		Assert::null(VideoPlatform::tryFromUrl('https://bar.vimeo.com/foo'));
+		Assert::null(VideoPlatform::tryFromUrl('https://bar.slideslive.com/foo'));
+		Assert::null(VideoPlatform::tryFromUrl('https://whatever.example'));
+		Assert::null(VideoPlatform::tryFromUrl(':-/'));
+	}
+
+
+	public function testGetName(): void
+	{
+		Assert::same(VideoPlatform::YouTube->value, VideoPlatform::YouTube->getName());
+	}
+
+}
+
+TestCaseRunner::run(VideoPlatformTest::class);

--- a/app/vendor/composer/installed.php
+++ b/app/vendor/composer/installed.php
@@ -3,7 +3,7 @@
         'name' => 'spaze/michalspacek.cz',
         'pretty_version' => 'dev-main',
         'version' => 'dev-main',
-        'reference' => '4effd6ff681cdf3ff46cc34f74cf76782c29abdb',
+        'reference' => 'd87015e58e0912e34a8fb4d71e8888ad15be96fd',
         'type' => 'project',
         'install_path' => __DIR__ . '/../../',
         'aliases' => array(),
@@ -522,7 +522,7 @@
         'spaze/michalspacek.cz' => array(
             'pretty_version' => 'dev-main',
             'version' => 'dev-main',
-            'reference' => '4effd6ff681cdf3ff46cc34f74cf76782c29abdb',
+            'reference' => 'd87015e58e0912e34a8fb4d71e8888ad15be96fd',
             'type' => 'project',
             'install_path' => __DIR__ . '/../../',
             'aliases' => array(),


### PR DESCRIPTION
Use the WHATWG parser as that's what browsers follow, and what I'm doing here is mostly about browsers and websites and things like that.

It would also be cool if frameworks started using the extension so that all URL parsing is done the same way, but I guess we'll need to wait.

https://www.php.net/releases/8.5/en.php#new-uri-extension
https://thephp.foundation/blog/2025/10/10/php-85-uri-extension/