### PR TITLE
Install packages for `tester-include-skipped` after the `vendor-dev` split

### DIFF
--- a/.github/workflows/php-tester-include-skipped.yml
+++ b/.github/workflows/php-tester-include-skipped.yml
@@ -25,6 +25,7 @@ jobs:
       run: |
         sudo mkdir --parents /srv/www
         sudo ln --symbolic $GITHUB_WORKSPACE /srv/www
+    - run: composer --working-dir=app/vendor-dev install
     - run: make --directory=app tester-include-skipped
     - name: Failed test output, if any
       if: failure()


### PR DESCRIPTION
Follow-up to #726