### PR TITLE
Remove `implements HtmlStringable` from `FormValidatorTexyRule`s

### DIFF
--- a/app/src/Form/Talk/TalkFormFactory.php
+++ b/app/src/Form/Talk/TalkFormFactory.php
@@ -55,12 +55,12 @@ final readonly class TalkFormFactory
 		$ruleTexy = $this->texyRuleFactory->create();
 		$form->addText('title', 'Název:')
 			->setRequired('Zadejte prosím název')
-			->addRule($ruleTexy->getRule(), $ruleTexy->getMessage())
+			->addRule($ruleTexy->getRule())
 			->addRule(Form::MaxLength, 'Maximální délka názvu je %d znaků', 200);
 		$ruleTexy = $this->texyRuleFactory->create();
 		$form->addTextArea('description', 'Popis:')
 			->setRequired(false)
-			->addRule($ruleTexy->getRule(), $ruleTexy->getMessage())
+			->addRule($ruleTexy->getRule())
 			->addRule(Form::MaxLength, 'Maximální délka popisu je %d znaků', 65535);
 		$this->trainingControlsFactory->addDate(
 			$form->addText('date', 'Datum:'),
@@ -86,7 +86,7 @@ final readonly class TalkFormFactory
 		$ruleTexy = $this->texyRuleFactory->create();
 		$form->addTextArea('slidesNote', 'Poznámka ke slajdům:')
 			->setRequired(false)
-			->addRule($ruleTexy->getRule(), $ruleTexy->getMessage())
+			->addRule($ruleTexy->getRule())
 			->addRule(Form::MaxLength, 'Maximální délka poznámek je %d znaků', 65535);
 		$form->addText('videoHref', 'Odkaz na video:')
 			->setRequired(false)
@@ -98,7 +98,7 @@ final readonly class TalkFormFactory
 		$ruleTexy = $this->texyRuleFactory->create();
 		$form->addText('event', 'Událost:')
 			->setRequired('Zadejte prosím událost')
-			->addRule($ruleTexy->getRule(), $ruleTexy->getMessage())
+			->addRule($ruleTexy->getRule())
 			->addRule(Form::MaxLength, 'Maximální délka události je %d znaků', 200);
 		$form->addText('eventHref', 'Odkaz na událost:')
 			->setRequired(false)
@@ -109,7 +109,7 @@ final readonly class TalkFormFactory
 		$ruleTexy = $this->texyRuleFactory->create();
 		$form->addTextArea('transcript', 'Přepis:')
 			->setRequired(false)
-			->addRule($ruleTexy->getRule(), $ruleTexy->getMessage())
+			->addRule($ruleTexy->getRule())
 			->addRule(Form::MaxLength, 'Maximální délka přepisu je %d znaků', 65535);
 		$form->addTextArea('favorite', 'Popis pro oblíbené:')
 			->setRequired(false)

--- a/app/src/Form/Talk/TalkSlidesFormFactory.php
+++ b/app/src/Form/Talk/TalkSlidesFormFactory.php
@@ -162,7 +162,7 @@ final readonly class TalkSlidesFormFactory
 			->setHtmlAttribute('class', 'slide-filename');
 		$ruleTexyTalkSlides = $this->talkSlidesTexyRuleFactory->create();
 		$container->addTextArea('speakerNotes', 'Poznámky:')
-			->addRule($ruleTexyTalkSlides->getRule(), $ruleTexyTalkSlides->getMessage())
+			->addRule($ruleTexyTalkSlides->getRule())
 			->setRequired('Zadejte prosím poznámky');
 	}
 

--- a/app/src/Form/Validators/FormValidatorRuleTexy.php
+++ b/app/src/Form/Validators/FormValidatorRuleTexy.php
@@ -5,21 +5,12 @@ namespace MichalSpacekCz\Form\Validators;
 
 use MichalSpacekCz\Form\Validators\Exceptions\FormValidatorTexyFormatterErrorException;
 use Nette\Forms\Controls\TextBase;
