### PR TITLE
Split `Manager` into typed token services

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -194,13 +194,16 @@ services:
 	- MichalSpacekCz\UpcKeys\Ubee(@database.upcKeys.explorer)
 	- MichalSpacekCz\UpcKeys\UpcKeys(routers: [@MichalSpacekCz\UpcKeys\Technicolor, @MichalSpacekCz\UpcKeys\Ubee])
 	- MichalSpacekCz\UpcKeys\UpcKeysStorageConversions
-	- MichalSpacekCz\User\Manager(permanentLoginInterval: %permanentLogin.interval%, resetEnabled: %authentication.passkeys.resetEnabled%, usersTableName: %authentication.tables.users%)
+	- MichalSpacekCz\User\AuthTokens\UserAuthTokens(usersTableName: %authentication.tables.users%)
+	- MichalSpacekCz\User\Manager(usersTableName: %authentication.tables.users%)
+	- MichalSpacekCz\User\PermanentLogin\PermanentLogin(interval: %permanentLogin.interval%)
 	passkeySessionSectionFactory: MichalSpacekCz\User\WebAuthn\PasskeySessionSectionFactory
 	- @passkeySessionSectionFactory::create()
 	userPasskeys: MichalSpacekCz\User\WebAuthn\UserPasskeys(passkeysTableName: %authentication.tables.passkeys%)
 	passkeyStorage: MichalSpacekCz\User\WebAuthn\PasskeyStorage(passkeysTableName: %authentication.tables.passkeys%, usersTableName: %authentication.tables.users%)
 	passkeyAuthentication: MichalSpacekCz\User\WebAuthn\PasskeyAuthenticator(rpId: %authentication.passkeys.rpId%, rpName: %authentication.passkeys.rpName%)
 	- MichalSpacekCz\User\WebAuthn\PasskeyReset
+	- MichalSpacekCz\User\WebAuthn\PasskeyResetTokens(resetEnabled: %authentication.passkeys.resetEnabled%)
 	- MichalSpacekCz\User\WebAuthn\PasskeyResetUrl
 	- MichalSpacekCz\User\UserSessionAdditionalData
 	sleep: MichalSpacekCz\Utils\Sleep

--- a/app/disallowed-calls.neon
+++ b/app/disallowed-calls.neon
@@ -74,6 +74,16 @@ parameters:
 				- 'Nette\Forms\Container::getValues()'
 				- 'Nette\Forms\Container::getUntrustedValues()'
 			message: 'use methods from MichalSpacekCz\Form\UiForm instead'
+		-
+			method: 'MichalSpacekCz\User\AuthTokens\UserAuthTokens::*'
+			message: 'instead use a class that implements the UserAuthTokenLifetime interface'
+			errorTip: 'Each token type has its own rules (TTL, whether it is enabled, etc.) checked by the classes that implement UserAuthTokenLifetime, calling these methods directly skips those checks'
+			allowIn:
+				- tests/*.phpt
+			allowInMethods:
+				- 'MichalSpacekCz\User\AuthTokens\UserAuthTokens::*' # internal calls, e.g. replaceForUser() -> insert()
+				- 'MichalSpacekCz\User\PermanentLogin\PermanentLogin::*'
+				- 'MichalSpacekCz\User\WebAuthn\PasskeyResetTokens::*'
 
 	disallowedConstants:
 		-

--- a/app/src/Form/User/PasskeyAuthenticateFormFactory.php
+++ b/app/src/Form/User/PasskeyAuthenticateFormFactory.php
@@ -7,6 +7,7 @@ use Contributte\Translation\Translator;
 use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\Form\UiForm;
 use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyException;
 use MichalSpacekCz\User\WebAuthn\WebAuthnAuthenticator;
 use Nette\Http\IRequest;
@@ -20,6 +21,7 @@ final readonly class PasskeyAuthenticateFormFactory
 		private FormFactory $factory,
 		private WebAuthnAuthenticator $passkeyAuthenticator,
 		private Manager $authenticator,
+		private PermanentLogin $permanentLogin,
 		private User $user,
 		private IRequest $httpRequest,
 		private Translator $translator,
@@ -49,7 +51,7 @@ final readonly class PasskeyAuthenticateFormFactory
 				$result = $this->passkeyAuthenticator->verifyAuthentication($values->credential);
 				$this->user->setExpiration('30 minutes', true);
 				$this->user->login($this->authenticator->getIdentity($result->userId, $result->username));
-				$this->authenticator->regeneratePermanentLogin($this->user);
+				$this->permanentLogin->regenerate($this->user);
 				Debugger::log("Successful passkey sign-in ({$result->username}, {$this->httpRequest->getRemoteAddress()})", 'auth');
 				$onSuccess();
 			} catch (PasskeyException $e) {

--- a/app/src/Form/User/RegenerateTokensFormFactory.php
+++ b/app/src/Form/User/RegenerateTokensFormFactory.php
@@ -5,7 +5,7 @@ namespace MichalSpacekCz\Form\User;
 
 use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\Form\UiForm;
-use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use Nette\Http\Session;
 use Nette\Security\User;
 use Nette\Utils\Html;
@@ -16,7 +16,7 @@ final readonly class RegenerateTokensFormFactory
 	public function __construct(
 		private FormFactory $factory,
 		private Session $sessionHandler,
-		private Manager $authenticator,
+		private PermanentLogin $permanentLogin,
 		private User $user,
 	) {
 	}
@@ -38,7 +38,7 @@ final readonly class RegenerateTokensFormFactory
 				$this->sessionHandler->regenerateId();
 			}
 			if ($values->permanent) {
-				$this->authenticator->regeneratePermanentLogin($this->user);
+				$this->permanentLogin->regenerate($this->user);
 			}
 			$onSuccess('Tokeny přegenerovány');
 		};

--- a/app/src/Http/Cookies/CookieDescriptions.php
+++ b/app/src/Http/Cookies/CookieDescriptions.php
@@ -7,14 +7,14 @@ use MichalSpacekCz\Application\Theme\Theme;
 use MichalSpacekCz\DateTime\DateTimeParser;
 use MichalSpacekCz\Formatter\TexyFormatter;
 use MichalSpacekCz\ShouldNotHappenException;
-use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use Nette\Http\Session;
 
 final readonly class CookieDescriptions
 {
 
 	public function __construct(
-		private Manager $authenticator,
+		private PermanentLogin $permanentLogin,
 		private Theme $theme,
 		private Session $sessionHandler,
 		private TexyFormatter $texyFormatter,
@@ -38,7 +38,7 @@ final readonly class CookieDescriptions
 				CookieName::PermanentLogin->value,
 				true,
 				$this->texyFormatter->translate('messages.cookies.cookie.permanentLogin'),
-				$this->dateTimeParser->getDaysFromString($this->authenticator->getPermanentLoginCookieLifetime()),
+				$this->dateTimeParser->getDaysFromString($this->permanentLogin->getCookieLifetime()),
 			),
 			new CookieDescription(
 				CookieName::Theme->value,

--- a/app/src/Presentation/Admin/Sign/SignPresenter.php
+++ b/app/src/Presentation/Admin/Sign/SignPresenter.php
@@ -13,6 +13,7 @@ use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirec
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Www\BasePresenter;
 use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetException;
 use MichalSpacekCz\User\WebAuthn\PasskeyReset;
 use MichalSpacekCz\User\WebAuthn\WebAuthnAuthenticator;
@@ -33,6 +34,7 @@ final class SignPresenter extends BasePresenter
 
 	public function __construct(
 		private readonly Manager $authenticator,
+		private readonly PermanentLogin $permanentLogin,
 		private readonly SignInHoneypotFormFactory $signInHoneypotFormFactory,
 		private readonly PasskeyAuthenticateFormFactory $passkeyAuthenticateFormFactory,
 		private readonly PasskeyResetFormFactory $passkeyResetFormFactory,
@@ -57,10 +59,10 @@ final class SignPresenter extends BasePresenter
 	{
 		$this->addPermissionsPolicy(PermissionsPolicyDirective::PublicKeyCredentialsGet, PermissionsPolicyOrigin::Self);
 		$this->sessionHandler->start();
-		$token = $this->authenticator->verifyPermanentLogin();
+		$token = $this->permanentLogin->verify();
 		if ($token !== null) {
 			$this->user->login($this->authenticator->getIdentity($token->getUserId(), $token->getUsername()));
-			$this->authenticator->regeneratePermanentLogin($this->user);
+			$this->permanentLogin->regenerate($this->user);
 			$this->restoreRequest($this->backlink);
 			$this->redirect('Homepage:');
 		}
@@ -138,7 +140,7 @@ final class SignPresenter extends BasePresenter
 
 	public function actionOut(): never
 	{
-		$this->authenticator->clearPermanentLogin($this->user);
+		$this->permanentLogin->clear($this->user);
 		$this->user->logout();
 		$this->flashMessage('Byli jste odhlášeni');
 		$this->redirect('in');

--- a/app/src/User/AuthTokens/UserAuthToken.php
+++ b/app/src/User/AuthTokens/UserAuthToken.php
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\User;
+namespace MichalSpacekCz\User\AuthTokens;
 
 final readonly class UserAuthToken
 {

--- a/app/src/User/AuthTokens/UserAuthTokenLifetime.php
+++ b/app/src/User/AuthTokens/UserAuthTokenLifetime.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\AuthTokens;
+
+interface UserAuthTokenLifetime
+{
+
+	public function getTokenType(): UserAuthTokenType;
+
+
+	/**
+	 * @return string Relative time expression accepted by DateTimeImmutable, e.g. '5 minutes' or '14 days'
+	 */
+	public function getTtl(): string;
+
+}

