### PR TITLE
Add Nette DI services usage provider for the Dead Code Detector

### DIFF
--- a/app/composer-dependency-analyser.php
+++ b/app/composer-dependency-analyser.php
@@ -17,6 +17,10 @@ return (new Configuration())
 	->setFileExtensions(['php', 'phpt'])
 	->addPathToScan(__DIR__ . '/tests', true)
 
+	// The provider references classes bundled inside PHPStan's phar (PhpParser\Node, PHPStan\Node\InClassNode).
+	// Composer cannot resolve those from outside PHPStan, so the analyser's reflection probe crashes.
+	->addPathToExclude(__DIR__ . '/src/PhpStan/DeadCode/NetteServicesUsageProvider.php')
+
 	// Add classes from services.neon and extensions.neon
 	->addForceUsedSymbols(DiServices::getAllClasses())
 

--- a/app/phpstan.neon
+++ b/app/phpstan.neon
@@ -35,3 +35,14 @@ includes:
 	- vendor/composer/pcre/extension.neon
 	- vendor-dev/vendor/phpstan/phpstan-strict-rules/rules.neon
 	- vendor-dev/vendor/shipmonk/dead-code-detector/rules.neon
+
+services:
+	-
+		class: MichalSpacekCz\PhpStan\DeadCode\NetteServicesUsageProvider
+		arguments:
+			paths:
+				- config/services.neon
+				- config/presenters.neon
+				- config/tests.neon
+		tags:
+			- shipmonk.deadCode.memberUsageProvider

--- a/app/phpstan.neon
+++ b/app/phpstan.neon
@@ -12,6 +12,10 @@ parameters:
 	checkMissingOverrideMethodAttribute: true
 	bootstrapFiles:
 		- vendor-dev/vendor/autoload.php
+	shipmonkDeadCode:
+		usageExcluders:
+			usageOverMixed:
+				enabled: true
 	ignoreErrors:
 		- # The getId() and getData() methods are called on a SimpleIdentity object, but are defined in a deprecated Identity class
 			identifier: method.deprecatedClass

--- a/app/psalm.xml
+++ b/app/psalm.xml
@@ -18,6 +18,7 @@
 			<directory name="temp" />
 			<directory name="vendor" />
 			<directory name="vendor-dev" />
+			<file name="src/PhpStan/DeadCode/NetteServicesUsageProvider.php" /> <!-- References PHPStan-phar-bundled classes (PhpParser\Node, PHPStan\Node\InClassNode) Composer's autoloader cannot resolve -->
 		</ignoreFiles>
 	</projectFiles>
 	<fileExtensions>

