### PR TITLE
Add database schema to `app/db/` via `make dump-db-schema`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -150,9 +150,11 @@ interface ArticleHeaderIconsFactory
 ### Database
 
 `TypedDatabase` wraps Nette Database Explorer with methods that return typed values (`fetchFieldString()`, `fetchPairsStringString()`, etc.) and throw on type mismatches. Three databases, each with its own `TypedDatabase` service instance:
-- `default` — main application data (talks, training, etc.)
-- `pulse` — password storage security ratings (companies, algorithms, disclosures)
-- `upcKeys` — WiFi router default key data (Technicolor, Ubee)
+- `default`: database `michalspacek_cz`, dump name `default.sql` — main application data (talks, training, etc.)
+- `pulse`: database `michalspacek_cz_pulse`, dump name `pulse.sql` — password storage security ratings (companies, algorithms, disclosures)
+- `upcKeys`: database `michalspacek_cz_upckeys`, dump name `upckeys.sql` — WiFi router default key data (Technicolor, Ubee)
+
+Schema dumps (and a small allow-list of lookup-table data) live in `app/db/*.sql`, refreshed by `make dump-db-schema` (which runs `app/bin/dump-db-schema.sh`). Read these instead of guessing — they're the source of truth for column names, types, constraints, and FKs. The dump scrubs `AUTO_INCREMENT=N` and `DEFINER=` clauses so commits don't leak row counts or operator accounts; data is included only for fixed enumerations (`auth_token_types`, `*_status`, `*_status_flow`, `twitter_card_types`, `languages`, `locales`) — tables with admin CRUD stay schema-only even when they look lookup-shaped (e.g. `url_actions`, `article_sources`).
 
 ### Database transactions
 

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,4 +1,4 @@
-.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt
+.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt dump-db-schema
 
 test: composer-audit composer-validate npm-audit check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
@@ -79,3 +79,6 @@ composer-dependency-analyser:
 
 update-security-txt:
 	bin/update-security.txt.sh
+
+dump-db-schema:
+	bin/dump-db-schema.sh

--- a/app/bin/dump-db-schema.sh
+++ b/app/bin/dump-db-schema.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+
+# Dumps each MySQL schema in $DBS to app/db/, schema-only for most tables.
+# Data is dumped for the $LOOKUP_DATA allow-list (fixed enumerations).
+# Output is deterministic so commits show real schema changes only.
+#
+# Override the binaries if needed:
+# MYSQL="sudo mysql" MYSQLDUMP="sudo mysqldump" make dump-db-schema
+
+set -euo pipefail
+
+MYSQL="${MYSQL:-mysql}"
+MYSQLDUMP="${MYSQLDUMP:-mysqldump}"
+
+# Support MYSQL="sudo mysql" or MYSQL="mysql --password"
+read -ra MYSQL_CMD <<< "$MYSQL"
+read -ra MYSQLDUMP_CMD <<< "$MYSQLDUMP"
+
+REPO_ROOT="$(realpath "$(dirname "$0")/..")"
+OUT_DIR="$REPO_ROOT/db"
+mkdir --parents "$OUT_DIR"
+
+# Databases to dump, in output order. The output filename is the db name with the
+# michalspacek_cz_ prefix stripped, or "default" for the unprefixed main db.
+DBS=(
+    michalspacek_cz
+    michalspacek_cz_pulse
+    michalspacek_cz_upckeys
+)
+
+# Tables whose data is dumped alongside the schema - empty list = schema-only,
+# anything not listed here stays schema-only: no operational, user-derived, or admin-mutated data.
+declare -A LOOKUP_DATA=(
+    [michalspacek_cz]="\
+        auth_token_types \
+        languages \
+        locales \
+        training_application_status \
+        training_application_status_flow \
+        training_date_status \
+        twitter_card_types"
+    [michalspacek_cz_pulse]=""
+    [michalspacek_cz_upckeys]=""
+)
+
+# Strip AUTO_INCREMENT=N (row-count leak), DEFINER='user'@'host' (operator account
+# leak on views/triggers/routines), and the per-table character-set save/restore wrappers.
+# Add blank lines between table blocks and between distinct INSERT blocks.
+scrub() {
+    local FILE="$1"
+    sed -E \
+        -e 's/ AUTO_INCREMENT=[0-9]+//g' \
+        -e "s/DEFINER=\`[^\`]+\`@\`[^\`]+\` //g" \
+        -e '/^\/\*![0-9]+ SET (@saved_(cs_client|cs_results|col_connection)|character_set_(client|results)|collation_connection) /d' \
+        "$FILE" | awk '
+            NR > 1 && /^CREATE TABLE/ { print "" }
+            NR > 1 && /^INSERT INTO `/ {
+                split($0, a, "`")
+                if (a[2] != prev_table) print ""
+                prev_table = a[2]
+            }
+            { print }
+        ' > "$FILE.scrubbed"
+    mv "$FILE.scrubbed" "$FILE"
+}
+
+for DB in "${DBS[@]}"; do
+    if [[ "$DB" == "michalspacek_cz" ]]; then
+        name="default"
+    else
+        name="${DB#michalspacek_cz_}"
+    fi
+    OUT="$OUT_DIR/$name.sql"
+    TMP="$(mktemp)"
+    trap 'rm -f "$TMP"' EXIT
+
+    echo "Dumping $DB -> ${OUT#"$REPO_ROOT"/}"
+
+    # Tables in alphabetical order so diffs reflect schema changes, not whatever order SHOW TABLES happens to return.
+    # Capture explicitly so auth/connection failures abort the script instead of looking like "no tables found".
+    if ! TABLES_RAW="$("${MYSQL_CMD[@]}" --skip-column-names --execute="SHOW TABLES" "$DB")"; then
+        echo "Error: failed to list tables in $DB" >&2
+        exit 1
+    fi
+    if [[ -z "$TABLES_RAW" ]]; then
+        echo "Error: no tables in $DB" >&2
+        exit 1
+    fi
+    mapfile -t TABLES < <(sort <<< "$TABLES_RAW")
+
+    echo -e "# Tables" > "$TMP"
+
+    # Schema for every table, plus routines/triggers/views.
+    "${MYSQLDUMP_CMD[@]}" \
+        --no-data \
+        --routines \
+        --triggers \
+        --compact \
+        --skip-dump-date \
+        --no-tablespaces \
+        "$DB" "${TABLES[@]}" >> "$TMP"
+
+    # Data for $LOOKUP_DATA TABLES, one row per INSERT for readable diffs.
+    # mysqldump dumps in the order tables are passed, so no runtime sort needed.
+    LOOKUP="${LOOKUP_DATA[$DB]:-}"
+    if [[ -n "$LOOKUP" ]]; then
+        echo -e "\n# Data" >> "$TMP"
+        read -ra LOOKUP_ARR <<< "$LOOKUP"
+        "${MYSQLDUMP_CMD[@]}" \
+            --no-create-info \
+            --skip-extended-insert \
+            --compact \
+            --skip-dump-date \
+            --no-tablespaces \
+            --single-transaction \
+            "$DB" "${LOOKUP_ARR[@]}" >> "$TMP"
+    else
+        echo -e "\n# No data\n" >> "$TMP"
+    fi
+
+    mv "$TMP" "$OUT"
+    scrub "$OUT"
+done
+
+echo "OK: files in ${OUT_DIR#"$REPO_ROOT"/}/*.sql"

