### PR TITLE
Tighten supply-chain hygiene: revive Dependabot, least-privilege CI tokens, fewer moving refs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,28 +8,14 @@ updates:
       default-days: 3
 
   - package-ecosystem: "npm"
-    directory: "/site"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 5
-
-  - package-ecosystem: "npm"
-    directory: "/site/vendor/nette/forms"
-    schedule:
-      interval: "monthly"
-    cooldown:
-      default-days: 5
-
-  - package-ecosystem: "npm"
-    directory: "/site/vendor/tracy/tracy"
+    directory: "/app"
     schedule:
       interval: "monthly"
     cooldown:
       default-days: 5
 
   - package-ecosystem: "composer"
-    directory: "/site"
+    directory: "/app"
     schedule:
       interval: "monthly"
     cooldown:

--- a/.github/workflows/certmonitor.yml
+++ b/.github/workflows/certmonitor.yml
@@ -17,6 +17,8 @@ jobs:
           - "8.5"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           coverage: none

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -61,6 +61,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -13,13 +13,12 @@ permissions:
 jobs:
   scan:
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # Fetch all history for all branches and tags
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Used to comment on PRs
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: false # Commenting would require a token with pull-requests=write
           GITLEAKS_VERSION: latest

--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           fetch-depth: 0  # Fetch all history for all branches and tags
+          persist-credentials: false
       - uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/php-tester-include-skipped.yml
+++ b/.github/workflows/php-tester-include-skipped.yml
@@ -17,6 +17,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: pcov

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -59,6 +59,12 @@ jobs:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
     - run: make --directory=app check-sri-macros-concat
 
+  check-dependabot-directories:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - run: make --directory=app check-dependabot-directories
+
   lint-php:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -31,12 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - run: make --directory=app composer-validate
 
   check-file-patterns:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - run: make --directory=app check-file-patterns
 
   check-makefile:
@@ -47,6 +51,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: none
@@ -57,12 +63,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - run: make --directory=app check-sri-macros-concat
 
   check-dependabot-directories:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - run: make --directory=app check-dependabot-directories
 
   lint-php:
@@ -73,6 +83,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: none
@@ -88,6 +100,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: none
@@ -102,6 +116,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: none
@@ -112,6 +128,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - run: make --directory=app lint-xml-auto-install-download-xsd
 
   phpcs:
@@ -122,6 +140,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Get PHP_CodeSniffer cache file pattern
       id: phpcs-cache
       run: echo "file=$(php -r "echo sys_get_temp_dir() . '/phpcs.*';")" >> $GITHUB_OUTPUT
@@ -144,6 +164,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Get PHPStan result cache directory
       id: phpstan-cache
       run: echo "dir=$(php -r "echo sys_get_temp_dir() . '/phpstan';")" >> $GITHUB_OUTPUT
@@ -166,6 +188,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - name: Get PHPStan result cache directory
       id: phpstan-cache
       run: echo "dir=$(php -r "echo sys_get_temp_dir() . '/phpstan';")" >> $GITHUB_OUTPUT
@@ -188,6 +212,8 @@ jobs:
           - "8.5"
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
       with:
         coverage: pcov
@@ -217,6 +243,8 @@ jobs:
           - "8.5"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           coverage: none
@@ -232,6 +260,8 @@ jobs:
           - "8.5"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
         with:
           coverage: none

--- a/.github/workflows/securitytxt.yml
+++ b/.github/workflows/securitytxt.yml
@@ -27,7 +27,7 @@ jobs:
         php-version: ${{ matrix.php-version }}
         extensions: gnupg
     - name: Install the checker
-      run: composer require spaze/security-txt:dev-main
+      run: composer require spaze/security-txt:^2.0
     - name: Check security.txt at ${{ matrix.host }}
       run: |
         php \

--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+      with:
+        persist-credentials: false
     - uses: symfonycorp/security-checker-action@258311ef7ac571f1310780ef3d79fc5abef642b5 # v5
       with:
           lock: app/composer.lock
