### PR TITLE
Restrict passkey APIs to `()` in `Permissions-Policy` where passkeys are not used or created

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -104,6 +104,7 @@ services:
 	- MichalSpacekCz\Http\SecurityHeaders\CrossOriginResourceSharing
 	integrityPolicy: MichalSpacekCz\Http\SecurityHeaders\IntegrityPolicy\IntegrityPolicyDefault
 	- MichalSpacekCz\Http\SecurityHeaders\SecurityHeaders(reportingApiUrl: %reporting.reportingApi%)
+	- MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicy
 	- MichalSpacekCz\Http\SessionGarbageCollector\SessionGarbageCollector
 	- MichalSpacekCz\Http\SessionGarbageCollector\SessionGarbageCollectorStatusFactory
 	- MichalSpacekCz\Http\SessionGarbageCollector\SessionGarbageCollectorStatusMessageFactory

--- a/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicy.php
+++ b/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicy.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy;
+
+use MichalSpacekCz\Http\StructuredHeaders;
+use MichalSpacekCz\Presentation\Www\BasePresenter;
+use Nette\Application\Application;
+use Nette\Http\IResponse;
+
+final readonly class PermissionsPolicy
+{
+
+	public function __construct(
+		private IResponse $httpResponse,
+		private Application $application,
+		private StructuredHeaders $structuredHeaders,
+	) {
+	}
+
+
+	public function set(): void
+	{
+		$policy = [];
+		foreach (PermissionsPolicyDirective::cases() as $directive) {
+			$policy[$directive->value] = PermissionsPolicyOrigin::None;
+		}
+		$presenter = $this->application->getPresenter();
+		if ($presenter instanceof BasePresenter) {
+			$policy = array_merge($policy, $presenter->getPermissionsPolicy());
+		}
+		$this->httpResponse->setHeader('Permissions-Policy', $this->structuredHeaders->get($policy));
+	}
+
+}

--- a/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyDirective.php
+++ b/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyDirective.php
@@ -14,6 +14,8 @@ enum PermissionsPolicyDirective: string
 	case Microphone = 'microphone';
 	case Midi = 'midi';
 	case Payment = 'payment';
+	case PublicKeyCredentialsCreate = 'publickey-credentials-create';
+	case PublicKeyCredentialsGet = 'publickey-credentials-get';
 	case Usb = 'usb';
 
 }

--- a/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyDirective.php
+++ b/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyDirective.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy;
+
+enum PermissionsPolicyDirective: string
+{
+
+	case Accelerometer = 'accelerometer';
+	case Camera = 'camera';
+	case Geolocation = 'geolocation';
+	case Gyroscope = 'gyroscope';
+	case Magnetometer = 'magnetometer';
+	case Microphone = 'microphone';
+	case Midi = 'midi';
+	case Payment = 'payment';
+	case Usb = 'usb';
+
+}

--- a/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyOrigin.php
+++ b/app/src/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyOrigin.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\Http\SecurityHeaders;
+namespace MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy;
 
 enum PermissionsPolicyOrigin: string
 {

--- a/app/src/Http/SecurityHeaders/SecurityHeaders.php
+++ b/app/src/Http/SecurityHeaders/SecurityHeaders.php
@@ -5,9 +5,7 @@ namespace MichalSpacekCz\Http\SecurityHeaders;
 
 use MichalSpacekCz\Http\ContentSecurityPolicy\CspValues;
 use MichalSpacekCz\Http\SecurityHeaders\IntegrityPolicy\IntegrityPolicy;
-use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
-use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
-use MichalSpacekCz\Http\StructuredHeaders;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicy;
 use Nette\Application\Application;
 use Nette\Application\UI\Presenter;
 use Nette\Http\IResponse;
@@ -21,7 +19,7 @@ final readonly class SecurityHeaders
 		private IResponse $httpResponse,
 		private Application $application,
 		private CspConfig $contentSecurityPolicy,
-		private StructuredHeaders $structuredHeaders,
+		private PermissionsPolicy $permissionsPolicy,
 		private IntegrityPolicy $integrityPolicy,
 		private string $reportingApiUrl,
 	) {
@@ -39,7 +37,7 @@ final readonly class SecurityHeaders
 		$this->httpResponse->setHeader('X-Frame-Options', 'DENY');
 		$this->httpResponse->setHeader('Referrer-Policy', 'no-referrer, strict-origin-when-cross-origin');
 		$this->sendContentSecurityPolicyHeaders($cspValues);
-		$this->httpResponse->setHeader('Permissions-Policy', $this->buildPermissionsPolicy());
+		$this->permissionsPolicy->set();
 		$this->integrityPolicy->set();
 		$this->httpResponse->setHeader('Report-To', Json::encode([
 			'group' => ReportingApiEndpointName::Default->value,
@@ -52,16 +50,6 @@ final readonly class SecurityHeaders
 			'max_age' => 31536000,
 			'include_subdomains' => true,
 		]));
-	}
-
-
-	private function buildPermissionsPolicy(): string
-	{
-		$policy = [];
-		foreach (PermissionsPolicyDirective::cases() as $directive) {
-			$policy[$directive->value] = PermissionsPolicyOrigin::None;
-		}
-		return $this->structuredHeaders->get($policy);
 	}
 
 

