### PR TITLE
Listen on `localhost` ports only in dev

### DIFF
--- a/conf/nginx/dev-michal-spacek.cz.conf
+++ b/conf/nginx/dev-michal-spacek.cz.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name michal-spacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name www.michal-spacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -15,7 +15,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name michal-spacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.com.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -23,7 +23,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name www.michal-spacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.com.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -31,7 +31,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name .michal-spacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michal-spacek.cz.conf;
@@ -41,7 +41,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name .michal-spacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michal-spacek.cz.conf;

--- a/conf/nginx/dev-michalspacek.cz.conf
+++ b/conf/nginx/dev-michalspacek.cz.conf
@@ -1,5 +1,5 @@
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -7,7 +7,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name www.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -15,7 +15,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name michalspacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.com.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -23,7 +23,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name www.michalspacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.com.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -31,7 +31,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name admin.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -39,7 +39,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name api.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -47,7 +47,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name heartbleed.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -55,7 +55,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name mta-sts.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -63,7 +63,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name pulse.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -71,7 +71,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name upc.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -79,7 +79,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name upcwifikeys.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -87,7 +87,7 @@ server {
 }
 
 server {
-    listen 80;
+    listen 127.0.0.1:80;
     server_name www.upcwifikeys.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/common-michalspacek.cz.conf;
     include /srv/www/michalspacek.cz/conf/nginx/common-headers-redir&notfound.conf;
@@ -95,7 +95,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name .michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -106,7 +106,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name .michalspacek.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -117,7 +117,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name admin.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -128,7 +128,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name api.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -139,7 +139,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name heartbleed.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -150,7 +150,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name mta-sts.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -161,7 +161,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name pulse.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -172,7 +172,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name upc.michalspacek.cz.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;
@@ -182,7 +182,7 @@ server {
 }
 
 server {
-    listen 443 ssl;
+    listen 127.0.0.1:443 ssl;
     http2 on;
     server_name .upcwifikeys.com.test;
     include /srv/www/michalspacek.cz/conf/nginx/dev-https-michalspacek.cz.conf;


### PR DESCRIPTION
No need to listen on all ports even though the server is not exposed.