@@ -22,10 +24,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: make --directory=app composer-audit
 
   npm-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - run: make --directory=app npm-audit

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -14,8 +14,9 @@ keywords = [
 [allowlist]
 paths = [
   '''js/openpgp\.min\.js''',
-  '''site/vendor/''',
+  '''site/vendor/''', # Old path, still in git history
+  '''app/vendor/''',
   # Paths otherwise .gitignored should be listed here if you want to use `gitleaks directory`
   '''i/build/''',
-  '''site/temp/cache/''',
+  '''app/temp/cache/''',
 ]

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,6 @@
-.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt dump-db-schema
+.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt dump-db-schema
 
-test: composer-audit composer-validate npm-audit check-file-patterns check-makefile check-sri-macros-concat lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
+test: composer-audit composer-validate npm-audit check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
 composer-audit:
 	composer audit
@@ -32,6 +32,9 @@ check-makefile:
 
 check-sri-macros-concat:
 	bin/check-sri-macros-concat.sh
+
+check-dependabot-directories:
+	bin/check-dependabot-directories.sh
 
 lint-php:
 	vendor-dev/vendor/php-parallel-lint/php-parallel-lint/parallel-lint --colors -e php,phtml,phpt,phpstub src/ public/ stubs/ tests/

--- a/app/bin/check-dependabot-directories.sh
+++ b/app/bin/check-dependabot-directories.sh
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+echo "Dependabot directories that no longer exist:"
+
+ROOT=$(git rev-parse --show-toplevel)
+CONFIG="$ROOT/.github/dependabot.yml"
+if [ ! -f "$CONFIG" ]; then
+	echo "Cannot find $CONFIG"
+	exit 1
+fi
+
+MISSING=""
+DIRS=$(grep -E '^[[:space:]]*directory:' "$CONFIG" | sed -E 's/^[[:space:]]*directory:[[:space:]]*//; s/"//g')
+for dir in $DIRS; do
+	rel="${dir#/}"
+	[ -z "$rel" ] && rel="."
+	if [ ! -e "$ROOT/$rel" ]; then
+		MISSING="$MISSING $dir"
+	fi
+done
+
+if [ -z "$MISSING" ]; then
+	echo "None, all watched directories exist"
+	exit 0
+else
+	echo "$MISSING"
+	echo "A directory: in dependabot.yml points outside the repo, so Dependabot silently stops updating it. A rename probably left dependabot.yml behind, like site/ to app/ did."
+	exit 1
+fi


### PR DESCRIPTION
A supply-chain review turned up a mostly solid posture (SHA-pinned actions, least-privilege workflow permissions, vendored dependencies, strict CSP and SRI) with a handful of gaps, most of them fallout from the old `site/` to `app/` rename (in #402). This cleans
them up. Each change is its own commit with the reasoning in the message.

Dependabot
- Repoint the npm and Composer updaters from `/site` to `/app`. They had pointed at the pre-rename path for about twenty months, so the automated dependency-update PRs silently stopped. Manual updates kept the deps current, but the backstop was gone.
Also drop the two npm entries for `vendor/nette/forms` and `vendor/tracy/tracy`: those manifests only list build tooling we never install or run, so watching them was noise.
- Add a `check-dependabot-directories` CI check (wired like `check-file-patterns`) that fails if any `directory:` in `dependabot.yml` no longer exists, so a future rename cannot silently break it again.

CI least privilege
- Drop the gitleaks job from `contents: write` to the inherited `contents: read` and stop passing `GITHUB_TOKEN`. It was only used to post PR comments, and a failed check plus the step log says the same thing.
- Set `persist-credentials: false` on every checkout. No job pushes back to the repo, so none need the token left in `.git/config` for later steps to read.

Fewer moving references
- Pin the security.txt checker from `spaze/security-txt:dev-main` to `^2.0`, the constraint the app already uses, so the daily check runs against a released, immutable version instead of a force-pushable branch.
- Match the gitleaks allowlist to the renamed dir: add `app/vendor/`, keep `site/vendor/` (the full-history scan still sees pre-rename commits under it), and repoint the cache path.

Deliberately left out
- A `composer.lock` URL-owner check and an upstream-tag-vs-Packagist canary. Packagist is [rolling out stable-version immutability](https://blog.packagist.com/an-update-on-composer-packagist-supply-chain-security/), with artifact provenance on their roadmap, which addresses the threat upstream, and the lock already pins commit SHAs.
- `roave/security-advisories: dev-latest stays` (it is published only as a dev metapackage). It will go once we require Composer 2.9+, whose built-in audit covers the same ground.