--- a/app/src/User/AuthTokens/UserAuthTokenType.php
+++ b/app/src/User/AuthTokens/UserAuthTokenType.php
@@ -1,13 +1,13 @@
 <?php
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\User;
+namespace MichalSpacekCz\User\AuthTokens;
 
 enum UserAuthTokenType: int
 {
 
 	case PermanentLogin = 1;
 	// ReturningUser = 2; not used anymore
-	case PasskeyReset = 3;
+	case AdminPasskeyReset = 3;
 
 }

--- a/app/src/User/AuthTokens/UserAuthTokens.php
+++ b/app/src/User/AuthTokens/UserAuthTokens.php
@@ -1,0 +1,138 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\AuthTokens;
+
+use DateTimeImmutable;
+use DateTimeInterface;
+use Exception;
+use Nette\Database\Explorer;
+use Nette\Database\UniqueConstraintViolationException;
+use Nette\Utils\Random;
+
+final readonly class UserAuthTokens
+{
+
+	private const string AUTH_SELECTOR_TOKEN_SEPARATOR = ':';
+
+
+	public function __construct(
+		private Explorer $database,
+		private string $usersTableName,
+	) {
+	}
+
+
+	/**
+	 * Insert authentication token into database.
+	 *
+	 * Selector and token are regenerated if selector already exists in the table.
+	 *
+	 * @return non-empty-string Concatenation of selector, separator, token
+	 * @throws Exception
+	 */
+	private function insert(int $userId, UserAuthTokenType $type): string
+	{
+		$selector = Random::generate(32, '0-9a-zA-Z');
+		$token = Random::generate(64, '0-9a-zA-Z');
+
+		try {
+			$this->database->query(
+				'INSERT INTO auth_tokens',
+				[
+					'key_user' => $userId,
+					'selector' => $selector,
+					'token' => $this->hashToken($token),
+					'created' => new DateTimeImmutable(),
+					'type' => $type->value,
+				],
+			);
+		} catch (UniqueConstraintViolationException) {
+			return $this->insert($userId, $type);
+		}
+		return $selector . self::AUTH_SELECTOR_TOKEN_SEPARATOR . $token;
+	}
+
+
+	/**
+	 * Delete all tokens of this type for the user, then insert a new one. Atomic.
+	 *
+	 * @return non-empty-string
+	 * @throws Exception
+	 */
+	public function replaceForUser(int $userId, UserAuthTokenType $type): string
+	{
+		$this->database->beginTransaction();
+		try {
+			$this->deleteAllForUser($userId, $type);
+			$value = $this->insert($userId, $type);
+			$this->database->commit();
+			return $value;
+		} catch (Exception $e) {
+			$this->database->rollBack();
+			throw $e;
+		}
+	}
+
+
+	/**
+	 * Verify and return a token of the given type, if present and valid.
+	 */
+	public function verify(string $value, DateTimeInterface $validity, UserAuthTokenType $type): ?UserAuthToken
+	{
+		$values = explode(self::AUTH_SELECTOR_TOKEN_SEPARATOR, $value);
+		if (count($values) !== 2) {
+			return null;
+		}
+		$row = $this->database->fetch(
+			'SELECT
+				at.id_auth_token AS id,
+				at.token,
+				u.id_user AS userId,
+				u.username
+			FROM
+				auth_tokens at
+				JOIN ?name u ON u.id_user = at.key_user
+			WHERE
+				at.selector = ?
+				AND at.created > ?
+				AND type = ?',
+			$this->usersTableName,
+			$values[0],
+			$validity,
+			$type->value,
+		);
+		if ($row === null) {
+			return null;
+		}
+		assert(is_int($row->id));
+		assert(is_string($row->token));
+		assert(is_int($row->userId));
+		assert(is_string($row->username));
+
+		$authToken = new UserAuthToken($row->id, $row->token, $row->userId, $row->username);
+		return hash_equals($authToken->getToken(), $this->hashToken($values[1])) ? $authToken : null;
+	}
+
+
+	public function deleteById(int $tokenId, UserAuthTokenType $type): void
+	{
+		$this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?', $tokenId, $type->value);
+	}
+
+
+	public function deleteAllForUser(int $userId, UserAuthTokenType $type): void
+	{
+		$this->database->query('DELETE FROM auth_tokens WHERE key_user = ? AND type = ?', $userId, $type->value);
+	}
+
+
+	/**
+	 * @return non-empty-string SHA-512 hash of the token
+	 */
+	private function hashToken(string $token): string
+	{
+		return hash('sha512', $token);
+	}
+
+}