--- a/app/src/Http/SecurityHeaders/SecurityHeaders.php
+++ b/app/src/Http/SecurityHeaders/SecurityHeaders.php
@@ -5,6 +5,8 @@ namespace MichalSpacekCz\Http\SecurityHeaders;
 
 use MichalSpacekCz\Http\ContentSecurityPolicy\CspValues;
 use MichalSpacekCz\Http\SecurityHeaders\IntegrityPolicy\IntegrityPolicy;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Http\StructuredHeaders;
 use Nette\Application\Application;
 use Nette\Application\UI\Presenter;
@@ -37,17 +39,7 @@ final readonly class SecurityHeaders
 		$this->httpResponse->setHeader('X-Frame-Options', 'DENY');
 		$this->httpResponse->setHeader('Referrer-Policy', 'no-referrer, strict-origin-when-cross-origin');
 		$this->sendContentSecurityPolicyHeaders($cspValues);
-		$this->httpResponse->setHeader('Permissions-Policy', $this->structuredHeaders->get([
-			'accelerometer' => PermissionsPolicyOrigin::None,
-			'camera' => PermissionsPolicyOrigin::None,
-			'geolocation' => PermissionsPolicyOrigin::None,
-			'gyroscope' => PermissionsPolicyOrigin::None,
-			'magnetometer' => PermissionsPolicyOrigin::None,
-			'microphone' => PermissionsPolicyOrigin::None,
-			'midi' => PermissionsPolicyOrigin::None,
-			'payment' => PermissionsPolicyOrigin::None,
-			'usb' => PermissionsPolicyOrigin::None,
-		]));
+		$this->httpResponse->setHeader('Permissions-Policy', $this->buildPermissionsPolicy());
 		$this->integrityPolicy->set();
 		$this->httpResponse->setHeader('Report-To', Json::encode([
 			'group' => ReportingApiEndpointName::Default->value,
@@ -60,6 +52,16 @@ final readonly class SecurityHeaders
 			'max_age' => 31536000,
 			'include_subdomains' => true,
 		]));
+	}
+
+
+	private function buildPermissionsPolicy(): string
+	{
+		$policy = [];
+		foreach (PermissionsPolicyDirective::cases() as $directive) {
+			$policy[$directive->value] = PermissionsPolicyOrigin::None;
+		}
+		return $this->structuredHeaders->get($policy);
 	}
 
 

--- a/app/src/Presentation/Admin/Passkey/PasskeyPresenter.php
+++ b/app/src/Presentation/Admin/Passkey/PasskeyPresenter.php
@@ -6,6 +6,8 @@ namespace MichalSpacekCz\Presentation\Admin\Passkey;
 use Contributte\Translation\Translator;
 use MichalSpacekCz\Form\UiForm;
 use MichalSpacekCz\Form\User\PasskeyRegisterFormFactory;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Admin\BasePresenter;
 use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\WebAuthn\WebAuthnAuthenticator;
@@ -30,6 +32,7 @@ final class PasskeyPresenter extends BasePresenter
 
 	public function actionRegister(): void
 	{
+		$this->addPermissionsPolicy(PermissionsPolicyDirective::PublicKeyCredentialsCreate, PermissionsPolicyOrigin::Self);
 		$this->template->pageTitle = $this->translator->translate('messages.passkeys.registerPasskey');
 	}
 

--- a/app/src/Presentation/Admin/Sign/SignPresenter.php
+++ b/app/src/Presentation/Admin/Sign/SignPresenter.php
@@ -9,6 +9,8 @@ use MichalSpacekCz\Form\User\PasskeyAuthenticateFormFactory;
 use MichalSpacekCz\Form\User\PasskeyResetFormFactory;
 use MichalSpacekCz\Form\User\SignInHoneypotFormFactory;
 use MichalSpacekCz\Http\HttpInput;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Www\BasePresenter;
 use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetException;
