### PR TITLE
Latent fixes: mocked datetime offsets, fuller cache key

### DIFF
--- a/app/src/Formatter/TexyFormatter.php
+++ b/app/src/Formatter/TexyFormatter.php
@@ -275,9 +275,17 @@ class TexyFormatter
 
 	public function getCacheKey(string $text, Texy $texy): string
 	{
-		// urlSchemeFilters is in the key so a future withTexy() variant with a different
-		// filter set lands in its own slot rather than reading a sibling's cached output.
-		$key = "{$text}|" . serialize($texy->allowedTags) . '|' . serialize($texy->allowed) . '|' . serialize($texy->urlSchemeFilters);
+		// Anything that varies per render and influences the output goes in the key
+		$key = serialize([
+			$text,
+			$texy->allowedTags,
+			$texy->allowed,
+			$texy->urlSchemeFilters,
+			$texy->headingModule->top,
+			$texy->obfuscateEmail,
+			$texy->imageModule->root,
+			$texy->imageModule->fileRoot,
+		]);
 		// Make the key shorter because Symfony Cache stores it in comments in cache files
 		// Don't hash the locale to make it visible inside cache files
 		return Hash::nonCryptographic($key) . '.' . $this->translator->getDefaultLocale();

--- a/app/src/Test/DateTime/DateTimeMachineFactory.php
+++ b/app/src/Test/DateTime/DateTimeMachineFactory.php
@@ -24,10 +24,29 @@ final class DateTimeMachineFactory extends DateTimeFactory
 	}
 
 
+	/**
+	 * Tests mock the "now" time, anything computed from it moves with the mock too. Only `+/-`-prefixed offsets
+	 * (`create('-10 days')`) are recognised here, other PHP relative phrasings ('now - 30 days', 'yesterday',
+	 * 'last Monday') fall through to the parent factory and reflect real time.
+	 */
 	#[Override]
 	public function create(string $datetime = 'now', ?DateTimeZone $timezone = null): DateTimeImmutable
 	{
-		return $this->dateTime ?? parent::create($datetime, $timezone);
+		if ($this->dateTime === null) {
+			return parent::create($datetime, $timezone);
+		}
+		$trimmed = trim($datetime);
+		// Apply the requested timezone to the base before modify() so relative offsets
+		// are computed in that zone (matters across DST boundaries), matching the parent's
+		// `new DateTimeImmutable($datetime, $timezone)` contract.
+		$base = $timezone === null ? $this->dateTime : $this->dateTime->setTimezone($timezone);
+		if ($trimmed === '' || strcasecmp($trimmed, 'now') === 0) {
+			return $base;
+		}
+		if ($trimmed[0] === '+' || $trimmed[0] === '-') {
+			return $base->modify($datetime);
+		}
+		return parent::create($datetime, $timezone);
 	}
 
 }

--- a/app/tests/Formatter/TexyFormatterTest.phpt
+++ b/app/tests/Formatter/TexyFormatterTest.phpt
@@ -151,6 +151,58 @@ final class TexyFormatterTest extends TestCase
 	}
 
 
+	public function testCacheKeyVariesWithTopHeading(): void
+	{
+		$texyH1 = $this->texyFormatter->createTexy();
+		$texyH1->headingModule->top = 1;
+		$texyH2 = $this->texyFormatter->createTexy();
+		$texyH2->headingModule->top = 2;
+		Assert::notSame(
+			$this->texyFormatter->getCacheKey('text', $texyH1),
+			$this->texyFormatter->getCacheKey('text', $texyH2),
+		);
+	}
+
+
+	public function testCacheKeyVariesWithObfuscateEmail(): void
+	{
+		$texyOn = $this->texyFormatter->createTexy();
+		$texyOn->obfuscateEmail = true;
+		$texyOff = $this->texyFormatter->createTexy();
+		$texyOff->obfuscateEmail = false;
+		Assert::notSame(
+			$this->texyFormatter->getCacheKey('text', $texyOn),
+			$this->texyFormatter->getCacheKey('text', $texyOff),
+		);
+	}
+
+
+	public function testCacheKeyVariesWithImageRoot(): void
+	{
+		$texyA = $this->texyFormatter->createTexy();
+		$texyA->imageModule->root = 'https://a.example/img/';
+		$texyB = $this->texyFormatter->createTexy();
+		$texyB->imageModule->root = 'https://b.example/img/';
+		Assert::notSame(
+			$this->texyFormatter->getCacheKey('text', $texyA),
+			$this->texyFormatter->getCacheKey('text', $texyB),
+		);
+	}
+
+
+	public function testCacheKeyVariesWithImageFileRoot(): void
+	{
+		$texyA = $this->texyFormatter->createTexy();
+		$texyA->imageModule->fileRoot = '/var/www/a/img';
+		$texyB = $this->texyFormatter->createTexy();
+		$texyB->imageModule->fileRoot = '/var/www/b/img';
+		Assert::notSame(
+			$this->texyFormatter->getCacheKey('text', $texyA),
+			$this->texyFormatter->getCacheKey('text', $texyB),
+		);
+	}
+
+
 	public function testSubstitutePossiblyUnsafeHtml(): void
 	{
 		Assert::same('<em>foo</em> bar 303', $this->texyFormatter->substitutePossiblyUnsafeHtml('*foo* %s %d', ['bar', 303])->render());

--- a/app/tests/Pulse/Passwords/PasswordsTest.phpt
+++ b/app/tests/Pulse/Passwords/PasswordsTest.phpt
@@ -547,7 +547,7 @@ final class PasswordsTest extends TestCase
 				'url' => 'https://di.example/',
 				'archive' => 'https://ar.di.example/',
 				'note' => 'note',
-				'published' => '2020-01-01 12:34:56',
+				'published' => '2020-11-22 00:00:00',
 				'added' => '2020-01-01 12:34:56',
 			]],
 			$this->database->getParamsArrayForQuery('INSERT INTO password_disclosures'),

