### PR TITLE
Replace the hardcoded threshold for "cert expires soon" warnings with an algorithm

### DIFF
--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -41,7 +41,6 @@ parameters:
 	permanentLogin:
 		interval: 14 days
 	certificatesApi:
-		expiringThreshold: 20
 		hideExpiredAfter: 10
 		users:  # Added in local.neon
 	blog:

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -125,7 +125,7 @@ services:
 	latte.templateFactory:
 		create: MichalSpacekCz\Templating\TemplateFactory()
 		autowired: Nette\Application\UI\TemplateFactory
-	- MichalSpacekCz\Tls\CertificateFactory(expiringThreshold: %certificatesApi.expiringThreshold%)
+	- MichalSpacekCz\Tls\CertificateFactory
 	- MichalSpacekCz\Tls\CertificateGatherer
 	- MichalSpacekCz\Tls\CertificateMonitor
 	- MichalSpacekCz\Tls\Certificates(users: %certificatesApi.users%, hideExpiredAfter: %certificatesApi.hideExpiredAfter%)

--- a/app/src/Tls/Certificate.php
+++ b/app/src/Tls/Certificate.php
@@ -27,7 +27,6 @@ final readonly class Certificate implements JsonSerializable
 		private ?array $subjectAlternativeNames,
 		private DateTimeImmutable $notBefore,
 		private DateTimeImmutable $notAfter,
-		private int $expiringThreshold,
 		private ?string $serialNumber,
 		private DateTimeImmutable $now,
 	) {
@@ -37,9 +36,10 @@ final readonly class Certificate implements JsonSerializable
 		$expiryDays = $this->notAfter->diff($this->now)->days;
 		assert(is_int($expiryDays));
 		$this->expiryDays = $expiryDays;
-
 		$this->expired = $this->notAfter < $this->now;
-		$this->expiringSoon = !$this->expired && $this->expiryDays < $this->expiringThreshold;
+		$validity = $this->notAfter->diff($this->notBefore)->days;
+		assert(is_int($validity));
+		$this->expiringSoon = !$this->expired && $this->expiryDays < $validity / 3;
 	}
 
 
@@ -119,7 +119,7 @@ final readonly class Certificate implements JsonSerializable
 
 
 	/**
-	 * @return array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}
+	 * @return array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, serialNumber:string|null, now:string, nowTz:string}
 	 */
 	#[Override]
 	public function jsonSerialize(): array
@@ -133,7 +133,6 @@ final readonly class Certificate implements JsonSerializable
 			'notBeforeTz' => $this->notBefore->getTimezone()->getName(),
 			'notAfter' => $this->notAfter->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			'notAfterTz' => $this->notAfter->getTimezone()->getName(),
-			'expiringThreshold' => $this->expiringThreshold,
 			'serialNumber' => $this->serialNumber,
 			'now' => $this->now->format(DateTimeFormat::RFC3339_MICROSECONDS),
 			'nowTz' => $this->now->getTimezone()->getName(),

--- a/app/src/Tls/CertificateFactory.php
+++ b/app/src/Tls/CertificateFactory.php
@@ -26,7 +26,6 @@ final readonly class CertificateFactory
 		private DateTimeZoneFactory $dateTimeZoneFactory,
 		private DateTimeFactory $dateTimeFactory,
 		private Processor $schemaProcessor,
-		private int $expiringThreshold,
 	) {
 	}
 
@@ -54,7 +53,6 @@ final readonly class CertificateFactory
 			$san,
 			$this->dateTimeFactory->createFrom($row->notBefore, $row->notBeforeTimezone),
 			$this->dateTimeFactory->createFrom($row->notAfter, $row->notAfterTimezone),
-			$this->expiringThreshold,
 			null,
 			$this->dateTimeFactory->create(),
 		);
@@ -98,7 +96,6 @@ final readonly class CertificateFactory
 			$details->getSubjectAlternativeNames(),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidFromTimeT()),
 			$this->dateTimeFactory->createFromFormat('U', (string)$details->getValidToTimeT()),