@@ -53,6 +55,7 @@ final class SignPresenter extends BasePresenter
 
 	public function actionIn(): void
 	{
+		$this->addPermissionsPolicy(PermissionsPolicyDirective::PublicKeyCredentialsGet, PermissionsPolicyOrigin::Self);
 		$this->sessionHandler->start();
 		$token = $this->authenticator->verifyPermanentLogin();
 		if ($token !== null) {
@@ -103,6 +106,7 @@ final class SignPresenter extends BasePresenter
 
 	public function actionPasskeyReset(): void
 	{
+		$this->addPermissionsPolicy(PermissionsPolicyDirective::PublicKeyCredentialsCreate, PermissionsPolicyOrigin::Self);
 		$this->template->pageTitle = $this->translator->translate('messages.passkeys.registration');
 	}
 

--- a/app/src/Presentation/Www/BasePresenter.php
+++ b/app/src/Presentation/Www/BasePresenter.php
@@ -11,6 +11,8 @@ use MichalSpacekCz\Css\CriticalCssFactory;
 use MichalSpacekCz\EasterEgg\FourOhFourButFound\FourOhFourButFound;
 use MichalSpacekCz\Form\ThemeFormFactory;
 use MichalSpacekCz\Form\UiForm;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Templating\DefaultTemplate;
 use MichalSpacekCz\User\Manager;
 use Nette\Application\Request;
@@ -25,6 +27,9 @@ use Override;
  */
 abstract class BasePresenter extends Presenter
 {
+
+	/** @var array<value-of<PermissionsPolicyDirective>, list<PermissionsPolicyOrigin|string>> */
+	private array $permissionsPolicy = [];
 
 	private Manager $authenticator;
 
@@ -180,6 +185,21 @@ abstract class BasePresenter extends Presenter
 	{
 		$this->getHttpResponse()->setContentType('application/json');
 		$this->sendResponse(new TextResponse($json));
+	}
+
+
+	protected function addPermissionsPolicy(PermissionsPolicyDirective $directive, PermissionsPolicyOrigin|string $origin): void
+	{
+		$this->permissionsPolicy[$directive->value][] = $origin;
+	}
+
+
+	/**
+	 * @return array<value-of<PermissionsPolicyDirective>, list<PermissionsPolicyOrigin|string>>
+	 */
+	public function getPermissionsPolicy(): array
+	{
+		return $this->permissionsPolicy;
 	}
 
 

--- a/app/tests/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyTest.phpt
+++ b/app/tests/Http/SecurityHeaders/PermissionsPolicy/PermissionsPolicyTest.phpt
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy;
+
+use MichalSpacekCz\Presentation\Www\BasePresenter;
+use MichalSpacekCz\Test\Http\Response;
+use MichalSpacekCz\Test\PrivateProperty;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Application\Application;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../../bootstrap.php';
+
+/** @testCase */
+final class PermissionsPolicyTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Response $httpResponse,
+		private readonly Application $application,
+		private readonly PermissionsPolicy $permissionsPolicy,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->httpResponse->reset();
+	}
+
+
+	public function testSetDefault(): void
+	{
+		$presenter = new class extends BasePresenter {
+		};
+		PrivateProperty::setValue($this->application, 'presenter', $presenter);
+		$this->permissionsPolicy->set();
+		Assert::same(
+			'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-create=(), publickey-credentials-get=(), usb=()',
+			$this->httpResponse->getHeaders()['permissions-policy'],
+		);
+	}
+
+
+	public function testSetMultipleOriginsIncludingString(): void
+	{
+		$presenter = new class extends BasePresenter {
+
+			public function addPermissionsPolicyPublic(PermissionsPolicyDirective $directive, PermissionsPolicyOrigin|string $origin): void
+			{
+				$this->addPermissionsPolicy($directive, $origin);
+			}
+
+		};
+		$presenter->addPermissionsPolicyPublic(PermissionsPolicyDirective::PublicKeyCredentialsGet, PermissionsPolicyOrigin::Self);
+		$presenter->addPermissionsPolicyPublic(PermissionsPolicyDirective::PublicKeyCredentialsGet, 'https://foo.example');
+		$presenter->addPermissionsPolicyPublic(PermissionsPolicyDirective::PublicKeyCredentialsCreate, PermissionsPolicyOrigin::Self);
+		$presenter->addPermissionsPolicyPublic(PermissionsPolicyDirective::PublicKeyCredentialsCreate, 'https://bar.example');
+		PrivateProperty::setValue($this->application, 'presenter', $presenter);
+		$this->permissionsPolicy->set();
+		Assert::same(
+			'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-create=(self "https://bar.example"), publickey-credentials-get=(self "https://foo.example"), usb=()',
+			$this->httpResponse->getHeaders()['permissions-policy'],
+		);
+	}
+
+}
+
+TestCaseRunner::run(PermissionsPolicyTest::class);

--- a/app/tests/Http/SecurityHeaders/SecurityHeadersTest.phpt
+++ b/app/tests/Http/SecurityHeaders/SecurityHeadersTest.phpt
@@ -33,7 +33,7 @@ final class SecurityHeadersTest extends TestCase
 		'x-content-type-options' => 'nosniff',
 		'x-frame-options' => 'DENY',
 		'referrer-policy' => 'no-referrer, strict-origin-when-cross-origin',
-		'permissions-policy' => 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), usb=()',
+		'permissions-policy' => 'accelerometer=(), camera=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), publickey-credentials-create=(), publickey-credentials-get=(), usb=()',
 		'integrity-policy' => 'foo=(bar)',
 		'report-to' => '{"group":"default","max_age":31536000,"endpoints":[{"url":"https://plz.report-uri.com/a/d/g"}],"include_subdomains":true}',
 		'nel' => '{"report_to":"default","max_age":31536000,"include_subdomains":true}',

--- a/app/tests/Http/StructuredHeadersTest.phpt
+++ b/app/tests/Http/StructuredHeadersTest.phpt
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Http;
 
-use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicyOrigin;
+use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;


### PR DESCRIPTION
Enforced by Chrome for cross-origin iframes, not enforced for top-level documents, at least for now, but let's allow `self` where passkeys are used or created.

For #731