### PR TITLE
The hours are counted using `floor()` so they're whole hours already

### DIFF
--- a/app/src/Tls/Certificate.php
+++ b/app/src/Tls/Certificate.php
@@ -105,15 +105,14 @@ final class Certificate implements JsonSerializable
 	}
 
 
+	/**
+	 * Return the number of hours either to expiration, or after expiration.
+	 */
 	public function getExpiryHours(): int
 	{
 		if ($this->expiryHours === null) {
 			$seconds = abs($this->notAfter->getTimestamp() - $this->now->getTimestamp());
-			$hours = (int)floor($seconds / 3600);
-			if ($seconds > 0 && $hours > 0 && $seconds % 3600 === 0) {
-				$hours--; // Only count whole hours, not started hours
-			}
-			$this->expiryHours = $hours;
+			$this->expiryHours = (int)floor($seconds / 3600);
 		}
 		return $this->expiryHours;
 	}

--- a/app/tests/Tls/CertificateTest.phpt
+++ b/app/tests/Tls/CertificateTest.phpt
@@ -79,7 +79,7 @@ final class CertificateTest extends TestCase
 			new DateTimeImmutable('2025-09-01 00:00:00'),
 			new DateTimeImmutable('2025-09-07 15:59:59'),
 			null,
-			new DateTimeImmutable('2025-09-05 01:59:59'),
+			new DateTimeImmutable('2025-09-05 02:59:59'),
 		);
 		Assert::same(6, $certificate->getValidityPeriodDays());
 		Assert::same(6 * 24 + 15, $certificate->getValidityPeriodHours());


### PR DESCRIPTION
Follow-up to #666 where the wrong calculation was added.