--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -31,7 +31,7 @@ latte:
 
 database:
 	default:
-		dsn: 'mysql:host=localhost;dbname=cz_michalspacek'
+		dsn: 'mysql:host=localhost;dbname=michalspacek_cz'
 		user: ...
 		password: ...
 		options:

--- a/app/db/default.sql
+++ b/app/db/default.sql
@@ -1,0 +1,585 @@
+# Tables
+
+CREATE TABLE `article_sources` (
+  `id_article_source` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_article_source`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `articles` (
+  `id_article` int unsigned NOT NULL AUTO_INCREMENT,
+  `title` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `date` datetime NOT NULL,
+  `key_article_source` int unsigned NOT NULL,
+  `excerpt` varchar(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `key_replaced_with_blog_post` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id_article`),
+  KEY `fk_article_source` (`key_article_source`),
+  KEY `key_replaced_with_blog_post` (`key_replaced_with_blog_post`),
+  CONSTRAINT `articles_ibfk_1` FOREIGN KEY (`key_replaced_with_blog_post`) REFERENCES `blog_posts` (`id_blog_post`),
+  CONSTRAINT `fk_article_source` FOREIGN KEY (`key_article_source`) REFERENCES `article_sources` (`id_article_source`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `auth_token_types` (
+  `id_auth_token_type` int NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_auth_token_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci COMMENT='Same values as the UserAuthTokenType enum';
+
+CREATE TABLE `auth_tokens` (
+  `id_auth_token` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_user` int unsigned NOT NULL,
+  `selector` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `token` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `created` datetime NOT NULL,
+  `type` int NOT NULL,
+  PRIMARY KEY (`id_auth_token`),
+  UNIQUE KEY `selector` (`selector`),
+  KEY `key_user` (`key_user`),
+  KEY `type` (`type`),
+  CONSTRAINT `auth_tokens_ibfk_1` FOREIGN KEY (`key_user`) REFERENCES `users` (`id_user`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `auth_tokens_ibfk_2` FOREIGN KEY (`type`) REFERENCES `auth_token_types` (`id_auth_token_type`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `blog_post_edits` (
+  `id_blog_post_edit` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_blog_post` int unsigned NOT NULL,
+  `edited_at` datetime NOT NULL,
+  `edited_at_timezone` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `summary` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  PRIMARY KEY (`id_blog_post_edit`),
+  KEY `key_blog_post` (`key_blog_post`),
+  CONSTRAINT `blog_post_edits_ibfk_1` FOREIGN KEY (`key_blog_post`) REFERENCES `blog_posts` (`id_blog_post`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `blog_posts` (
+  `id_blog_post` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_locale` int unsigned NOT NULL,
+  `key_twitter_card_type` int unsigned DEFAULT NULL,
+  `key_translation_group` int unsigned DEFAULT NULL COMMENT 'No foreign key, yet',
+  `slug` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `title` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `published` datetime DEFAULT NULL,
+  `published_timezone` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `preview_key` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `lead` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+  `text` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci NOT NULL,
+  `originally` text CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci,
+  `og_image` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `tags` json DEFAULT NULL,
+  `slug_tags` json DEFAULT NULL,
+  `recommended` json DEFAULT NULL,
+  `csp_snippets` json DEFAULT NULL,
+  `allowed_tags` json DEFAULT NULL,
+  `omit_exports` bit(1) DEFAULT NULL,
+  PRIMARY KEY (`id_blog_post`),
+  UNIQUE KEY `slug` (`slug`),
+  UNIQUE KEY `key_locale_key_translation_group` (`key_locale`,`key_translation_group`),
+  KEY `published` (`published`),
+  KEY `key_twitter_card_type` (`key_twitter_card_type`),
+  CONSTRAINT `blog_posts_ibfk_1` FOREIGN KEY (`key_twitter_card_type`) REFERENCES `twitter_card_types` (`id_twitter_card_type`) ON UPDATE RESTRICT,
+  CONSTRAINT `blog_posts_ibfk_2` FOREIGN KEY (`key_locale`) REFERENCES `locales` (`id_locale`) ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `certificate_requests` (
+  `id_certificate_request` int unsigned NOT NULL AUTO_INCREMENT,
+  `certificate_name` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `certificate_name_ext` varchar(200) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `cn` varchar(200) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `san` json DEFAULT NULL,
+  `time` datetime NOT NULL,
+  `time_timezone` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `success` bit(1) NOT NULL,
+  PRIMARY KEY (`id_certificate_request`),
+  KEY `cn_ext` (`certificate_name`,`certificate_name_ext`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `certificates` (
+  `id_certificate` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_certificate_request` int unsigned NOT NULL,
+  `not_before` datetime NOT NULL,
+  `not_before_timezone` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `not_after` datetime NOT NULL,
+  `not_after_timezone` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `hidden` bit(1) NOT NULL DEFAULT b'0',
+  PRIMARY KEY (`id_certificate`),
+  KEY `key_certificate_request` (`key_certificate_request`),
+  CONSTRAINT `certificates_ibfk_3` FOREIGN KEY (`key_certificate_request`) REFERENCES `certificate_requests` (`id_certificate_request`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `files` (
+  `id_file` int unsigned NOT NULL AUTO_INCREMENT,
+  `filename` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `added` datetime NOT NULL,
+  `added_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_file`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `forbidden` (
+  `id_forbidden` int unsigned NOT NULL AUTO_INCREMENT,
+  `ip` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_forbidden`),
+  UNIQUE KEY `ip_UNIQUE` (`ip`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `gc_log` (
+  `gc_type` int NOT NULL,
+  `gc_time` datetime NOT NULL,
+  `gc_time_timezone` varchar(200) NOT NULL,
+  `deleted` int DEFAULT NULL,
+  `return_code` int NOT NULL,
+  `message` text,
+  PRIMARY KEY (`gc_type`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `interviews` (
+  `id_interview` int unsigned NOT NULL AUTO_INCREMENT,
+  `action` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `title` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `date` datetime NOT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `audio_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `audio_embed` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_thumbnail` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_thumbnail_alternative` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_embed` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `source_name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `source_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  PRIMARY KEY (`id_interview`),
+  UNIQUE KEY `action_UNIQUE` (`action`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `languages` (
+  `id_language` int unsigned NOT NULL AUTO_INCREMENT,
+  `language` varchar(5) NOT NULL,
+  PRIMARY KEY (`id_language`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+CREATE TABLE `locales` (
+  `id_locale` int unsigned NOT NULL AUTO_INCREMENT,
+  `locale` varchar(5) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  PRIMARY KEY (`id_locale`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `passkeys` (
+  `id_passkey` binary(16) NOT NULL,
+  `key_user` int unsigned NOT NULL,
+  `credential_id` varbinary(1023) NOT NULL,
+  `credential_record` json NOT NULL,
+  `name` varchar(200) NOT NULL,
+  `created` datetime NOT NULL,
+  `created_timezone` varchar(200) NOT NULL,
+  `last_used` datetime DEFAULT NULL,
+  `last_used_timezone` varchar(200) DEFAULT NULL,
+  PRIMARY KEY (`id_passkey`),
+  UNIQUE KEY `credential_id` (`credential_id`),
+  KEY `key_user` (`key_user`),
+  CONSTRAINT `fk_passkey_key_user` FOREIGN KEY (`key_user`) REFERENCES `users` (`id_user`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `redirections` (
+  `id_redirection` int unsigned NOT NULL AUTO_INCREMENT,
+  `source` varchar(200) NOT NULL,
+  `destination` varchar(200) NOT NULL,
+  `description` varchar(2000) NOT NULL,
+  PRIMARY KEY (`id_redirection`),
+  UNIQUE KEY `source_UNIQUE` (`source`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci;
+
+CREATE TABLE `sessions` (
+  `id` binary(32) NOT NULL,
+  `timestamp` bigint unsigned NOT NULL,
+  `data` longtext COLLATE utf8mb4_general_ci NOT NULL,
+  `key_user` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `key_user` (`key_user`),
+  CONSTRAINT `sessions_ibfk_1` FOREIGN KEY (`key_user`) REFERENCES `users` (`id_user`) ON DELETE RESTRICT ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `talk_slides` (
+  `id_slide` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_talk` int unsigned NOT NULL,
+  `alias` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `number` int unsigned DEFAULT NULL,
+  `filename` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `filename_alternative` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `width` smallint unsigned DEFAULT NULL,
+  `height` smallint unsigned DEFAULT NULL,
+  `title` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `speaker_notes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  PRIMARY KEY (`id_slide`),
+  UNIQUE KEY `key_talk_number` (`key_talk`,`number`),
+  KEY `fk_talk` (`key_talk`),
+  CONSTRAINT `talk_slides_ibfk_1` FOREIGN KEY (`key_talk`) REFERENCES `talks` (`id_talk`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `talks` (
+  `id_talk` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_locale` int unsigned NOT NULL,
+  `key_translation_group` int unsigned DEFAULT NULL COMMENT 'No foreign key, yet',
+  `action` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `title` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `description` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `date` datetime NOT NULL,
+  `duration` int unsigned DEFAULT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `key_talk_slides` int unsigned DEFAULT NULL COMMENT 'The slides from this talk will be symlinked to current talk including transcript and og:image',
+  `key_talk_filenames` int unsigned DEFAULT NULL COMMENT 'The image filenames from this talk will be used for slides',
+  `slides_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `slides_embed` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `slides_note` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `video_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_thumbnail` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_thumbnail_alternative` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `video_embed` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `event` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `event_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `og_image` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `transcript` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `favorite` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `key_superseded_by` int unsigned DEFAULT NULL,
+  `publish_slides` bit(1) NOT NULL,
+  `tags` json DEFAULT NULL,
+  `slug_tags` json DEFAULT NULL,
+  PRIMARY KEY (`id_talk`),
+  UNIQUE KEY `action_UNIQUE` (`action`),
+  UNIQUE KEY `key_locale_key_translation_group` (`key_locale`,`key_translation_group`),
+  KEY `key_talk_slides` (`key_talk_slides`),
+  KEY `key_superseded_by` (`key_superseded_by`),
+  CONSTRAINT `talks_ibfk_1` FOREIGN KEY (`key_talk_slides`) REFERENCES `talks` (`id_talk`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `talks_ibfk_2` FOREIGN KEY (`key_superseded_by`) REFERENCES `talks` (`id_talk`) ON DELETE RESTRICT ON UPDATE RESTRICT,
+  CONSTRAINT `talks_ibfk_3` FOREIGN KEY (`key_locale`) REFERENCES `locales` (`id_locale`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `training_application_sources` (
+  `id_source` int unsigned NOT NULL AUTO_INCREMENT,
+  `alias` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_source`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_application_status` (
+  `id_status` int unsigned NOT NULL AUTO_INCREMENT,
+  `status` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `description` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_status`),
+  UNIQUE KEY `status_UNIQUE` (`status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_application_status_flow` (
+  `id_status_flow` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_status_from` int unsigned DEFAULT NULL,
+  `key_status_to` int unsigned DEFAULT NULL,
+  PRIMARY KEY (`id_status_flow`),
+  UNIQUE KEY `from_to_UNIQUE` (`key_status_from`,`key_status_to`),
+  KEY `fk_training_application_status_flow_from_idx` (`key_status_from`),
+  KEY `fk_training_application_status_flow_to_idx` (`key_status_to`),
+  CONSTRAINT `fk_training_application_status_flow_from` FOREIGN KEY (`key_status_from`) REFERENCES `training_application_status` (`id_status`),
+  CONSTRAINT `fk_training_application_status_flow_to` FOREIGN KEY (`key_status_to`) REFERENCES `training_application_status` (`id_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_application_status_history` (
+  `id_status_log` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_application` int unsigned NOT NULL,
+  `key_status` int unsigned NOT NULL,
+  `status_time` datetime NOT NULL,
+  `status_time_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_status_log`),
+  KEY `fk_status_history_application` (`key_application`),
+  KEY `fk_status_history_status` (`key_status`),
+  CONSTRAINT `fk_status_history_application` FOREIGN KEY (`key_application`) REFERENCES `training_applications` (`id_application`),
+  CONSTRAINT `fk_status_history_status` FOREIGN KEY (`key_status`) REFERENCES `training_application_status` (`id_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_applications` (
+  `id_application` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_date` int unsigned DEFAULT NULL,
+  `key_training` int unsigned DEFAULT NULL,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `email` text CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci,
+  `familiar` tinyint(1) NOT NULL DEFAULT '0',
+  `company` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `street` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `city` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `zip` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `country` varchar(2) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `company_id` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `company_tax_id` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `note` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `price` decimal(10,2) unsigned DEFAULT NULL,
+  `vat_rate` decimal(4,3) unsigned DEFAULT NULL,
+  `price_vat` decimal(10,2) unsigned DEFAULT NULL,
+  `discount` int unsigned DEFAULT NULL,
+  `invoice_id` int unsigned DEFAULT NULL,
+  `paid` datetime DEFAULT NULL,
+  `paid_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `access_token` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `key_status` int unsigned NOT NULL,
+  `status_time` datetime NOT NULL,
+  `status_time_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `key_source` int unsigned NOT NULL,
+  PRIMARY KEY (`id_application`),
+  UNIQUE KEY `access_code_UNIQUE` (`access_token`),
+  KEY `fk_training_date` (`key_date`),
+  KEY `fk_training_application_status` (`key_status`),
+  KEY `fk_training_source` (`key_source`),
+  KEY `key_training` (`key_training`),
+  CONSTRAINT `fk_training_application_status` FOREIGN KEY (`key_status`) REFERENCES `training_application_status` (`id_status`),
+  CONSTRAINT `fk_training_date` FOREIGN KEY (`key_date`) REFERENCES `training_dates` (`id_date`),
+  CONSTRAINT `fk_training_source` FOREIGN KEY (`key_source`) REFERENCES `training_application_sources` (`id_source`),
+  CONSTRAINT `training_applications_ibfk_1` FOREIGN KEY (`key_training`) REFERENCES `trainings` (`id_training`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_cooperations` (
+  `id_cooperation` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `description` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  PRIMARY KEY (`id_cooperation`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_date_status` (
+  `id_status` int unsigned NOT NULL AUTO_INCREMENT,
+  `status` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `description` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_status`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci COMMENT='Same values as the TrainingDateStatus enum';
+
+CREATE TABLE `training_dates` (
+  `id_date` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_training` int unsigned NOT NULL,
+  `key_venue` int unsigned DEFAULT NULL,
+  `remote` bit(1) NOT NULL,
+  `start` datetime NOT NULL,
+  `end` datetime NOT NULL,
+  `label` json DEFAULT NULL,
+  `key_status` int unsigned NOT NULL,
+  `public` bit(1) NOT NULL DEFAULT b'1',
+  `key_cooperation` int unsigned DEFAULT NULL,
+  `note` varchar(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `price` int unsigned DEFAULT NULL,
+  `student_discount` int unsigned DEFAULT NULL,
+  `remote_url` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `remote_notes` text CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci,
+  `video_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `feedback_href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  PRIMARY KEY (`id_date`),
+  KEY `fk_training` (`key_training`),
+  KEY `fk_venue` (`key_venue`),
+  KEY `fk_training_date_status` (`key_status`),
+  KEY `fk_training_cooperation_idx` (`key_cooperation`),
+  CONSTRAINT `fk_training` FOREIGN KEY (`key_training`) REFERENCES `trainings` (`id_training`),
+  CONSTRAINT `fk_training_cooperation` FOREIGN KEY (`key_cooperation`) REFERENCES `training_cooperations` (`id_cooperation`),
+  CONSTRAINT `fk_training_date_status` FOREIGN KEY (`key_status`) REFERENCES `training_date_status` (`id_status`),
+  CONSTRAINT `fk_venue` FOREIGN KEY (`key_venue`) REFERENCES `training_venues` (`id_venue`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `training_materials` (
+  `id_idtraining_material` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_file` int unsigned NOT NULL,
+  `key_application` int unsigned NOT NULL,
+  PRIMARY KEY (`id_idtraining_material`),
+  KEY `fk_training_material_file_idx` (`key_file`),
+  KEY `fk_training_material_application_idx` (`key_application`),
+  CONSTRAINT `fk_training_material_application` FOREIGN KEY (`key_application`) REFERENCES `training_applications` (`id_application`),
+  CONSTRAINT `fk_training_material_file` FOREIGN KEY (`key_file`) REFERENCES `files` (`id_file`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `training_reviews` (
+  `id_review` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_date` int unsigned NOT NULL,
+  `name` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `company` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `job_title` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `review` varchar(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  `added` datetime NOT NULL,
+  `added_timezone` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `hidden` tinyint(1) NOT NULL DEFAULT '1',
+  `ranking` int unsigned DEFAULT NULL,
+  `note` varchar(2000) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci DEFAULT NULL,
+  PRIMARY KEY (`id_review`),
+  KEY `key_date` (`key_date`),
+  CONSTRAINT `training_reviews_ibfk_1` FOREIGN KEY (`key_date`) REFERENCES `training_dates` (`id_date`) ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `training_url_actions` (
+  `id_training_url_action` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_training` int unsigned NOT NULL,
+  `key_url_action` int unsigned NOT NULL,
+  PRIMARY KEY (`id_training_url_action`),
+  KEY `key_training` (`key_training`),
+  KEY `key_url_action` (`key_url_action`),
+  CONSTRAINT `training_url_actions_ibfk_1` FOREIGN KEY (`key_training`) REFERENCES `trainings` (`id_training`) ON UPDATE RESTRICT,
+  CONSTRAINT `training_url_actions_ibfk_2` FOREIGN KEY (`key_url_action`) REFERENCES `url_actions` (`id_url_action`) ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+CREATE TABLE `training_venues` (
+  `id_venue` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `name_extended` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `address` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `city` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `description` varchar(2000) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `action` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `entrance` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `entrance_navigation` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `streetview` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `parking` text CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci,
+  `public_transport` text CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci,
+  `order` tinyint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id_venue`),
+  UNIQUE KEY `action` (`action`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `trainings` (
+  `id_training` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `description` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `upsell` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `content` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `prerequisites` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `audience` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `capacity` int unsigned DEFAULT NULL,
+  `price` int unsigned DEFAULT NULL,
+  `student_discount` int unsigned DEFAULT NULL,
+  `materials` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
+  `custom` bit(1) NOT NULL DEFAULT b'0',
+  `key_successor` int unsigned DEFAULT NULL,
+  `key_discontinued` int unsigned DEFAULT NULL,
+  `order` tinyint unsigned DEFAULT NULL,
+  PRIMARY KEY (`id_training`),
+  KEY `key_successor` (`key_successor`),
+  KEY `order` (`order`),
+  KEY `key_discontinued` (`key_discontinued`),
+  CONSTRAINT `trainings_ibfk_1` FOREIGN KEY (`key_successor`) REFERENCES `trainings` (`id_training`),
+  CONSTRAINT `trainings_ibfk_2` FOREIGN KEY (`key_discontinued`) REFERENCES `trainings_discontinued` (`id_trainings_discontinued`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `trainings_company` (
+  `id_training_company` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_training` int unsigned NOT NULL,
+  `description` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `upsell` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `price` int unsigned NOT NULL,
+  `alternative_duration_price` int unsigned NOT NULL,
+  `duration` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `alternative_duration` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  `alternative_duration_price_text` varchar(200) CHARACTER SET utf8mb4 COLLATE utf8mb4_czech_ci NOT NULL,
+  PRIMARY KEY (`id_training_company`),
+  KEY `fk_training` (`key_training`),
+  CONSTRAINT `fk_company_training` FOREIGN KEY (`key_training`) REFERENCES `trainings` (`id_training`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_czech_ci;
+
+CREATE TABLE `trainings_discontinued` (
+  `id_trainings_discontinued` int unsigned NOT NULL AUTO_INCREMENT,
+  `description` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `href` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  PRIMARY KEY (`id_trainings_discontinued`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+CREATE TABLE `twitter_card_types` (
+  `id_twitter_card_type` int unsigned NOT NULL AUTO_INCREMENT,
+  `card` varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  `title` varchar(200) CHARACTER SET latin1 COLLATE latin1_swedish_ci NOT NULL,
+  PRIMARY KEY (`id_twitter_card_type`),
+  UNIQUE KEY `card` (`card`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+CREATE TABLE `url_actions` (
+  `id_url_action` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_language` int unsigned NOT NULL,
+  `action` varchar(200) NOT NULL,
+  PRIMARY KEY (`id_url_action`),
+  UNIQUE KEY `key_language_action` (`key_language`,`action`),
+  CONSTRAINT `url_actions_ibfk_1` FOREIGN KEY (`key_language`) REFERENCES `languages` (`id_language`) ON UPDATE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3;
+
+CREATE TABLE `users` (
+  `id_user` int unsigned NOT NULL AUTO_INCREMENT,
+  `username` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `passkey_user_handle` varbinary(64) NOT NULL,
+  PRIMARY KEY (`id_user`),
+  UNIQUE KEY `username_UNIQUE` (`username`),
+  UNIQUE KEY `passkey_user_handle` (`passkey_user_handle`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb3 COLLATE=utf8mb3_czech_ci;
+
+# Data
+
+INSERT INTO `auth_token_types` VALUES (1,'Permanent login token');
+INSERT INTO `auth_token_types` VALUES (3,'Passkey bootstrap token');
+
+INSERT INTO `languages` VALUES (1,'cs_CZ');
+INSERT INTO `languages` VALUES (2,'en_US');
+
+INSERT INTO `locales` VALUES (1,'cs_CZ');
+INSERT INTO `locales` VALUES (2,'en_US');
+
+INSERT INTO `training_application_status` VALUES (1,'CREATED','The application was just created. The flow always starts here.');
+INSERT INTO `training_application_status` VALUES (2,'TENTATIVE','The application is just tentative because the date of the training is not yet known. Skipped for known dates.');
+INSERT INTO `training_application_status` VALUES (3,'INVITED','An invitation was sent as the date for training is known. Skipped for known dates.');
+INSERT INTO `training_application_status` VALUES (4,'SIGNED_UP','The attendee is signed up.');
+INSERT INTO `training_application_status` VALUES (5,'INVOICE_SENT','The invoice was sent.');
+INSERT INTO `training_application_status` VALUES (6,'NOTIFIED','The attendee was notified about an upcoming training or partner was notified that the attendee has signed up.');
+INSERT INTO `training_application_status` VALUES (7,'ATTENDED','The attendee has showed up at the training.');
+INSERT INTO `training_application_status` VALUES (8,'MATERIALS_SENT','The materials from the training were sent. Could be just a link to download them too.');
+INSERT INTO `training_application_status` VALUES (9,'ACCESS_TOKEN_USED','Access token was used to access the website or download the materials.');
+INSERT INTO `training_application_status` VALUES (10,'CANCELED','Canceled by the attendee for whatever reason.');
+INSERT INTO `training_application_status` VALUES (11,'REFUNDED','Money sent back to attendee for whatever reason eg. training canceled.');
+INSERT INTO `training_application_status` VALUES (12,'CREDIT','Payment will be used for application for the next date of the same training, which will have the same invoice id.');
+INSERT INTO `training_application_status` VALUES (13,'IMPORTED','The record was imported from a partner website where the attendee signed up at.');
+INSERT INTO `training_application_status` VALUES (14,'NON_PUBLIC_TRAINING','The guy have attended a non-public/in-house training.');
+INSERT INTO `training_application_status` VALUES (15,'REMINDED','Reminder has been sent.');
+INSERT INTO `training_application_status` VALUES (16,'PAID_AFTER','Send the invoice after the training.');
+INSERT INTO `training_application_status` VALUES (17,'INVOICE_SENT_AFTER','The invoice was sent after the training.');
+INSERT INTO `training_application_status` VALUES (18,'PRO_FORMA_INVOICE_SENT','The pro forma invoice was sent.');
+INSERT INTO `training_application_status` VALUES (19,'SPAM','Someone tried to spam or pentest the app.');
+
+INSERT INTO `training_application_status_flow` VALUES (1,1,2);
+INSERT INTO `training_application_status_flow` VALUES (20,1,4);
+INSERT INTO `training_application_status_flow` VALUES (15,1,13);
+INSERT INTO `training_application_status_flow` VALUES (17,1,14);
+INSERT INTO `training_application_status_flow` VALUES (2,2,3);
+INSERT INTO `training_application_status_flow` VALUES (33,2,10);
+INSERT INTO `training_application_status_flow` VALUES (35,2,19);
+INSERT INTO `training_application_status_flow` VALUES (3,3,4);
+INSERT INTO `training_application_status_flow` VALUES (7,3,10);
+INSERT INTO `training_application_status_flow` VALUES (8,4,5);
+INSERT INTO `training_application_status_flow` VALUES (4,4,10);
+INSERT INTO `training_application_status_flow` VALUES (25,4,16);
+INSERT INTO `training_application_status_flow` VALUES (32,4,18);
+INSERT INTO `training_application_status_flow` VALUES (36,4,19);
+INSERT INTO `training_application_status_flow` VALUES (13,5,10);
+INSERT INTO `training_application_status_flow` VALUES (9,5,15);
+INSERT INTO `training_application_status_flow` VALUES (14,6,10);
+INSERT INTO `training_application_status_flow` VALUES (10,6,15);
+INSERT INTO `training_application_status_flow` VALUES (11,7,8);
+INSERT INTO `training_application_status_flow` VALUES (27,7,17);
+INSERT INTO `training_application_status_flow` VALUES (12,8,9);
+INSERT INTO `training_application_status_flow` VALUES (5,10,11);
+INSERT INTO `training_application_status_flow` VALUES (6,10,12);
+INSERT INTO `training_application_status_flow` VALUES (21,13,10);
+INSERT INTO `training_application_status_flow` VALUES (16,13,15);
+INSERT INTO `training_application_status_flow` VALUES (24,14,7);
+INSERT INTO `training_application_status_flow` VALUES (19,14,10);
+INSERT INTO `training_application_status_flow` VALUES (18,14,15);
+INSERT INTO `training_application_status_flow` VALUES (22,15,7);
+INSERT INTO `training_application_status_flow` VALUES (23,15,10);
+INSERT INTO `training_application_status_flow` VALUES (29,16,10);
+INSERT INTO `training_application_status_flow` VALUES (26,16,15);
+INSERT INTO `training_application_status_flow` VALUES (28,17,8);
+INSERT INTO `training_application_status_flow` VALUES (34,18,5);
+INSERT INTO `training_application_status_flow` VALUES (30,18,10);
+INSERT INTO `training_application_status_flow` VALUES (31,18,15);
+
+INSERT INTO `training_date_status` VALUES (1,'CREATED','Displayed in admin only');
+INSERT INTO `training_date_status` VALUES (2,'TENTATIVE','Displayed on the site as month, tentative signup');
+INSERT INTO `training_date_status` VALUES (3,'CONFIRMED','Displayed on the site with full date, regular signup');
+INSERT INTO `training_date_status` VALUES (4,'CANCELED','Displayed only in admin');
+
+INSERT INTO `twitter_card_types` VALUES (1,'summary','Summary Card');
+INSERT INTO `twitter_card_types` VALUES (2,'summary_large_image','Summary Card with Large Image');

--- a/app/db/pulse.sql
+++ b/app/db/pulse.sql
@@ -1,0 +1,85 @@
+# Tables
+
+CREATE TABLE `companies` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `name` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `trade_name` varchar(200) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `alias` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `added` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `password_algos` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `algo` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `alias` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `salted` bit(1) NOT NULL,
+  `stretched` bit(1) NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `password_disclosure_types` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `type` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `alias` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `password_disclosures` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_password_disclosure_types` int unsigned NOT NULL,
+  `url` varchar(2000) COLLATE utf8mb4_general_ci NOT NULL,
+  `archive` varchar(2000) COLLATE utf8mb4_general_ci NOT NULL,
+  `note` varchar(2000) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  `published` datetime DEFAULT NULL,
+  `added` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `key_password_disclosure_types` (`key_password_disclosure_types`),
+  CONSTRAINT `password_disclosures_ibfk_1` FOREIGN KEY (`key_password_disclosure_types`) REFERENCES `password_disclosure_types` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `password_disclosures_password_storages` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_password_disclosures` int unsigned NOT NULL,
+  `key_password_storages` int unsigned NOT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `key_password_disclosures_key_password_storages` (`key_password_disclosures`,`key_password_storages`),
+  KEY `key_password_storages` (`key_password_storages`),
+  CONSTRAINT `password_disclosures_password_storages_ibfk_1` FOREIGN KEY (`key_password_disclosures`) REFERENCES `password_disclosures` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `password_disclosures_password_storages_ibfk_2` FOREIGN KEY (`key_password_storages`) REFERENCES `password_storages` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `password_storages` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_companies` int unsigned DEFAULT NULL,
+  `key_password_algos` int unsigned NOT NULL,
+  `key_sites` int unsigned DEFAULT NULL,
+  `from` datetime DEFAULT NULL,
+  `from_confirmed` bit(1) NOT NULL,
+  `attributes` json DEFAULT NULL,
+  `note` varchar(2000) COLLATE utf8mb4_general_ci DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  KEY `key_password_algos` (`key_password_algos`),
+  KEY `key_sites` (`key_sites`),
+  KEY `key_companies` (`key_companies`),
+  CONSTRAINT `password_storages_ibfk_1` FOREIGN KEY (`key_companies`) REFERENCES `companies` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `password_storages_ibfk_2` FOREIGN KEY (`key_password_algos`) REFERENCES `password_algos` (`id`) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT `password_storages_ibfk_4` FOREIGN KEY (`key_sites`) REFERENCES `sites` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `sites` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_companies` int unsigned NOT NULL,
+  `url` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `alias` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  `shared_with` json DEFAULT NULL,
+  `added` datetime DEFAULT NULL,
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `alias` (`alias`),
+  KEY `key_companies` (`key_companies`),
+  CONSTRAINT `sites_ibfk_1` FOREIGN KEY (`key_companies`) REFERENCES `companies` (`id`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+# No data
+

--- a/app/db/upckeys.sql
+++ b/app/db/upckeys.sql
@@ -1,0 +1,33 @@
+# Tables
+
+CREATE TABLE `keys` (
+  `id_key` int unsigned NOT NULL AUTO_INCREMENT,
+  `key_ssid` int unsigned NOT NULL,
+  `prefix_id` tinyint unsigned NOT NULL,
+  `serial` int unsigned NOT NULL,
+  `key` bit(40) NOT NULL,
+  `type` int unsigned NOT NULL,
+  PRIMARY KEY (`id_key`),
+  KEY `key_ssid` (`key_ssid`),
+  CONSTRAINT `keys_ibfk_1` FOREIGN KEY (`key_ssid`) REFERENCES `ssids` (`id_ssid`) ON DELETE CASCADE ON UPDATE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `keys_ubee` (
+  `mac` mediumint unsigned NOT NULL,
+  `ssid` mediumint unsigned NOT NULL,
+  `key` bit(40) NOT NULL,
+  PRIMARY KEY (`mac`),
+  KEY `ssid` (`ssid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE `ssids` (
+  `id_ssid` int unsigned NOT NULL AUTO_INCREMENT,
+  `ssid` varchar(100) COLLATE utf8mb4_general_ci NOT NULL,
+  `added` datetime NOT NULL,
+  `added_timezone` varchar(200) COLLATE utf8mb4_general_ci NOT NULL,
+  PRIMARY KEY (`id_ssid`),
+  UNIQUE KEY `ssid` (`ssid`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+# No data
+


### PR DESCRIPTION
Commits the current schema of all 3 databases to `app/db/*.sql` so diagnostics (by both agents and humans) start from real DDL instead of guesses, plus `make dump-db-schema` to refresh them.

Schema-only by default, data is dumped only for fixed enumerations (status enums, languages, locales, Twitter card types). Scrubs `AUTO_INCREMENT=N` and `DEFINER=` to avoid row-count and operator-account leaks as this repo is public.

Drive-by: fixes a stale `default` DSN in `common.neon` that was being masked by `local.neon`.

Follow-ups:
- #754