--- a/app/src/PhpStan/DeadCode/NetteServicesUsageProvider.php
+++ b/app/src/PhpStan/DeadCode/NetteServicesUsageProvider.php
@@ -1,0 +1,192 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\PhpStan\DeadCode;
+
+use Composer\Pcre\Preg;
+use LogicException;
+use Nette\Neon\Entity;
+use Nette\Neon\Neon;
+use Override;
+use PhpParser\Node;
+use PHPStan\Analyser\Scope;
+use PHPStan\Node\InClassNode;
+use PHPStan\Reflection\ReflectionProvider;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodRef;
+use ShipMonk\PHPStan\DeadCode\Graph\ClassMethodUsage;
+use ShipMonk\PHPStan\DeadCode\Graph\UsageOrigin;
+use ShipMonk\PHPStan\DeadCode\Provider\MemberUsageProvider;
+use ShipMonk\PHPStan\DeadCode\Provider\VirtualUsageData;
+
+/**
+ * Marks members of classes registered as Nette DI services as used by the dead-code detector.
+ *
+ * Nette DI instantiates services dynamically (`new $serviceClass(...)` where the class name is
+ * a class-string), which the dead-code detector cannot see statically. Without a provider like
+ * this one, those constructors would be reported as dead.
+ *
+ * Service definition shapes recognised in the `services:` block:
+ *   - "ClassName" / name: ClassName (scalar FQCN)
+ *   - "ClassName(args)" / name: ClassName(args) (NEON Entity, .value is the FQCN)
+ *   - name: { create: ClassName } (recurses into create)
+ *   - name: { factory: ClassName } (recurses into factory)
+ *   - name: { implement: InterfaceName } (recurses into implement; for the same automatically
+ *     generated factory handling as a bare interface registration)
+ *
+ * When a registered class is an interface with a create() method, the return type of create()
+ * is also marked as used - Nette DI auto-generates a class implementing the interface whose
+ * create() does `new ReturnType(...)`, and that `new` has no statically visible call site.
+ *
+ * Not supported:
+ *   - @serviceName::method references (factory-call form, not an instantiation here)
+ *   - type: + imported: (service imported from elsewhere, not instantiated by this entry)
+ */
+final class NetteServicesUsageProvider implements MemberUsageProvider
+{
+
+	/** @var array<class-string, true> */
+	private array $services = [];
+
+
+	/**
+	 * @param list<string> $paths relative or absolute paths to NEON files
+	 */
+	public function __construct(
+		private readonly ReflectionProvider $reflectionProvider,
+		array $paths,
+	) {
+		foreach ($paths as $path) {
+			$this->loadFromNeon($path);
+		}
+	}
+
+
+	#[Override]
+	public function getUsages(Node $node, Scope $scope): array
+	{
+		if (!$node instanceof InClassNode) { // @phpstan-ignore phpstanApi.instanceofAssumption
+			return [];
+		}
+		$classReflection = $node->getClassReflection();
+		$className = $classReflection->getName();
+		if (!isset($this->services[$className])) {
+			return [];
+		}
+		$nativeReflection = $classReflection->getNativeReflection();
+		if (!$nativeReflection->hasMethod('__construct')) {
+			return [];
+		}
+		$declaringClass = $nativeReflection->getMethod('__construct')->getDeclaringClass()->getName();
+		return [
+			new ClassMethodUsage(
+				UsageOrigin::createVirtual($this, VirtualUsageData::withNote('Instantiated by Nette DI container')),
+				new ClassMethodRef($declaringClass, '__construct', possibleDescendant: false),
+			),
+		];
+	}
+
+
+	/**
+	 * Pulls FQCNs out of the `services:` block of a NEON string. Static so it can be
+	 * unit-tested without a ReflectionProvider; the reflection check + auto-impl factory
+	 * return-type resolution stay in the instance.
+	 *
+	 * @return list<class-string>
+	 */
+	public static function findServiceClassesInNeon(string $neonContent): array
+	{
+		$classes = [];
+		$decoded = Neon::decode($neonContent);
+		if (!is_array($decoded) || !isset($decoded['services']) || !is_array($decoded['services'])) {
+			return [];
+		}
+		foreach ($decoded['services'] as $entry) {
+			$class = self::resolveServiceClass($entry);
+			if ($class !== null) {
+				$classes[] = $class;
+			}
+		}
+		return $classes;
+	}
+
+
+	private function loadFromNeon(string $neonFile): void
+	{
+		$contents = file_get_contents($neonFile);
+		if ($contents === false) {
+			throw new LogicException(sprintf('NEON file %s does not exist or is not readable', $neonFile));
+		}
+		foreach (self::findServiceClassesInNeon($contents) as $class) {
+			if ($this->reflectionProvider->hasClass($class)) {
+				$this->markServiceClass($class);
+			}
+		}
+	}
+
+
+	/**
+	 * @param class-string $class
+	 */
+	private function markServiceClass(string $class): void
+	{
+		$this->services[$class] = true;
+
+		// Automatically generated factory interfaces: Nette DI generates a class implementing
+		// the interface whose create() returns `new ReturnType(...)`. The return type's
+		// constructor also needs to be marked as used - there's no statically visible `new`
+		// for it anywhere in PHP source.
+		$classReflection = $this->reflectionProvider->getClass($class);
+		if (!$classReflection->isInterface() || !$classReflection->hasNativeMethod('create')) {
+			return;
+		}
+		$createMethod = $classReflection->getNativeMethod('create');
+		foreach ($createMethod->getVariants() as $variant) {
+			foreach ($variant->getReturnType()->getObjectClassNames() as $returnedClass) {
+				if ($this->reflectionProvider->hasClass($returnedClass)) {
+					$this->services[$returnedClass] = true;
+				}
+			}
+		}
+	}
+
+
+	/**
+	 * @return class-string|null
+	 */
+	private static function resolveServiceClass(mixed $value): ?string
+	{
+		if (is_string($value)) {
+			return self::extractClassName($value);
+		}
+		if ($value instanceof Entity && is_string($value->value)) {
+			return self::extractClassName($value->value);
+		}
+		if (is_array($value)) {
+			if (isset($value['create'])) {
+				return self::resolveServiceClass($value['create']);
+			}
+			if (isset($value['factory'])) {
+				return self::resolveServiceClass($value['factory']);
+			}
+			if (isset($value['implement'])) {
+				return self::resolveServiceClass($value['implement']);
+			}
+		}
+		return null;
+	}
+
+
+	/**
+	 * @return class-string|null
+	 */
+	private static function extractClassName(string $value): ?string
+	{
+		if (!Preg::isMatch('/^\\\\?[A-Za-z_][A-Za-z0-9_]*(\\\\[A-Za-z_][A-Za-z0-9_]*)*$/', $value)) {
+			return null;
+		}
+		/** @var class-string $normalised */
+		$normalised = ltrim($value, '\\');
+		return $normalised;
+	}
+
+}

