### PR TITLE
Add safe Texy format filters with literal-arg substitution

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,19 @@ admin.sign.passkeyreset:   # Nette: Admin:Sign:passkeyReset → lowercased, dott
         - "'self'"
 ```
 
+### Texy format filters
+
+Two Latte filters and their `TexyFormatter` PHP equivalents exist for formatting translated strings with substituted arguments:
+
+| Latte filter | PHP method | Use when |
+|---|---|---|
+| `\|formatText` | `TexyFormatter::substituteText()` / `translateText()` | Any arg may be user-controlled — args are HTML-escaped and never interpreted as Texy markup |
+| `\|formatPossiblyUnsafeHtml` | `TexyFormatter::substitute()` / `translate()` | Args are developer/admin-controlled Texy content (`link:Www:Foo:`, URLs, emails) |
+
+`|format` is a legacy alias for `|formatPossiblyUnsafeHtml` — do not use in new code.
+
+When reviewing templates: flag any `|formatPossiblyUnsafeHtml:$variable` or `|format:$variable` where the variable may be user-controlled. Use `|formatText` instead.
+
 ### Error and UI messages
 
 Do not end error or UI messages with a full stop (`.`). This applies to short status and error strings (e.g. "Passkey registration failed") — full instructional sentences that are grammatically complete may keep their period.

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -60,9 +60,6 @@ parameters:
 				form: [action, method, target]
 				button: []
 				input: [type, name, value]
-	texyFormatter:
-		allowed:
-			longWords: true
 
 	# Added/changed in local.neon
 	contact:

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -79,9 +79,9 @@ services:
 	- MichalSpacekCz\Form\Validators\FormValidatorTexyFormatter
 	- MichalSpacekCz\Formatter\Placeholders\TrainingDateTexyFormatterPlaceholder
 	- MichalSpacekCz\Formatter\Placeholders\FetchMetadataTexyFormatterPlaceholder
-	texyFormatter: MichalSpacekCz\Formatter\TexyFormatter(cache: @texyFormatterPhpFilesAdapter, placeholders: typed(MichalSpacekCz\Formatter\Placeholders\TexyFormatterPlaceholder), allowedLongWords: %texyFormatter.allowed.longWords%, staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
+	texyFormatter: MichalSpacekCz\Formatter\TexyFormatter(cache: @texyFormatterPhpFilesAdapter, placeholders: typed(MichalSpacekCz\Formatter\Placeholders\TexyFormatterPlaceholder), staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
 	texyFormatterNoPlaceholders:
-		create: MichalSpacekCz\Formatter\TexyFormatter(cache: @texyFormatterPhpFilesAdapter, placeholders: [], allowedLongWords: %texyFormatter.allowed.longWords%, staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
+		create: MichalSpacekCz\Formatter\TexyFormatter(cache: @texyFormatterPhpFilesAdapter, placeholders: [], staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
 		autowired: false
 	- MichalSpacekCz\Formatter\TexyPhraseHandler\Shortcuts\TexyShortcutBlog
 	- MichalSpacekCz\Formatter\TexyPhraseHandler\Shortcuts\TexyShortcutBlogWithLocale

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -7,9 +7,6 @@ parameters:
 		rootDomainMapping:
 			cz: rizek.test
 			com: burger.test
-	texyFormatter:
-		allowed:
-			longWords: false
 	encryption:
 		keys:
 			password!:
@@ -44,7 +41,7 @@ services:
 	database.upcKeys.explorer: @database.default.explorer
 	database.pulse.explorer: @database.default.explorer
 	dateTimeFactory: MichalSpacekCz\Test\DateTime\DateTimeMachineFactory
-	texyFormatter: MichalSpacekCz\Test\Formatter\TexyFormatterMock(cache: @texyFormatterPhpFilesAdapter, placeholders: typed(MichalSpacekCz\Formatter\Placeholders\TexyFormatterPlaceholder), allowedLongWords: %texyFormatter.allowed.longWords%, staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
+	texyFormatter: MichalSpacekCz\Test\Formatter\TexyFormatterMock(cache: @texyFormatterPhpFilesAdapter, placeholders: typed(MichalSpacekCz\Formatter\Placeholders\TexyFormatterPlaceholder), staticRoot: %domain.sharedStaticRoot%, imagesRoot: %domain.imagesRoot%, locationRoot: %domain.locationRoot%)
 	httpClient: MichalSpacekCz\Test\Http\Client\HttpClientMock
 	- MichalSpacekCz\Test\Form\FormComponents
 	passkeyAuthentication: MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock

--- a/app/psalm.xml
+++ b/app/psalm.xml
@@ -81,6 +81,7 @@
 				<referencedMethod name="MichalSpacekCz\Application\Routing\RouterFactory::createRouter" /> <!-- Used in services.neon -->
 				<referencedMethod name="/^MichalSpacekCz\\Test\\Http\\Request::(set|add).*/" /> <!-- Not used but keep them just in case -->
 				<referencedMethod name="/^MichalSpacekCz\\Test\\Http\\Response::(deleteHeader|sent).*/" /> <!-- Not used but keep them just in case -->
+				<referencedMethod name="MichalSpacekCz\Formatter\TexyFormatter::translateText" /> <!-- Used in the passkeys UI, separate PR #737 -->
 			</errorLevel>
 		</PossiblyUnusedMethod>
 		<PossiblyUnusedReturnValue>

--- a/app/src/Form/Validators/FormValidatorTexyFormatter.php
+++ b/app/src/Form/Validators/FormValidatorTexyFormatter.php
@@ -29,7 +29,7 @@ final readonly class FormValidatorTexyFormatter
 		try {
 			// Use a fresh Texy instance to avoid stale internal status throwing "Processing is in progress" exception on next Texy render.
 			// It's ok to format the same input multiple times, because TexyFormatter caches the output and uses the cache when needed.
-			$texyFormatter = $this->texyFormatter->withTexy($this->texyFormatter->getTexy());
+			$texyFormatter = $this->texyFormatter->withTexy($this->texyFormatter->createTexy());
 			return $texyFormatter->format($value);
 		} catch (Exception $e) {
 			$prefix = $e instanceof InvalidLinkException ? 'Invalid link' : $e::class;

--- a/app/src/Formatter/TexyFormatter.php
+++ b/app/src/Formatter/TexyFormatter.php
@@ -22,6 +22,8 @@ class TexyFormatter
 
 	private ?Texy $texy = null;
 
+	private ?Texy $texyNoLongWords = null;
+
 	private bool $cacheResult = true;
 
 	/**
@@ -53,7 +55,6 @@ class TexyFormatter
 		private readonly Translator $translator,
 		private readonly TexyPhraseHandler $phraseHandler,
 		private readonly array $placeholders,
-		private readonly bool $allowedLongWords,
 		string $staticRoot,
 		string $imagesRoot,
 		string $locationRoot,
@@ -94,29 +95,46 @@ class TexyFormatter
 		if ($this->texy !== null) {
 			$this->texy->headingModule->top = $this->topHeading;
 		}
+		if ($this->texyNoLongWords !== null) {
+			$this->texyNoLongWords->headingModule->top = $this->topHeading;
+		}
 		return $this;
 	}
 
 
-	/**
-	 * Create Texy object.
-	 *
-	 * @return Texy
-	 */
+	public function createTexy(): Texy
+	{
+		$texy = new Texy();
+		$texy->allowedTags = Texy::NONE;
+		$texy->imageModule->root = "{$this->staticRoot}/{$this->imagesRoot}";
+		$texy->imageModule->fileRoot = "{$this->locationRoot}/{$this->imagesRoot}";
+		$texy->figureModule->widthDelta = false; // prevents adding 'unsafe-inline' style="width: Xpx" attribute to <div class="figure">
+		$texy->headingModule->generateID = true;
+		$texy->headingModule->idPrefix = '';
+		$texy->headingModule->top = $this->topHeading;
+		$texy->typographyModule->locale = substr($this->translator->getDefaultLocale(), 0, 2); // en_US → en
+		$texy->allowed['phrase/del'] = true;
+		$texy->allowed['longwords'] = true;
+		$texy->addHandler('phrase', $this->phraseHandler->solve(...));
+		return $texy;
+	}
+
+
+	private function getTexyNoLongWords(): Texy
+	{
+		if ($this->texyNoLongWords === null) {
+			$this->texyNoLongWords = $this->createTexy();
+			$this->texyNoLongWords->allowed['longwords'] = false;
+		}
+		return $this->texyNoLongWords;
+	}
+
+
 	public function getTexy(): Texy
 	{
-		$this->texy = new Texy();
-		$this->texy->allowedTags = Texy::NONE;
-		$this->texy->imageModule->root = "{$this->staticRoot}/{$this->imagesRoot}";
-		$this->texy->imageModule->fileRoot = "{$this->locationRoot}/{$this->imagesRoot}";
-		$this->texy->figureModule->widthDelta = false; // prevents adding 'unsafe-inline' style="width: Xpx" attribute to <div class="figure">
-		$this->texy->headingModule->generateID = true;
-		$this->texy->headingModule->idPrefix = '';
-		$this->texy->typographyModule->locale = substr($this->translator->getDefaultLocale(), 0, 2); // en_US → en
-		$this->texy->allowed['phrase/del'] = true;
-		$this->texy->allowed['longwords'] = $this->allowedLongWords;
-		$this->texy->addHandler('phrase', $this->phraseHandler->solve(...));
-		$this->setTopHeading($this->topHeading);
+		if ($this->texy === null) {
+			$this->texy = $this->createTexy();
+		}
 		return $this->texy;
 	}
 
@@ -134,6 +152,30 @@ class TexyFormatter
 
 
 	/**
+	 * Like substitute() but treats each arg as literal text - args are HTML-escaped and never interpreted as Texy markup.
+	 * Use this whenever any arg may be user-controlled.
+	 *
+	 * @param list<string|Stringable|int> $args
+	 */
+	public function substituteText(string|Stringable $format, array $args): Html
+	{
+		$formatString = (string)$format;
+		// Texy::protect() can't be used: Texy::process() clears $this->marks
+		// No : in prefix to avoid matching format placeholders (KEY:value)
+		$markerPrefix = 'TEXY_FORMAT_ARG_' . Hash::nonCryptographic($formatString);
+		$markers = [];
+		$replacements = [];
+		foreach ($args as $i => $arg) {
+			$marker = $markerPrefix . '#' . $i;
+			$markers[] = $marker;
+			$replacements[$marker] = htmlspecialchars((string)$arg);
+		}
+		$html = (string)$this->withTexy($this->getTexyNoLongWords())->format(vsprintf($formatString, $markers));
+		return Html::el()->setHtml(strtr($html, $replacements));
+	}
+
+
+	/**
 	 * @param list<string> $replacements
 	 * @throws InvalidArgument
 	 */
@@ -144,13 +186,25 @@ class TexyFormatter
 
 
 	/**
+	 * Like translate() but treats each replacement as literal text - replacements are HTML-escaped and never interpreted as Texy markup.
+	 * Use this whenever any replacement may be user-controlled.
+	 *
+	 * @param list<string> $replacements
+	 */
+	public function translateText(string $message, array $replacements = []): Html
+	{
+		return $this->substituteText($this->translator->translate($message), $replacements);
+	}
+
+
+	/**
 	 * Format string and strip surrounding P element.
 	 *
 	 * Suitable for "inline" strings like headers.
 	 */
 	public function format(string $text): Html
 	{
-		$texy = $this->texy ?? $this->getTexy();
+		$texy = $this->getTexy();
 		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
 			return Regex::replace('~^\s*<p[^>]*>(.*)</p>\s*$~s', '$1', $texy->process($text))->result;
 		});
@@ -162,7 +216,7 @@ class TexyFormatter
 	 */
 	public function formatBlock(string $text): Html
 	{
-		$texy = $this->texy ?? $this->getTexy();
+		$texy = $this->getTexy();
 		return $this->replace($text . self::CACHE_KEY_DELIMITER . __FUNCTION__, $texy, function () use ($texy, $text): string {
 			return $texy->process($text);
 		});
@@ -203,7 +257,7 @@ class TexyFormatter
 
 	public function getCacheKey(string $text, Texy $texy): string
 	{
-		$key = "{$text}|" . serialize($texy->allowedTags);
+		$key = "{$text}|" . serialize($texy->allowedTags) . '|' . serialize($texy->allowed);
 		// Make the key shorter because Symfony Cache stores it in comments in cache files
 		// Don't hash the locale to make it visible inside cache files
 		return Hash::nonCryptographic($key) . '.' . $this->translator->getDefaultLocale();

--- a/app/src/Templating/Filters.php
+++ b/app/src/Templating/Filters.php
@@ -27,6 +27,8 @@ final readonly class Filters
 			'staticUrl' => $this->staticUrl(...),
 			'staticImageUrl' => $this->staticImageUrl(...),
 			'format' => $this->format(...),
+			'formatText' => $this->formatText(...),
+			'formatPossiblyUnsafeHtml' => $this->formatPossiblyUnsafeHtml(...),
 			'localeDay' => $this->dateTimeFormatter->localeDay(...),
 			'localeMonth' => $this->dateTimeFormatter->localeMonth(...),
 			'localeIntervalDay' => $this->dateTimeFormatter->localeIntervalDay(...),
@@ -48,6 +50,18 @@ final readonly class Filters
 
 
 	public function format(string|Stringable $message, string|Stringable|int ...$args): Html
+	{
+		return $this->formatPossiblyUnsafeHtml($message, ...$args);
+	}
+
+
+	public function formatText(string|Stringable $message, string|Stringable|int ...$args): Html
+	{
+		return $this->texyFormatter->substituteText($message, array_values($args));
+	}
+
+
+	public function formatPossiblyUnsafeHtml(string|Stringable $message, string|Stringable|int ...$args): Html
 	{
 		return $this->texyFormatter->substitute($message, array_values($args));
 	}

--- a/app/src/Test/Formatter/TexyFormatterMock.php
+++ b/app/src/Test/Formatter/TexyFormatterMock.php
@@ -7,11 +7,21 @@ use MichalSpacekCz\Formatter\TexyFormatter;
 use MichalSpacekCz\Test\WillThrow;
 use Nette\Utils\Html;
 use Override;
+use Texy\Texy;
 
 final class TexyFormatterMock extends TexyFormatter
 {
 
 	use WillThrow;
+
+
+	#[Override]
+	public function createTexy(): Texy
+	{
+		$texy = parent::createTexy();
+		$texy->allowed['longwords'] = false;
+		return $texy;
+	}
 
 
 	#[Override]

--- a/app/tests/Formatter/TexyFormatterTest.phpt
+++ b/app/tests/Formatter/TexyFormatterTest.phpt
@@ -184,6 +184,30 @@ final class TexyFormatterTest extends TestCase
 	}
 
 
+	public function testSetTopHeadingUpdatesNoLongWordsTexy(): void
+	{
+		$this->texyFormatter->substituteText('%s', ['init']); // Initialize $texyNoLongWords
+		$this->texyFormatter->setTopHeading(2);
+		Assert::same("<h2 id=\"title\">Title</h2>\n\n<p>`foo`</p>\n", $this->texyFormatter->substituteText("Title\n#####\n%s", ['`foo`'])->render());
+	}
+
+
+	public function testSubstituteText(): void
+	{
+		Assert::same('foo', $this->texyFormatter->substituteText('%s', ['foo'])->render());
+		Assert::same('42', $this->texyFormatter->substituteText('%s', [42])->render());
+		Assert::same('&lt;b&gt;bold&lt;/b&gt;', $this->texyFormatter->substituteText('%s', ['<b>bold</b>'])->render());
+		Assert::same('a &amp; b', $this->texyFormatter->substituteText('%s', ['a & b'])->render());
+		Assert::same('&quot;quoted&quot;', $this->texyFormatter->substituteText('%s', ['"quoted"'])->render());
+		Assert::same('&#039;single-quoted&#039;', $this->texyFormatter->substituteText('%s', ["'single-quoted'"])->render());
+		Assert::same('**bold**', $this->texyFormatter->substituteText('%s', ['**bold**'])->render());
+		Assert::same('<em>foo</em>', $this->texyFormatter->substituteText('//%s//', ['foo'])->render());
+		Assert::same('<em>&lt;script&gt;alert(1)&lt;/script&gt;</em>', $this->texyFormatter->substituteText('//%s//', ['<script>alert(1)</script>'])->render());
+		Assert::same('foo,bar', $this->texyFormatter->substituteText('%s,%s', ['foo', 'bar'])->render());
+		Assert::same('foo `bar` baz', $this->texyFormatter->substituteText('%s', ['foo `bar` baz'])->render());
+	}
+
+
 	/**
 	 * @param list<string> $args
 	 */

--- a/app/tests/Templating/FiltersTest.phpt
+++ b/app/tests/Templating/FiltersTest.phpt
@@ -55,6 +55,20 @@ final class FiltersTest extends TestCase
 		Assert::same('<strong>foo</strong>', $this->filters->format("**%s**", $html)->render());
 	}
 
+
+	public function testFormatText(): void
+	{
+		Assert::same('&lt;b&gt;bold&lt;/b&gt;', $this->filters->formatText('%s', '<b>bold</b>')->render());
+		Assert::same('**bold**', $this->filters->formatText('%s', '**bold**')->render());
+		Assert::same('<em>foo</em>', $this->filters->formatText('//%s//', 'foo')->render());
+	}
+
+
+	public function testFormatPossiblyUnsafeHtml(): void
+	{
+		Assert::same('<strong>foo</strong>', $this->filters->formatPossiblyUnsafeHtml('**%s**', 'foo')->render());
+	}
+
 }
 
 TestCaseRunner::run(FiltersTest::class);


### PR DESCRIPTION
`TexyFormatter::substitute()` passes args through Texy processing, so user-controlled values can inject Texy markup (e.g. a passkey name containing \`code\` or \*\*bold\*\* would be rendered as HTML). This becomes a real concern as the site expands beyond a personal blog to include user signups.

Adds `substituteText()` and `translateText()` as safe alternatives: args are replaced with opaque markers before Texy processing, then substituted back as `htmlspecialchars()`-escaped strings after. Adds `|formatText` and `|formatPossiblyUnsafeHtml` Latte filters backed by these methods. `|format` is kept as a legacy alias for `|formatPossiblyUnsafeHtml`.

The safe path uses a dedicated no-longwords Texy instance (`getTexyNoLongWords()`) to prevent the `LongWords` module from inserting soft hyphens into markers and breaking the substitution. The `allowedLongWords` constructor param is removed — test behavior is now handled by `TexyFormatterMock::getTexy()` overriding to disable longwords. Cache key updated to include `serialize($texy->allowed)` to avoid collisions between the two Texy instances.