--- a/app/src/User/Manager.php
+++ b/app/src/User/Manager.php
@@ -3,47 +3,23 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User;
 
-use DateTimeInterface;
-use Exception;
-use MichalSpacekCz\Application\LinkGenerator;
 use MichalSpacekCz\Database\TypedDatabase;
-use MichalSpacekCz\Http\Cookies\CookieName;
-use MichalSpacekCz\Http\Cookies\Cookies;
 use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use MichalSpacekCz\User\Exceptions\IdentityUsernameNotStringException;
 use MichalSpacekCz\User\Exceptions\IdentityWithoutUsernameException;
-use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
-use Nette\Database\Explorer;
-use Nette\Database\UniqueConstraintViolationException;
 use Nette\Http\IRequest;
-use Nette\Http\Url;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
-use Nette\Utils\DateTime;
-use Nette\Utils\Random;
 
 final readonly class Manager
 {
 
-	private const string AUTH_SELECTOR_TOKEN_SEPARATOR = ':';
-
-	private const string RESET_TOKEN_EXPIRY = '5 minutes';
-
-	private string $authCookiesPath;
-
-
 	public function __construct(
-		private Explorer $database,
 		private TypedDatabase $typedDatabase,
 		private IRequest $httpRequest,
-		private Cookies $cookies,
-		LinkGenerator $linkGenerator,
-		private string $permanentLoginInterval,
-		private bool $resetEnabled,
 		private string $usersTableName,
 	) {
-		$this->authCookiesPath = (new Url($linkGenerator->link('Admin:Sign:in')))->getPath();
 	}
 
 
@@ -80,6 +56,19 @@ final readonly class Manager
 	}
 
 