-			$this->expiringThreshold,
 			$details->getSerialNumberHex(),
 			$this->dateTimeFactory->create(),
 		);
@@ -119,7 +116,6 @@ final readonly class CertificateFactory
 		string $notBeforeTz,
 		string $notAfter,
 		string $notAfterTz,
-		int $expiringThreshold,
 		?string $serialNumber,
 		string $now,
 		string $nowTz,
@@ -131,7 +127,6 @@ final readonly class CertificateFactory
 			$subjectAlternativeNames,
 			$this->createDateTimeImmutable($notBefore, $notBeforeTz),
 			$this->createDateTimeImmutable($notAfter, $notAfterTz),
-			$expiringThreshold,
 			$serialNumber,
 			$this->createDateTimeImmutable($now, $nowTz),
 		);

--- a/app/src/Tls/CertificatesApiClient.php
+++ b/app/src/Tls/CertificatesApiClient.php
@@ -63,7 +63,6 @@ final readonly class CertificatesApiClient
 					'notBeforeTz' => Expect::string()->required(),
 					'notAfter' => Expect::string()->required(),
 					'notAfterTz' => Expect::string()->required(),
-					'expiringThreshold' => Expect::int()->required(),
 					'serialNumber' => Expect::string()->required()->nullable(),
 					'now' => Expect::string()->required(),
 					'nowTz' => Expect::string()->required(),
@@ -71,7 +70,7 @@ final readonly class CertificatesApiClient
 			),
 		]);
 		try {
-			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string}>} $data */
+			/** @var object{status:string, certificates:list<object{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, serialNumber:string|null, now:string, nowTz:string}>} $data */
 			$data = $this->schemaProcessor->process($schema, $decoded);
 		} catch (ValidationException $e) {
 			throw new CertificatesApiException(sprintf('Cannot validate response from %s (`%s`): %s', $request->getUrl(), $json, implode(', ', $e->getMessages())), previous: $e);
@@ -89,7 +88,6 @@ final readonly class CertificatesApiClient
 				$details->notBeforeTz,
 				$details->notAfter,
 				$details->notAfterTz,
-				$details->expiringThreshold,
 				$details->serialNumber,
 				$details->now,
 				$details->nowTz,

--- a/app/tests/Tls/CertificateFactoryTest.phpt
+++ b/app/tests/Tls/CertificateFactoryTest.phpt
@@ -34,11 +34,10 @@ final class CertificateFactoryTest extends TestCase
 			['cert.example', 'www.cert.example'],
 			new DateTimeImmutable('-2 weeks'),
 			new DateTimeImmutable('+3 weeks'),
-			3,
 			'CafeCe37',
 			new DateTimeImmutable(),
 		);
-		/** @var array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, expiringThreshold:int, serialNumber:string|null, now:string, nowTz:string} $array */
+		/** @var array{certificateName:string, certificateNameExt:string|null, cn:string|null, san:list<string>|null, notBefore:string, notBeforeTz:string, notAfter:string, notAfterTz:string, serialNumber:string|null, now:string, nowTz:string} $array */
 		$array = Json::decode(Json::encode($expected), forceArrays: true);
 		$certificate = $this->certificateFactory->get(
 			$array['certificateName'],
@@ -49,7 +48,6 @@ final class CertificateFactoryTest extends TestCase
 			$array['notBeforeTz'],
 			$array['notAfter'],
 			$array['notAfterTz'],
-			$array['expiringThreshold'],
 			$array['serialNumber'],
 			$array['now'],
 			$array['nowTz'],

--- a/app/tests/Tls/CertificateTest.phpt
+++ b/app/tests/Tls/CertificateTest.phpt
@@ -23,7 +23,6 @@ final class CertificateTest extends TestCase
 			['cert.example'],
 			new DateTimeImmutable('2025-09-01 00:00:00'),
 			new DateTimeImmutable('2025-09-09 00:00:00'),
-			3,
 			null,
 			new DateTimeImmutable('2025-09-02 00:00:01'),
 		);
@@ -40,7 +39,6 @@ final class CertificateTest extends TestCase
 			['cert.example'],
 			new DateTimeImmutable('2025-09-01 00:00:00'),
 			new DateTimeImmutable('2025-09-09 00:00:00'),