-use Nette\HtmlStringable;
-use Override;
-use Stringable;
 
 /**
  * Checks whether a form field has a valid Texy content that can be rendered without any issues.
- *
- * Implements HtmlStringable in addition to Stringable, because while TextArea::addRule() accepts Stringable,
- * Validator::formatMessage() doesn't know how to process it, but knows about HtmlStringable.
  */
-final class FormValidatorRuleTexy implements HtmlStringable, Stringable
+final class FormValidatorRuleTexy
 {
-
-	private string $message = '';
-
 
 	public function __construct(
 		private readonly FormValidatorTexyFormatter $formValidatorTexyFormatter,
@@ -33,28 +24,13 @@ final class FormValidatorRuleTexy implements HtmlStringable, Stringable
 	public function getRule(): callable
 	{
 		return function (TextBase $input): bool {
-			$this->message = '';
 			try {
 				$this->formValidatorTexyFormatter->format($input->value);
 			} catch (FormValidatorTexyFormatterErrorException $e) {
-				$this->message = $e->getMessage();
-				return false;
+				$input->addError($e->getMessage(), translate: false);
 			}
 			return true;
 		};
-	}
-
-
-	public function getMessage(): self
-	{
-		return $this;
-	}
-
-
-	#[Override]
-	public function __toString(): string
-	{
-		return $this->message;
 	}
 
 }

--- a/app/src/Form/Validators/FormValidatorRuleTexyTalkSlides.php
+++ b/app/src/Form/Validators/FormValidatorRuleTexyTalkSlides.php
@@ -6,21 +6,12 @@ namespace MichalSpacekCz\Form\Validators;
 use Composer\Pcre\Regex;
 use MichalSpacekCz\Form\Validators\Exceptions\FormValidatorTexyFormatterErrorException;
 use Nette\Forms\Controls\TextBase;
-use Nette\HtmlStringable;
-use Override;
-use Stringable;
 
 /**
  * Checks whether a form field has a valid Texy content that can be rendered as a talk slide without any issues.
- *
- * Implements HtmlStringable in addition to Stringable, because while TextArea::addRule() accepts Stringable,
- * Validator::formatMessage() doesn't know how to process it, but knows about HtmlStringable.
  */
-final class FormValidatorRuleTexyTalkSlides implements HtmlStringable, Stringable
+final class FormValidatorRuleTexyTalkSlides
 {
-
-	private string $message = '';
-
 
 	public function __construct(
 		private readonly FormValidatorTexyFormatter $formValidatorTexyFormatter,
@@ -34,35 +25,20 @@ final class FormValidatorRuleTexyTalkSlides implements HtmlStringable, Stringabl
 	public function getRule(): callable
 	{
 		return function (TextBase $input): bool {
-			$this->message = '';
 			try {
 				$html = $this->formValidatorTexyFormatter->format($input->value);
 			} catch (FormValidatorTexyFormatterErrorException $e) {
-				$this->message = $e->getMessage();
-				return false;
+				$input->addError($e->getMessage(), translate: false);
+				return true;
 			}
 			if ($html !== null) {
 				$result = Regex::matchStrictGroups('~</(ol|ul|blockquote|pre|table)>\Z~i', rtrim($html->render()));
 				if ($result->matched) {
-					$this->message = 'Text ends with ' . strtoupper($result->matches[1]) . ', but it should end with a paragraph, otherwise the slide number will be on a separate line';
-					return false;
+					$input->addError('Text ends with ' . strtoupper($result->matches[1]) . ', but it should end with a paragraph, otherwise the slide number will be on a separate line', translate: false);
 				}
 			}
 			return true;
 		};
-	}
-
-
-	public function getMessage(): self
-	{
-		return $this;
-	}
-
-
-	#[Override]
-	public function __toString(): string
-	{
-		return $this->message;
 	}
 
 }

--- a/app/tests/Form/Validators/FormValidatorRuleTexyTalkSlidesTest.phpt
+++ b/app/tests/Form/Validators/FormValidatorRuleTexyTalkSlidesTest.phpt
@@ -73,12 +73,11 @@ final class FormValidatorRuleTexyTalkSlidesTest extends TestCase
 		$textArea = new TextArea();
 		$textArea->value = $input;
 		$rule = $this->rule;
+		Assert::true($rule->getRule()($textArea));
 		if ($endTag !== null) {
-			Assert::false($rule->getRule()($textArea));
-			Assert::same("Text ends with $endTag, but it should end with a paragraph, otherwise the slide number will be on a separate line", (string)$rule);
+			Assert::same(["Text ends with $endTag, but it should end with a paragraph, otherwise the slide number will be on a separate line"], $textArea->getErrors());
 		} else {
-			Assert::true($rule->getRule()($textArea));
-			Assert::same('', (string)$rule);
+			Assert::same([], $textArea->getErrors());
 		}
 	}
 
@@ -89,9 +88,8 @@ final class FormValidatorRuleTexyTalkSlidesTest extends TestCase
 		$textArea = new TextArea();
 		$textArea->value = 'Le Bar "foo":[link:Www:Talks:talk foo/bar]';
 		$rule = $this->rule;
-		Assert::false($rule->getRule()($textArea));
-		Assert::same('Invalid link: oops/bar', (string)$rule);
-		Assert::same((string)$rule, (string)$rule->getMessage());
+		Assert::true($rule->getRule()($textArea));
+		Assert::same(['Invalid link: oops/bar'], $textArea->getErrors());
 	}
 
 }