--- a/app/tests/Test/DateTime/DateTimeMachineFactoryTest.phpt
+++ b/app/tests/Test/DateTime/DateTimeMachineFactoryTest.phpt
@@ -1,0 +1,70 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Test\DateTime;
+
+use DateTimeImmutable;
+use MichalSpacekCz\DateTime\DateTimeZoneFactory;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class DateTimeMachineFactoryTest extends TestCase
+{
+
+	public function __construct(
+		private readonly DateTimeMachineFactory $factory,
+		private readonly DateTimeZoneFactory $zones,
+	) {
+	}
+
+
+	public function testCreateWithoutSetDateTimeDelegatesToParent(): void
+	{
+		$this->factory->setDateTime(null);
+		Assert::same('2024-01-15', $this->factory->create('2024-01-15')->format('Y-m-d'));
+	}
+
+
+	public function testCreateReturnsSetDateTimeForNow(): void
+	{
+		$this->factory->setDateTime(new DateTimeImmutable('2026-05-17 12:00:00'));
+		Assert::same('2026-05-17 12:00:00', $this->factory->create()->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-17 12:00:00', $this->factory->create('now')->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-17 12:00:00', $this->factory->create('')->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-17 12:00:00', $this->factory->create('NOW')->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-17 12:00:00', $this->factory->create('  nOw  ')->format('Y-m-d H:i:s'));
+	}
+
+
+	public function testCreateAppliesRelativeOffsetToSetDateTime(): void
+	{
+		$this->factory->setDateTime(new DateTimeImmutable('2026-05-17 12:00:00'));
+		Assert::same('2026-05-03 12:00:00', $this->factory->create('-14 days')->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-17 13:30:00', $this->factory->create('+90 minutes')->format('Y-m-d H:i:s'));
+		Assert::same('2026-04-12 12:00:00', $this->factory->create('  -35 days')->format('Y-m-d H:i:s'));
+	}
+
+
+	public function testCreateWithAbsoluteDatetimeIgnoresSetDateTime(): void
+	{
+		$this->factory->setDateTime(new DateTimeImmutable('2026-05-17 12:00:00'));
+		Assert::same('2020-11-22 00:00:00', $this->factory->create('2020-11-22')->format('Y-m-d H:i:s'));
+	}
+
+
+	public function testCreateAppliesTimezoneOnMockedPath(): void
+	{
+		$this->factory->setDateTime(new DateTimeImmutable('2026-05-17 12:00:00', $this->zones->get('UTC')));
+		$prague = $this->zones->get('Europe/Prague');
+		Assert::same('2026-05-17 14:00:00', $this->factory->create('now', $prague)->format('Y-m-d H:i:s'));
+		Assert::same('2026-05-03 14:00:00', $this->factory->create('-14 days', $prague)->format('Y-m-d H:i:s'));
+	}
+
+}
+
+TestCaseRunner::run(DateTimeMachineFactoryTest::class);


### PR DESCRIPTION
Spotted during PR #750/#751 work, neither visible today.

- `DateTimeMachineFactory::create()` now applies `+/-` offsets to the set time. Was returning the set time as-is so `create('-14 days')`-style mocked cutoffs were meaningless.
- `TexyFormatter::getCacheKey()` now also hashes `topHeading`, `obfuscateEmail`, and the image roots. Uniform usage today, but a future per-render variation would have meant two configurations sharing a cache slot.