### PR TITLE
Stop turning CLI arguments into a string just to parse them back

### DIFF
--- a/app/src/Application/Bootstrap.php
+++ b/app/src/Application/Bootstrap.php
@@ -105,14 +105,10 @@ final class Bootstrap
 	 */
 	private static function getCliArgs(string $argsProvider): CliArgs
 	{
-		$args = $argsProvider::getArgs();
-		$hasCustomArgs = $args !== [];
-		$args[] = self::DEBUG;
-		$args[] = self::COLORS;
-		if ($hasCustomArgs) {
-			$args = array_unique($args);
-		}
-		$cliArgsParser = new Parser("\n " . implode("\n ", $args), $argsProvider::getPositionalArgs());
+		$cliArgsParser = new Parser();
+		$argsProvider::defineArgs($cliArgsParser);
+		$cliArgsParser->addSwitch(self::DEBUG); // --debug and --colors are available to every script, but can be readded there for readability
+		$cliArgsParser->addSwitch(self::COLORS);
 		$cliArgsParsed = [];
 		$cliArgsError = null;
 		try {

--- a/app/src/Application/Cli/CliArgsProvider.php
+++ b/app/src/Application/Cli/CliArgsProvider.php
@@ -9,14 +9,9 @@ interface CliArgsProvider
 {
 
 	/**
-	 * @return list<string>
+	 * Declare the script's command-line arguments on the parser, using its
+	 * `addSwitch()`/`addArgument()`/`addOption()` builders.
 	 */
-	public static function getArgs(): array;
-
-
-	/**
-	 * @return array<string, array<Parser::Argument|Parser::Optional|Parser::Repeatable|Parser::Enum|Parser::RealPath|Parser::Normalizer|Parser::Default, int|string|bool>>
-	 */
-	public static function getPositionalArgs(): array;
+	public static function defineArgs(Parser $parser): void;
 
 }

--- a/app/src/Application/Cli/NoCliArgs.php
+++ b/app/src/Application/Cli/NoCliArgs.php
@@ -3,22 +3,15 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application\Cli;
 
+use Nette\CommandLine\Parser;
 use Override;
 
 final class NoCliArgs implements CliArgsProvider
 {
 
 	#[Override]
-	public static function getArgs(): array
+	public static function defineArgs(Parser $parser): void
 	{
-		return [];
-	}
-
-
-	#[Override]
-	public static function getPositionalArgs(): array
-	{
-		return [];
 	}
 
 }

--- a/app/src/Templating/LatteLinter.php
+++ b/app/src/Templating/LatteLinter.php
@@ -70,21 +70,14 @@ final readonly class LatteLinter implements CliArgsProvider
 
 
 	#[Override]
-	public static function getArgs(): array
+	public static function defineArgs(Parser $parser): void
 	{
-		return [
-			self::ARG_DEBUG,
-			self::ARG_DISABLE_STRICT_PARSING,
-		];
-	}
-
-
-	#[Override]
-	public static function getPositionalArgs(): array
-	{
-		return [
-			self::ARG_PATH => [Parser::RealPath => true],
-		];
+		$parser->addSwitch(self::ARG_DEBUG);
+		$parser->addSwitch(self::ARG_DISABLE_STRICT_PARSING);
+		$parser->addArgument(self::ARG_PATH, normalizer: static function (mixed $path): string {
+			assert(is_string($path)); // a positional argument's value always arrives as a string from $argv
+			return Parser::normalizeRealPath($path);
+		});
 	}
 
 }

--- a/app/src/Tls/CertificateMonitor.php
+++ b/app/src/Tls/CertificateMonitor.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Tls;
 use Exception;
 use MichalSpacekCz\Application\Cli\CliArgs;
 use MichalSpacekCz\Application\Cli\CliArgsProvider;
+use Nette\CommandLine\Parser;
 use Override;
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
 
@@ -151,16 +152,9 @@ final class CertificateMonitor implements CliArgsProvider
 
 
 	#[Override]
-	public static function getArgs(): array
+	public static function defineArgs(Parser $parser): void
 	{
-		return [self::NO_IPV6];
-	}
-
-
-	#[Override]
-	public static function getPositionalArgs(): array
-	{
-		return [];
+		$parser->addSwitch(self::NO_IPV6);
 	}
 
 }

--- a/app/src/User/WebAuthn/PasskeyResetUrl.php
+++ b/app/src/User/WebAuthn/PasskeyResetUrl.php
@@ -56,18 +56,9 @@ final readonly class PasskeyResetUrl implements CliArgsProvider
 
 
 	#[Override]
-	public static function getArgs(): array
+	public static function defineArgs(Parser $parser): void
 	{
-		return [];
-	}
-
-
-	#[Override]
-	public static function getPositionalArgs(): array
-	{
-		return [
-			self::ARG_USERNAME => [Parser::Argument => true],
-		];
+		$parser->addArgument(self::ARG_USERNAME);
 	}
 
 }

--- a/app/tests/User/WebAuthn/PasskeyResetUrlTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyResetUrlTest.phpt
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User\WebAuthn;
 
+use Exception;
 use MichalSpacekCz\Application\Cli\CliArgs;
 use MichalSpacekCz\Application\LinkGenerator;
 use MichalSpacekCz\Database\TypedDatabase;
@@ -86,10 +87,14 @@ final class PasskeyResetUrlTest extends TestCase
 	}
 
 
-	public function testArgs(): void
+	public function testDefineArgs(): void
 	{
-		Assert::same([], PasskeyResetUrl::getArgs());
-		Assert::same(['username' => [Parser::Argument => true]], PasskeyResetUrl::getPositionalArgs());
+		$parser = new Parser();
+		PasskeyResetUrl::defineArgs($parser);
+		Assert::same(['username' => 'leet'], $parser->parse(['leet']));
+		Assert::exception(function () use ($parser): void {
+			$parser->parse([]);
+		}, Exception::class, 'Missing required argument <username>.');
 	}
 
 }


### PR DESCRIPTION
`CliArgsProvider` split each script's command-line arguments across `getArgs()` for flags and `getPositionalArgs()` for positional ones, and `Bootstrap` glued them back into a fake help string just so Nette's `Parser` could parse them straight out again. That round-trip only existed because older `nette/command-line` offered no other way in. Version 1.9 added `addSwitch()`/`addArgument()`/`addOption()`, so one `defineArgs(Parser)` now lets each script describe its arguments to the parser directly, and the string juggling disappears.

Returning a list of `Option` objects, as the issue sketches, wouldn't actually help: `Parser` has no public way to accept a prebuilt `Option`, so each one would just get translated back into a builder call. Configuring the parser in place avoids that.

`LatteLinter` resolves its path argument with Nette's `normalizeRealPath`, which is string-typed but has to be passed to a `Closure(mixed): mixed` normalizer slot. A positional argument always arrives as a string from `argv`, so we assert that rather than widen the path to `mixed`, the same way we assert the shape of a database row.

The rename of "args" to "options" that the issue floats is intentionally left out: "arguments" is the standard umbrella for every kind of command-line input, while "options" means only the `--foo` kind, so it would make the name less accurate, not more.

Closes #718