+	/**
+	 * @throws IdentityIdNotIntException
+	 */
+	public function getUserId(User $user): int
+	{
+		$userId = $user->getId();
+		if (!is_int($userId)) {
+			throw new IdentityIdNotIntException(get_debug_type($userId));
+		}
+		return $userId;
+	}
+
+
 	public function isForbidden(): bool
 	{
 		$forbidden = $this->typedDatabase->fetchFieldIntNullable(
@@ -92,206 +81,6 @@ final readonly class Manager
 			$this->httpRequest->getRemoteAddress(),
 		);
 		return (bool)$forbidden;
-	}
-
-
-	/**
-	 * Hash token used for permanent login.
-	 *
-	 * @return non-empty-string SHA-512 hash of the token
-	 */
-	private function hashToken(string $token): string
-	{
-		return hash('sha512', $token);
-	}
-
-
-	/**
-	 * Insert authentication token into database.
-	 *
-	 * Selector and token are regenerated if selector already exists in the table.
-	 *
-	 * @return non-empty-string Concatenation of selector, separator, token
-	 * @throws Exception
-	 */
-	private function insertToken(int $userId, UserAuthTokenType $type): string
-	{
-		$selector = Random::generate(32, '0-9a-zA-Z');
-		$token = Random::generate(64, '0-9a-zA-Z');
-
-		try {
-			$this->database->query(
-				'INSERT INTO auth_tokens',
-				[
-					'key_user' => $userId,
-					'selector' => $selector,
-					'token' => $this->hashToken($token),
-					'created' => new DateTime(),
-					'type' => $type->value,
-				],
-			);
-		} catch (UniqueConstraintViolationException) {
-			// regenerate the access code and try harder this time
-			return $this->insertToken($userId, $type);
-		}
-		return $selector . self::AUTH_SELECTOR_TOKEN_SEPARATOR . $token;
-	}
-
-
-	/**
-	 * @throws IdentityIdNotIntException
-	 */
-	private function getUserId(User $user): int
-	{
-		$userId = $user->getId();
-		if (!is_int($userId)) {
-			throw new IdentityIdNotIntException(get_debug_type($userId));
-		}
-		return $userId;
-	}
-
-
-	/**
-	 * Store permanent login token in database and send a cookie to the browser.
-	 *
-	 * @throws Exception
-	 */
-	public function storePermanentLogin(User $user): void
-	{
-		$value = $this->insertToken($this->getUserId($user), UserAuthTokenType::PermanentLogin);
-		$this->cookies->set(CookieName::PermanentLogin, $value, $this->permanentLoginInterval, $this->authCookiesPath, sameSite: 'Strict');
-	}
-
-
-	/**
-	 * Delete all permanent login tokens and delete the cookie in the browser.
-	 */
-	public function clearPermanentLogin(User $user): void
-	{
-		$this->database->query('DELETE FROM auth_tokens WHERE key_user = ? AND type = ?', $this->getUserId($user), UserAuthTokenType::PermanentLogin->value);
-		$this->cookies->delete(CookieName::PermanentLogin, $this->authCookiesPath);
-	}
-
-
-	/**
-	 * Regenerate permanent login token.
-	 *
-	 * @throws Exception
-	 */
-	public function regeneratePermanentLogin(User $user): void
-	{
-		$userId = $this->getUserId($user); // Fail before starting a transaction, if you're going to fail
-		$this->database->beginTransaction();
-		try {
-			$this->database->query('DELETE FROM auth_tokens WHERE key_user = ? AND type = ?', $userId, UserAuthTokenType::PermanentLogin->value);
-			$this->storePermanentLogin($user);
-			$this->database->commit();
-		} catch (Exception $e) {
-			$this->database->rollBack();
-			throw $e;
-		}
-	}
-
-
-	/**
-	 * Verify and return permanent token, if present, and valid.
-	 */
-	public function verifyPermanentLogin(): ?UserAuthToken
-	{
-		$cookie = $this->cookies->getString(CookieName::PermanentLogin) ?? '';
-		return $this->verifyToken($cookie, DateTime::from("-{$this->permanentLoginInterval}"), UserAuthTokenType::PermanentLogin);
-	}
-
-
-	/**
-	 * Verify and return any token, if present, and valid.
-	 */
-	private function verifyToken(string $value, DateTimeInterface $validity, UserAuthTokenType $type): ?UserAuthToken
-	{
-		$values = explode(self::AUTH_SELECTOR_TOKEN_SEPARATOR, $value);
-		if (count($values) !== 2) {
-			return null;
-		}
-		$row = $this->database->fetch(
-			'SELECT
-				at.id_auth_token AS id,
-				at.token,
-				u.id_user AS userId,
-				u.username
-			FROM
-				auth_tokens at
-				JOIN ?name u ON u.id_user = at.key_user
-			WHERE
-				at.selector = ?
-				AND at.created > ?
-				AND type = ?',
-			$this->usersTableName,
-			$values[0],
-			$validity,
-			$type->value,
-		);
-		if ($row === null) {
-			return null;
-		}
-		assert(is_int($row->id));
-		assert(is_string($row->token));
-		assert(is_int($row->userId));
-		assert(is_string($row->username));
-
-		$authToken = new UserAuthToken($row->id, $row->token, $row->userId, $row->username);
-		return hash_equals($authToken->getToken(), $this->hashToken($values[1])) ? $authToken : null;
-	}
-
-
-	public function getPermanentLoginCookieLifetime(): string
-	{
-		return $this->permanentLoginInterval;
-	}
-
-
-	public function isPasskeyResetEnabled(): bool
-	{
-		return $this->resetEnabled;
-	}
-
-
-	/**
-	 * @throws PasskeyResetDisabledException
-	 * @throws Exception
-	 */
-	public function createPasskeyResetToken(int $userId): string
-	{
-		if (!$this->resetEnabled) {
-			throw new PasskeyResetDisabledException();
-		}
-		$this->database->beginTransaction();
-		try {
-			$this->database->query('DELETE FROM auth_tokens WHERE key_user = ? AND type = ?', $userId, UserAuthTokenType::PasskeyReset->value);
-			$token = $this->insertToken($userId, UserAuthTokenType::PasskeyReset);
-			$this->database->commit();
-		} catch (Exception $e) {
-			$this->database->rollBack();
-			throw $e;
-		}
-		return $token;
-	}
-
-
-	/**
-	 * @throws PasskeyResetDisabledException
-	 */
-	public function verifyPasskeyResetToken(string $value): ?UserAuthToken
-	{
-		if (!$this->resetEnabled) {
-			throw new PasskeyResetDisabledException();
-		}
-		return $this->verifyToken($value, DateTime::from('-' . self::RESET_TOKEN_EXPIRY), UserAuthTokenType::PasskeyReset);
-	}
-
-
-	public function deletePasskeyResetToken(int $tokenId): void
-	{
-		$this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?', $tokenId, UserAuthTokenType::PasskeyReset->value);
 	}
 
 }

--- a/app/src/User/PermanentLogin/PermanentLogin.php
+++ b/app/src/User/PermanentLogin/PermanentLogin.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\PermanentLogin;
+
+use DateTimeImmutable;
+use Exception;
+use MichalSpacekCz\Application\LinkGenerator;
+use MichalSpacekCz\Http\Cookies\CookieName;
+use MichalSpacekCz\Http\Cookies\Cookies;
+use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenLifetime;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
+use MichalSpacekCz\User\Manager;
+use Nette\Http\Url;
+use Nette\Security\User;
+use Override;
+
+final readonly class PermanentLogin implements UserAuthTokenLifetime
+{
+
+	private string $authCookiesPath;
+
+
+	public function __construct(
+		private UserAuthTokens $tokens,
+		private Cookies $cookies,
+		private Manager $manager,
+		LinkGenerator $linkGenerator,
+		private string $interval,
+	) {
+		$this->authCookiesPath = (new Url($linkGenerator->link('Admin:Sign:in')))->getPath();
+	}
+
+
+	#[Override]
+	public function getTokenType(): UserAuthTokenType
+	{
+		return UserAuthTokenType::PermanentLogin;
+	}
+
+
+	#[Override]
+	public function getTtl(): string
+	{
+		return $this->interval;
+	}
+
+
+	public function clear(User $user): void
+	{
+		$this->tokens->deleteAllForUser($this->manager->getUserId($user), $this->getTokenType());
+		$this->cookies->delete(CookieName::PermanentLogin, $this->authCookiesPath);
+	}
+
+
+	/**
+	 * @throws Exception
+	 */
+	public function regenerate(User $user): void
+	{
+		$value = $this->tokens->replaceForUser($this->manager->getUserId($user), $this->getTokenType());
+		$this->setCookie($value);
+	}
+
+
+	public function verify(): ?UserAuthToken
+	{
+		$cookie = $this->cookies->getString(CookieName::PermanentLogin) ?? '';
+		return $this->tokens->verify($cookie, new DateTimeImmutable('-' . $this->getTtl()), $this->getTokenType());
+	}
+
+
+	public function getCookieLifetime(): string
+	{
+		return $this->interval;
+	}
+
+
+	private function setCookie(string $value): void
+	{
+		$this->cookies->set(CookieName::PermanentLogin, $value, $this->interval, $this->authCookiesPath, sameSite: 'Strict');
+	}
+
+}