-			3,
 			null,
 			new DateTimeImmutable('2025-09-06 00:00:01'),
 		);
@@ -57,7 +55,6 @@ final class CertificateTest extends TestCase
 			['cert.example'],
 			new DateTimeImmutable('2025-09-01 00:00:00'),
 			new DateTimeImmutable('2025-09-09 00:00:00'),
-			3,
 			null,
 			new DateTimeImmutable('2025-09-10 00:00:01'),
 		);

--- a/app/tests/Tls/CertificatesTest.phpt
+++ b/app/tests/Tls/CertificatesTest.phpt
@@ -53,7 +53,7 @@ final class CertificatesTest extends TestCase
 	public function testLog(): void
 	{
 		$this->database->setDefaultInsertId('42');
-		$certificate = new Certificate('foo.example', null, 'cn.example', [], $this->notBefore, $this->notAfter, 0, null, new DateTimeImmutable());
+		$certificate = new Certificate('foo.example', null, 'cn.example', [], $this->notBefore, $this->notAfter, null, new DateTimeImmutable());
 		$this->certificates->log($certificate);
 		$params = $this->database->getParamsArrayForQuery('INSERT INTO certificate_requests');
 		Assert::count(1, $params);
@@ -80,7 +80,7 @@ final class CertificatesTest extends TestCase
 	{
 		$exception = new DriverException();
 		$this->database->willThrow($exception);
-		$certificate = new Certificate('foo.example', null, null, null, $this->notBefore, $this->notAfter, 0, null, new DateTimeImmutable());
+		$certificate = new Certificate('foo.example', null, null, null, $this->notBefore, $this->notAfter, null, new DateTimeImmutable());
 		Assert::exception(function () use ($certificate): void {
 			$this->certificates->log($certificate);
 		}, SomeCertificatesLoggedToFileException::class, 'Error logging to database, some certificates logged to file instead');
@@ -106,7 +106,7 @@ final class CertificatesTest extends TestCase
 
 	public function testGetNewestAndGetNewestWithWarnings(): void
 	{
-		$now = new DateTimeImmutable('2025-12-01 00:00:00 UTC');
+		$now = new DateTimeImmutable('2025-11-29 00:00:00 UTC');
 		$this->dateTimeFactory->setDateTime($now);
 		$this->database->addFetchAllResult([
 			[
@@ -124,9 +124,9 @@ final class CertificatesTest extends TestCase
 				'certificateNameExt' => null,
 				'cn' => null,
 				'san' => Json::encode(['cert2.name.example']),
-				'notBefore' => new DateTime('2025-10-20 10:20:30 UTC'),
+				'notBefore' => new DateTime('2025-09-20 10:20:30 UTC'),
 				'notBeforeTimezone' => 'UTC',
-				'notAfter' => new DateTime('2025-11-20 10:20:29 UTC'),
+				'notAfter' => new DateTime('2025-10-20 10:20:29 UTC'),
 				'notAfterTimezone' => 'UTC',
 			],
 			[
@@ -147,7 +147,6 @@ final class CertificatesTest extends TestCase
 			['cert1.name.example'],
 			new DateTimeImmutable('2025-09-30 10:20:30 UTC'),
 			new DateTimeImmutable('2025-12-30 10:20:29 UTC'),
-			20,
 			null,
 			$now,
 		);
@@ -158,7 +157,6 @@ final class CertificatesTest extends TestCase
 			['cert3.name.example'],
 			new DateTimeImmutable('2025-09-08 10:20:30 UTC'),
 			new DateTimeImmutable('2025-12-08 10:20:29 UTC'),
-			20,
 			null,
 			$now,
 		);


### PR DESCRIPTION
Now the certificate "expires soon" when there's less than a third of its validity period left, no matter how long the period is.

This is because Let's Encrypt [now offers 6-day certificates](https://letsencrypt.org/2026/01/15/6day-and-ip-general-availability), so they were always shown as if they expire soon. Well, they kinda do, but it's a feature, not a bug.