### PR TITLE
Cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,26 +4,36 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    cooldown:
+      default-days: 3
 
   - package-ecosystem: "npm"
     directory: "/site"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "npm"
     directory: "/site/vendor/nette/forms"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "npm"
     directory: "/site/vendor/tracy/tracy"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
 
   - package-ecosystem: "composer"
     directory: "/site"
     schedule:
       interval: "monthly"
+    cooldown:
+      default-days: 5
     allow:
       # Allow both direct and indirect updates for all packages
       - dependency-type: "all"


### PR DESCRIPTION
Defines a cooldown period for dependency updates, allowing updates to be delayed for a configurable number of days. The cooldown option is only available for version updates, not security updates.

https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-