--- a/app/src/User/WebAuthn/PasskeyReset.php
+++ b/app/src/User/WebAuthn/PasskeyReset.php
@@ -3,8 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User\WebAuthn;
 
-use MichalSpacekCz\User\Manager;
-use MichalSpacekCz\User\UserAuthToken;
+use MichalSpacekCz\User\AuthTokens\UserAuthToken;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetInvalidOrExpiredTokenException;
 
@@ -12,7 +11,7 @@ final readonly class PasskeyReset
 {
 
 	public function __construct(
-		private Manager $authenticator,
+		private PasskeyResetTokens $resetTokens,
 		private WebAuthnAuthenticator $passkeyAuthenticator,
 	) {
 	}
@@ -24,7 +23,7 @@ final readonly class PasskeyReset
 	 */
 	public function getUserAuthToken(string $token): UserAuthToken
 	{
-		$userAuthToken = $this->authenticator->verifyPasskeyResetToken($token);
+		$userAuthToken = $this->resetTokens->verify($token);
 		if ($userAuthToken === null) {
 			throw new PasskeyResetInvalidOrExpiredTokenException();
 		}
@@ -48,7 +47,7 @@ final readonly class PasskeyReset
 
 	public function cleanupToken(UserAuthToken $userAuthToken): void
 	{
-		$this->authenticator->deletePasskeyResetToken($userAuthToken->getId());
+		$this->resetTokens->deleteById($userAuthToken->getId());
 	}
 
 }

--- a/app/src/User/WebAuthn/PasskeyResetTokens.php
+++ b/app/src/User/WebAuthn/PasskeyResetTokens.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\WebAuthn;
+
+use DateTimeImmutable;
+use Exception;
+use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenLifetime;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
+use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
+use Override;
+
+final readonly class PasskeyResetTokens implements UserAuthTokenLifetime
+{
+
+	public function __construct(
+		private UserAuthTokens $tokens,
+		private bool $resetEnabled,
+	) {
+	}
+
+
+	#[Override]
+	public function getTokenType(): UserAuthTokenType
+	{
+		return UserAuthTokenType::AdminPasskeyReset;
+	}
+
+
+	#[Override]
+	public function getTtl(): string
+	{
+		return '5 minutes';
+	}
+
+
+	public function isEnabled(): bool
+	{
+		return $this->resetEnabled;
+	}
+
+
+	/**
+	 * @throws PasskeyResetDisabledException
+	 * @throws Exception
+	 */
+	public function create(int $userId): string
+	{
+		if (!$this->resetEnabled) {
+			throw new PasskeyResetDisabledException();
+		}
+		return $this->tokens->replaceForUser($userId, $this->getTokenType());
+	}
+
+
+	/**
+	 * @throws PasskeyResetDisabledException
+	 */
+	public function verify(string $value): ?UserAuthToken
+	{
+		if (!$this->resetEnabled) {
+			throw new PasskeyResetDisabledException();
+		}
+		return $this->tokens->verify($value, new DateTimeImmutable('-' . $this->getTtl()), $this->getTokenType());
+	}
+
+
+	public function deleteById(int $tokenId): void
+	{
+		$this->tokens->deleteById($tokenId, $this->getTokenType());
+	}
+
+}

--- a/app/src/User/WebAuthn/PasskeyResetUrl.php
+++ b/app/src/User/WebAuthn/PasskeyResetUrl.php
@@ -21,6 +21,7 @@ final readonly class PasskeyResetUrl implements CliArgsProvider
 
 	public function __construct(
 		private Manager $authenticator,
+		private PasskeyResetTokens $resetTokens,
 		private LinkGenerator $linkGenerator,
 		private CliArgs $cliArgs,
 	) {
@@ -39,7 +40,7 @@ final readonly class PasskeyResetUrl implements CliArgsProvider
 			throw new PasskeyResetArgsException($error);
 		}
 
-		if (!$this->authenticator->isPasskeyResetEnabled()) {
+		if (!$this->resetTokens->isEnabled()) {
 			throw new PasskeyResetDisabledException();
 		}
 
@@ -49,7 +50,7 @@ final readonly class PasskeyResetUrl implements CliArgsProvider
 			throw new PasskeyResetUserNotFoundException($username);
 		}
 
-		$selectorToken = $this->authenticator->createPasskeyResetToken($userId);
+		$selectorToken = $this->resetTokens->create($userId);
 		return $this->linkGenerator->link('Admin:Sign:passkeyReset#' . $selectorToken);
 	}
 

--- a/app/tests/Form/User/PasskeyResetFormFactoryTest.phpt
+++ b/app/tests/Form/User/PasskeyResetFormFactoryTest.phpt
@@ -5,20 +5,18 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Form\User;
 
 use Contributte\Translation\Translator;
-use MichalSpacekCz\Application\LinkGenerator;
-use MichalSpacekCz\Database\TypedDatabase;
 use MichalSpacekCz\Form\Controls\PasskeyFormControls;
 use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\Form\UiForm;
-use MichalSpacekCz\Http\Cookies\Cookies;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
-use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyRegistrationAttestationResponseValidatorException;
 use MichalSpacekCz\User\WebAuthn\PasskeyReset;
+use MichalSpacekCz\User\WebAuthn\PasskeyResetTokens;
 use Nette\Forms\Controls\HiddenField;
 use Nette\Forms\Controls\TextInput;
 use Nette\Utils\Arrays;
@@ -38,14 +36,11 @@ final class PasskeyResetFormFactoryTest extends TestCase
 
 	public function __construct(
 		private readonly Database $database,
-		private readonly TypedDatabase $typedDatabase,
 		private readonly FormFactory $factory,
 		private readonly PasskeyFormControls $passkeyFormControls,
 		private readonly ApplicationPresenter $applicationPresenter,
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
 		private readonly Request $httpRequest,
-		private readonly LinkGenerator $linkGenerator,
-		private readonly Cookies $cookies,
 		private readonly Translator $translator,
 	) {
 	}