--- a/app/tests/Form/Validators/FormValidatorRuleTexyTest.phpt
+++ b/app/tests/Form/Validators/FormValidatorRuleTexyTest.phpt
@@ -49,14 +49,12 @@ final class FormValidatorRuleTexyTest extends TestCase
 		$textArea->value = 'Le Bar "foo":[link:Www:Talks:talk foo-bar]';
 		$rule = $this->rule;
 		Assert::true($rule->getRule()($textArea));
-		Assert::same('', (string)$rule);
-		Assert::same((string)$rule, (string)$rule->getMessage());
+		Assert::same([], $textArea->getErrors());
 
 		$textArea = new TextArea();
 		$textArea->value = 808;
 		Assert::true($rule->getRule()($textArea));
-		Assert::same('', (string)$rule);
-		Assert::same((string)$rule, (string)$rule->getMessage());
+		Assert::same([], $textArea->getErrors());
 	}
 
 
@@ -66,9 +64,8 @@ final class FormValidatorRuleTexyTest extends TestCase
 		$textArea = new TextArea();
 		$textArea->value = 'Le Bar "foo":[link:Www:Talks:talk foo/bar]';
 		$rule = $this->rule;
-		Assert::false($rule->getRule()($textArea));
-		Assert::same(ShouldNotHappenException::class . ': wuh', (string)$rule);
-		Assert::same((string)$rule, (string)$rule->getMessage());
+		Assert::true($rule->getRule()($textArea));
+		Assert::same([ShouldNotHappenException::class . ': wuh'], $textArea->getErrors());
 	}
 
 
@@ -78,9 +75,8 @@ final class FormValidatorRuleTexyTest extends TestCase
 		$textArea = new TextArea();
 		$textArea->value = 'Le Bar "foo":[link:Www:Talks:talk foo/bar]';
 		$rule = $this->rule;
-		Assert::false($rule->getRule()($textArea));
-		Assert::same('Invalid link: oops/bar', (string)$rule);
-		Assert::same((string)$rule, (string)$rule->getMessage());
+		Assert::true($rule->getRule()($textArea));
+		Assert::same(['Invalid link: oops/bar'], $textArea->getErrors());
 	}
 
 }


### PR DESCRIPTION
The rules now directly set the error message on the field and return true like nothing happened. This makes the code shorter, clear and more secure.

To test that all the things are escaped properly, try editing talk slides, and add
```latte
foo:[blog:<img src=x>]
```
To the slide's speaker notes field. Submit the form and you should see
```
Invalid link: Blog post linked in [blog:<img src=x>] doesn't exist
```
in two places, one error message below the field and another one above the form, both correctly escaped.

The interfaces originally added in #684

Close #685