--- a/app/src/Test/TestCaseRunner.php
+++ b/app/src/Test/TestCaseRunner.php
@@ -6,8 +6,7 @@ namespace MichalSpacekCz\Test;
 use LogicException;
 use MichalSpacekCz\Application\Bootstrap;
 use Nette\Utils\Type;
-use ReflectionException;
-use ReflectionMethod;
+use ReflectionClass;
 use Tester\Environment;
 use Tester\TestCase;
 
@@ -19,17 +18,18 @@ final class TestCaseRunner
 
 
 	/**
-	 * @param class-string $test
+	 * @param class-string<TestCase> $test
 	 * @return void
 	 */
 	public static function run(string $test): void
 	{
+		$reflection = new ReflectionClass($test);
+		$constructor = $reflection->getConstructor();
 		$params = [];
-		try {
-			$method = new ReflectionMethod($test, '__construct');
+		if ($constructor !== null) {
 			$container = Bootstrap::bootTest();
 			Environment::setup();
-			foreach ($method->getParameters() as $parameter) {
+			foreach ($constructor->getParameters() as $parameter) {
 				$type = Type::fromReflection($parameter);
 				$paramIdent = "Parameter #{$parameter->getPosition()} \${$parameter->getName()}";
 				if ($type === null) {
@@ -50,14 +50,8 @@ final class TestCaseRunner
 				}
 				$params[] = $container->getByType($singleName);
 			}
-		} catch (ReflectionException) {
-			// pass, __construct() does not exist
 		}
-		$testCase = new $test(...$params);
-		if (!$testCase instanceof TestCase) {
-			throw new LogicException(sprintf("%s() can only be used to run tests that extend %s", __METHOD__, TestCase::class));
-		}
-		$testCase->run();
+		$reflection->newInstanceArgs($params)->run();
 	}
 
 

--- a/app/tests/PhpStan/DeadCode/NetteServicesUsageProviderTest.phpt
+++ b/app/tests/PhpStan/DeadCode/NetteServicesUsageProviderTest.phpt
@@ -1,0 +1,210 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\PhpStan\DeadCode;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class NetteServicesUsageProviderTest extends TestCase
+{
+
+	public function testScalarFqcnInAnonymousEntry(): void
+	{
+		Assert::same(
+			['Foo\Bar'],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\t- Foo\\Bar"),
+		);
+	}
+
+
+	public function testScalarFqcnInNamedEntry(): void
+	{
+		Assert::same(
+			['Foo\Bar'],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\tservice: Foo\\Bar"),
+		);
+	}
+
+
+	public function testEntityWithConstructorArgs(): void
+	{
+		Assert::same(
+			['Foo\Bar'],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\t- Foo\\Bar(arg1, arg2)"),
+		);
+	}
+
+
+	public function testCreateMapping(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					create: Foo\Bar
+			NEON;
+		Assert::same(['Foo\Bar'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testCreateMappingWithConstructorArgs(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					create: Foo\Bar(arg1, arg2)
+			NEON;
+		Assert::same(['Foo\Bar'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testFactoryMapping(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					factory: Foo\Bar
+			NEON;
+		Assert::same(['Foo\Bar'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testLeadingBackslashStripped(): void
+	{
+		Assert::same(
+			['Foo\Bar'],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\t- \\Foo\\Bar"),
+		);
+	}
+
+
+	public function testSkipsServiceReference(): void
+	{
+		Assert::same(
+			[],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\t- @otherService::create()"),
+		);
+	}
+
+
+	public function testSkipsNamedServiceReference(): void
+	{
+		Assert::same(
+			[],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\tservice: @otherService::method"),
+		);
+	}
+
+
+	public function testSkipsImportedTypeMapping(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					type: Foo\Bar
+					imported: true
+			NEON;
+		Assert::same([], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testImplementMappingRecurses(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					implement: Foo\BarFactory
+			NEON;
+		Assert::same(['Foo\BarFactory'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testRejectsClassNameWithSpace(): void
+	{
+		Assert::same(
+			[],
+			NetteServicesUsageProvider::findServiceClassesInNeon("services:\n\t- Foo Bar"),
+		);
+	}
+
+
+	public function testCreateWinsOverFactoryWhenBothPresent(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					create: Foo\Create
+					factory: Foo\Factory
+			NEON;
+		Assert::same(['Foo\Create'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testNestedCreateChainsRecurse(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					create:
+						create: Foo\Bar
+			NEON;
+		Assert::same(['Foo\Bar'], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testServicesNotAnArrayReturnsEmpty(): void
+	{
+		Assert::same([], NetteServicesUsageProvider::findServiceClassesInNeon("services: not a list"));
+	}
+
+
+	public function testEntryWithOnlySetupBlockReturnsNoClass(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				service:
+					setup:
+						- @foo::method()
+			NEON;
+		Assert::same([], NetteServicesUsageProvider::findServiceClassesInNeon($neon));
+	}
+
+
+	public function testReturnsAllRecognisedEntriesInOrder(): void
+	{
+		$neon = <<<'NEON'
+			services:
+				- Foo\Alpha
+				named: Foo\Beta
+				- Foo\Gamma(arg)
+				bravo:
+					create: Foo\Delta
+				charlie:
+					factory: Foo\Epsilon
+				skipped: @other::method
+			NEON;
+		Assert::same(
+			['Foo\Alpha', 'Foo\Beta', 'Foo\Gamma', 'Foo\Delta', 'Foo\Epsilon'],
+			NetteServicesUsageProvider::findServiceClassesInNeon($neon),
+		);
+	}
+
+
+	public function testReturnsEmptyForMissingServicesBlock(): void
+	{
+		Assert::same([], NetteServicesUsageProvider::findServiceClassesInNeon("parameters:\n\tfoo: bar"));
+	}
+
+
+	public function testReturnsEmptyForEmptyServicesBlock(): void
+	{
+		Assert::same([], NetteServicesUsageProvider::findServiceClassesInNeon("services:"));
+	}
+
+}
+
+TestCaseRunner::run(NetteServicesUsageProviderTest::class);


### PR DESCRIPTION
- Teaches the Dead Code Detector (#755) about classes that Nette DI instantiates - until now those constructors were only kept alive by `TestCaseRunner::run()`'s unbounded `@param class-string $test` acting as a wildcard credit.
- Narrows the `TestCaseRunner` parameter to `class-string<TestCase>` now that the wildcard is no longer needed.
- Enables `usageExcluders.usageOverMixed` so any future mixed-typed call site fails the build rather than disappearing into an informational line at the end of the analysis.

`shipmonk-rnd/dead-code-detector` ships providers for Symfony, Laravel, Doctrine, etc. but not for Nette DI, so the provider lives here for now. Probably worth upstreaming once it settles, though the `Nette\Neon` dependency may push it to a separate extension package rather than the main detector. If upstream accepts it, then the exclusions in `app/composer-dependency-analyser.php` and `app/psalm.xml` should be reverted.

Close #728, again

Follow-ups:
- #757