@@ -105,20 +100,11 @@ final class PasskeyResetFormFactoryTest extends TestCase
 
 	private function createFormFactory(): PasskeyResetFormFactory
 	{
-		$manager = new Manager(
-			$this->database,
-			$this->typedDatabase,
-			$this->httpRequest,
-			$this->cookies,
-			$this->linkGenerator,
-			'14 days',
-			true,
-			'users',
-		);
+		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), true);
 		return new PasskeyResetFormFactory(
 			$this->factory,
 			$this->passkeyAuthenticator,
-			new PasskeyReset($manager, $this->passkeyAuthenticator),
+			new PasskeyReset($resetTokens, $this->passkeyAuthenticator),
 			$this->passkeyFormControls,
 			$this->httpRequest,
 			$this->translator,

--- a/app/tests/User/AuthTokens/UserAuthTokenLifetimeTest.phpt
+++ b/app/tests/User/AuthTokens/UserAuthTokenLifetimeTest.phpt
@@ -1,0 +1,83 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\AuthTokens;
+
+use DateTimeImmutable;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\DI\Container;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class UserAuthTokenLifetimeTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Container $container,
+	) {
+	}
+
+
+	public function testGetTtlIsAPositiveInterval(): void
+	{
+		foreach ($this->getServices() as $service) {
+			$ttl = $service->getTtl();
+			$past = null;
+			Assert::noError(function () use (&$past, $ttl): void {
+				$past = new DateTimeImmutable('-' . $ttl);
+			});
+			assert($past instanceof DateTimeImmutable);
+			$now = new DateTimeImmutable();
+			Assert::true(
+				$past < $now,
+				sprintf("%s::getTtl() returned '%s', return a positive interval instead", $service::class, $ttl),
+			);
+		}
+	}
+
+
+	public function testGetTtlIsNotEmpty(): void
+	{
+		foreach ($this->getServices() as $service) {
+			Assert::notSame('', $service->getTtl(), $service::class . '::getTtl() returned an empty string');
+		}
+	}
+
+
+	public function testEachImplementationDeclaresUniqueType(): void
+	{
+		$seen = [];
+		foreach ($this->getServices() as $service) {
+			$type = $service->getTokenType();
+			Assert::notContains(
+				$type,
+				$seen,
+				sprintf('%s declares %s which is already claimed by another service', $service::class, $type->name),
+			);
+			$seen[] = $type;
+		}
+	}
+
+
+	/**
+	 * @return list<UserAuthTokenLifetime>
+	 */
+	private function getServices(): array
+	{
+		$services = [];
+		foreach ($this->container->findByType(UserAuthTokenLifetime::class) as $name) {
+			$service = $this->container->getService($name);
+			assert($service instanceof UserAuthTokenLifetime);
+			$services[] = $service;
+		}
+		Assert::true(count($services) > 0, 'No UserAuthTokenLifetime services found in DI container');
+		return $services;
+	}
+
+}
+
+TestCaseRunner::run(UserAuthTokenLifetimeTest::class);

--- a/app/tests/User/AuthTokens/UserAuthTokensTest.phpt
+++ b/app/tests/User/AuthTokens/UserAuthTokensTest.phpt
@@ -1,0 +1,60 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\AuthTokens;
+
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\DatabaseTransactionStatus;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class UserAuthTokensTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Database $database,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+	}
+
+
+	public function testReplaceForUserDeletesThenInsertsInTransaction(): void
+	{
+		$userId = 1337;
+		$value = (new UserAuthTokens($this->database, 'users'))
+			->replaceForUser($userId, UserAuthTokenType::AdminPasskeyReset);
+
+		Assert::same(DatabaseTransactionStatus::Committed, $this->database->transactionStatus);
+
+		Assert::same(
+			[$userId, UserAuthTokenType::AdminPasskeyReset->value],
+			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE key_user = ? AND type = ?'),
+		);
+
+		$inserts = $this->database->getParamsArrayForQuery('INSERT INTO auth_tokens');
+		Assert::count(1, $inserts);
+		Assert::same($userId, $inserts[0]['key_user']);
+		Assert::same(UserAuthTokenType::AdminPasskeyReset->value, $inserts[0]['type']);
+		Assert::type('string', $inserts[0]['selector']);
+		Assert::type('string', $inserts[0]['token']);
+
+		[$selector, $token] = explode(':', $value);
+		Assert::same($inserts[0]['selector'], $selector);
+		Assert::same($inserts[0]['token'], hash('sha512', $token));
+	}
+
+}
+
+TestCaseRunner::run(UserAuthTokensTest::class);

--- a/app/tests/User/ManagerTest.phpt
+++ b/app/tests/User/ManagerTest.phpt
@@ -6,10 +6,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User;
 
-use MichalSpacekCz\Application\LinkGenerator;
 use MichalSpacekCz\Database\TypedDatabase;
-use MichalSpacekCz\Http\Cookies\CookieName;
-use MichalSpacekCz\Http\Cookies\Cookies;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\PrivateProperty;
@@ -17,7 +14,6 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\User\Exceptions\IdentityNotSimpleIdentityException;
 use MichalSpacekCz\User\Exceptions\IdentityUsernameNotStringException;
 use MichalSpacekCz\User\Exceptions\IdentityWithoutUsernameException;
-use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Override;
@@ -35,8 +31,6 @@ final class ManagerTest extends TestCase
 		private readonly Database $database,
 		private readonly TypedDatabase $typedDatabase,
 		private readonly Request $httpRequest,
-		private readonly Cookies $cookies,
-		private readonly LinkGenerator $linkGenerator,
 	) {
 	}
 
@@ -53,7 +47,7 @@ final class ManagerTest extends TestCase
 	{
 		$id = 1337;
 		$username = 'pizza';
-		$identity = $this->getAuthenticator(false)->getIdentity($id, $username);
+		$identity = $this->getManager()->getIdentity($id, $username);
 		Assert::type(SimpleIdentity::class, $identity);
 		Assert::same($id, $identity->id);
 		Assert::same($id, $identity->getId());
@@ -69,7 +63,7 @@ final class ManagerTest extends TestCase
 	public function testGetIdentityUsernameByUserNoIdentity(): void
 	{
 		Assert::exception(function (): void {
-			$this->getAuthenticator(false)->getIdentityUsernameByUser($this->user);
+			$this->getManager()->getIdentityUsernameByUser($this->user);
 		}, IdentityNotSimpleIdentityException::class, 'Identity is of class <null> but should be Nette\Security\SimpleIdentity');
 	}
 
@@ -79,7 +73,7 @@ final class ManagerTest extends TestCase
 		PrivateProperty::setValue($this->user, 'authenticated', true);
 		PrivateProperty::setValue($this->user, 'identity', new SimpleIdentity(1337));
 		Assert::exception(function (): void {
-			$this->getAuthenticator(false)->getIdentityUsernameByUser($this->user);
+			$this->getManager()->getIdentityUsernameByUser($this->user);
 		}, IdentityWithoutUsernameException::class);
 	}
 
@@ -89,7 +83,7 @@ final class ManagerTest extends TestCase
 		PrivateProperty::setValue($this->user, 'authenticated', true);
 		PrivateProperty::setValue($this->user, 'identity', new SimpleIdentity(1337, [], ['username' => 303]));
 		Assert::exception(function (): void {
-			$this->getAuthenticator(false)->getIdentityUsernameByUser($this->user);
+			$this->getManager()->getIdentityUsernameByUser($this->user);
 		}, IdentityUsernameNotStringException::class, 'Identity username is of type int, not a string');
 	}
 
@@ -98,80 +92,19 @@ final class ManagerTest extends TestCase
 	{
 		$id = 1337;
 		$username = 'pizza';
-		$authenticator = $this->getAuthenticator(false);
-		$identity = $authenticator->getIdentity($id, $username);
+		$manager = $this->getManager();
+		$identity = $manager->getIdentity($id, $username);
 		PrivateProperty::setValue($this->user, 'authenticated', true);
 		PrivateProperty::setValue($this->user, 'identity', $identity);
-		Assert::same($username, $authenticator->getIdentityUsernameByUser($this->user));
+		Assert::same($username, $manager->getIdentityUsernameByUser($this->user));
 	}
 
 
-	public function testIsResetEnabled(): void
-	{
-		Assert::false($this->getAuthenticator(false)->isPasskeyResetEnabled());
-		Assert::true($this->getAuthenticator(true)->isPasskeyResetEnabled());
-		Assert::false($this->getAuthenticator(false)->isPasskeyResetEnabled());
-	}
-
-
-	public function testCreateResetTokenThrowsWhenDisabled(): void
-	{
-		Assert::exception(function (): void {
-			$this->getAuthenticator(false)->createPasskeyResetToken(1337);
-		}, PasskeyResetDisabledException::class);
-	}
-
-
-	public function testVerifyResetTokenThrowsWhenDisabled(): void
-	{
-		Assert::exception(function (): void {
-			$this->getAuthenticator(false)->verifyPasskeyResetToken('some token');
-		}, PasskeyResetDisabledException::class);
-	}
-
-
-	public function testVerifyPermanentLogin(): void
-	{
-		$authenticator = $this->getAuthenticator(false);
-		Assert::null($authenticator->verifyPermanentLogin());
-
-		$tokenId = 1337;
-		$token = 'bar';
-		$hash = hash('sha512', $token);
-		$userId = 1338;
-		$username = '🍪🍪🍪';
-		$this->database->setFetchDefaultResult([
-			'id' => $tokenId,
-			'token' => $hash,
-			'userId' => $userId,
-			'username' => $username,
-		]);
-		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "foo:{$token}");
-		$authToken = $authenticator->verifyPermanentLogin();
-		if (!$authToken instanceof UserAuthToken) {
-			Assert::fail('Token is of a wrong type ' . get_debug_type($authToken));
-		} else {
-			Assert::same($tokenId, $authToken->getId());
-			Assert::same($hash, $authToken->getToken());
-			Assert::same($userId, $authToken->getUserId());
-			Assert::same($username, $authToken->getUsername());
-		}
-
-		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "foo:not{$token}");
-		Assert::null($authenticator->verifyPermanentLogin());
-	}
-
-
-	private function getAuthenticator(bool $resetEnabled): Manager
+	private function getManager(): Manager
 	{
 		return new Manager(
-			$this->database,
 			$this->typedDatabase,
 			$this->httpRequest,
-			$this->cookies,
-			$this->linkGenerator,
-			'14 days',
-			$resetEnabled,
 			'users',
 		);
 	}

--- a/app/tests/User/PermanentLogin/PermanentLoginTest.phpt
+++ b/app/tests/User/PermanentLogin/PermanentLoginTest.phpt
@@ -1,0 +1,91 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\PermanentLogin;
+
+use MichalSpacekCz\Application\LinkGenerator;
+use MichalSpacekCz\Database\TypedDatabase;
+use MichalSpacekCz\Http\Cookies\CookieName;
+use MichalSpacekCz\Http\Cookies\Cookies;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Http\Request;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\Manager;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class PermanentLoginTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Database $database,
+		private readonly TypedDatabase $typedDatabase,
+		private readonly Request $httpRequest,
+		private readonly Cookies $cookies,
+		private readonly LinkGenerator $linkGenerator,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+	}
+
+
+	public function testVerify(): void
+	{
+		$permanentLogin = $this->getPermanentLogin();
+		Assert::null($permanentLogin->verify());
+
+		$tokenId = 1337;
+		$token = 'bar';
+		$hash = hash('sha512', $token);
+		$userId = 1338;
+		$username = '🍪🍪🍪';
+		$this->database->setFetchDefaultResult([
+			'id' => $tokenId,
+			'token' => $hash,
+			'userId' => $userId,
+			'username' => $username,
+		]);
+		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "foo:{$token}");
+		$authToken = $permanentLogin->verify();
+		if (!$authToken instanceof UserAuthToken) {
+			Assert::fail('Token is of a wrong type ' . get_debug_type($authToken));
+		} else {
+			Assert::same($tokenId, $authToken->getId());
+			Assert::same($hash, $authToken->getToken());
+			Assert::same($userId, $authToken->getUserId());
+			Assert::same($username, $authToken->getUsername());
+		}
+
+		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "foo:not{$token}");
+		Assert::null($permanentLogin->verify());
+	}
+
+
+	public function testGetCookieLifetime(): void
+	{
+		Assert::same('14 days', $this->getPermanentLogin()->getCookieLifetime());
+	}
+
+
+	private function getPermanentLogin(): PermanentLogin
+	{
+		$manager = new Manager($this->typedDatabase, $this->httpRequest, 'users');
+		$tokens = new UserAuthTokens($this->database, 'users');
+		return new PermanentLogin($tokens, $this->cookies, $manager, $this->linkGenerator, '14 days');
+	}
+
+}
+
+TestCaseRunner::run(PermanentLoginTest::class);

--- a/app/tests/User/WebAuthn/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyResetTest.phpt
@@ -4,16 +4,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User\WebAuthn;
 
-use MichalSpacekCz\Application\LinkGenerator;
-use MichalSpacekCz\Database\TypedDatabase;
-use MichalSpacekCz\Http\Cookies\Cookies;
 use MichalSpacekCz\Test\Database\Database;
-use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
-use MichalSpacekCz\User\Manager;
-use MichalSpacekCz\User\UserAuthToken;
-use MichalSpacekCz\User\UserAuthTokenType;
+use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetInvalidOrExpiredTokenException;
 use Override;
 use Tester\Assert;
@@ -27,11 +23,7 @@ final class PasskeyResetTest extends TestCase
 
 	public function __construct(
 		private readonly Database $database,
-		private readonly TypedDatabase $typedDatabase,
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
-		private readonly Request $httpRequest,
-		private readonly LinkGenerator $linkGenerator,
-		private readonly Cookies $cookies,
 	) {
 	}
 
@@ -90,7 +82,7 @@ final class PasskeyResetTest extends TestCase
 		$tokenId = 42;
 		$this->createPasskeyReset()->cleanupToken(new UserAuthToken($tokenId, 'hash', 1337, 'foo'));
 		Assert::same(
-			[$tokenId, UserAuthTokenType::PasskeyReset->value],
+			[$tokenId, UserAuthTokenType::AdminPasskeyReset->value],
 			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),
 		);
 	}
@@ -98,17 +90,9 @@ final class PasskeyResetTest extends TestCase
 
 	private function createPasskeyReset(): PasskeyReset
 	{
-		$manager = new Manager(
-			$this->database,
-			$this->typedDatabase,
-			$this->httpRequest,
-			$this->cookies,
-			$this->linkGenerator,
-			'14 days',
-			true,
-			'users',
-		);
-		return new PasskeyReset($manager, $this->passkeyAuthenticator);
+		$tokens = new UserAuthTokens($this->database, 'users');
+		$resetTokens = new PasskeyResetTokens($tokens, true);
+		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator);
 	}
 
 }

--- a/app/tests/User/WebAuthn/PasskeyResetTokensTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyResetTokensTest.phpt
@@ -1,0 +1,76 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\WebAuthn;
+
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
+use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class PasskeyResetTokensTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Database $database,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+	}
+
+
+	public function testIsEnabled(): void
+	{
+		Assert::false($this->getTokens(false)->isEnabled());
+		Assert::true($this->getTokens(true)->isEnabled());
+		Assert::false($this->getTokens(false)->isEnabled());
+	}
+
+
+	public function testCreateThrowsWhenDisabled(): void
+	{
+		Assert::exception(function (): void {
+			$this->getTokens(false)->create(1337);
+		}, PasskeyResetDisabledException::class);
+	}
+
+
+	public function testVerifyThrowsWhenDisabled(): void
+	{
+		Assert::exception(function (): void {
+			$this->getTokens(false)->verify('some token');
+		}, PasskeyResetDisabledException::class);
+	}
+
+
+	public function testDeleteByIdQueriesAdminResetType(): void
+	{
+		$this->getTokens(true)->deleteById(42);
+		Assert::same(
+			[42, UserAuthTokenType::AdminPasskeyReset->value],
+			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),
+		);
+	}
+
+
+	private function getTokens(bool $enabled): PasskeyResetTokens
+	{
+		return new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $enabled);
+	}
+
+}
+
+TestCaseRunner::run(PasskeyResetTokensTest::class);

--- a/app/tests/User/WebAuthn/PasskeyResetUrlTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyResetUrlTest.phpt
@@ -7,9 +7,9 @@ namespace MichalSpacekCz\User\WebAuthn;
 use MichalSpacekCz\Application\Cli\CliArgs;
 use MichalSpacekCz\Application\LinkGenerator;
 use MichalSpacekCz\Database\TypedDatabase;
-use MichalSpacekCz\Http\Cookies\Cookies;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetArgsException;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyResetDisabledException;
@@ -30,7 +30,6 @@ final class PasskeyResetUrlTest extends TestCase
 		private readonly Database $database,
 		private readonly TypedDatabase $typedDatabase,
 		private readonly IRequest $httpRequest,
-		private readonly Cookies $cookies,
 		private readonly LinkGenerator $linkGenerator,
 	) {
 	}
@@ -45,17 +44,9 @@ final class PasskeyResetUrlTest extends TestCase
 
 	private function getPasskeyResetUrl(CliArgs $cliArgs, bool $passkeyResetEnabled): PasskeyResetUrl
 	{
-		$manager = new Manager(
-			$this->database,
-			$this->typedDatabase,
-			$this->httpRequest,
-			$this->cookies,
-			$this->linkGenerator,
-			'14 days',
-			$passkeyResetEnabled,
-			'users',
-		);
-		return new PasskeyResetUrl($manager, $this->linkGenerator, $cliArgs);
+		$manager = new Manager($this->typedDatabase, $this->httpRequest, 'users');
+		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $passkeyResetEnabled);
+		return new PasskeyResetUrl($manager, $resetTokens, $this->linkGenerator, $cliArgs);
 	}
 
 


### PR DESCRIPTION
Sets up the future auth-token GC and the public app's reset flow: each token type now owns its own TTL and gates in a dedicated service, rather than sharing a hardcoded const inside `Manager`.

Behavior nuance: `PermanentLogin::regenerate` sets the cookie after the DB commit, not inside the transaction try block. A failed commit no longer leaves an orphan cookie pointing to a rolled back row.

For #731, kind of.