### PR TITLE
Enforce that namespaces match their file path

### DIFF
--- a/app/phpcs.xml
+++ b/app/phpcs.xml
@@ -6,6 +6,20 @@
 	<arg value="s"/>
 	<arg value="p"/>
 	<rule ref="vendor-dev/vendor/spaze/coding-standard/src/ruleset.xml"/>
+	<rule ref="SlevomatCodingStandard.Files.TypeNameMatchesFileName">
+		<properties>
+			<property name="rootNamespaces" type="array">
+				<element key="src" value="MichalSpacekCz"/>
+				<element key="tests" value="MichalSpacekCz"/>
+				<!-- bin scripts are procedural, so this only catches a class placed in bin/ if any, not a script's namespace -->
+				<element key="bin" value="MichalSpacekCz\Bin"/>
+			</property>
+			<property name="extensions" type="array">
+				<element value="php"/>
+				<element value="phpt"/>
+			</property>
+		</properties>
+	</rule>
 	<rule ref="PSR1.Files.SideEffects.FoundWithSymbols">
 		<exclude-pattern>tests/</exclude-pattern> <!-- PHPStorm's @noinspection must be on the first line, before declare(strict_types = 1) -->
 	</rule>

--- a/app/tests/Database/TypedDatabaseTest.phpt
+++ b/app/tests/Database/TypedDatabaseTest.phpt
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Database;
+namespace MichalSpacekCz\Database;
 
 use MichalSpacekCz\Database\Exceptions\TypedDatabaseTypeException;
 use MichalSpacekCz\Database\TypedDatabase;

--- a/app/tests/EasterEgg/FourOhFourButFound/FourOhFourButFoundTest.phpt
+++ b/app/tests/EasterEgg/FourOhFourButFound/FourOhFourButFoundTest.phpt
@@ -3,7 +3,7 @@
 /** @noinspection PhpMissingParentConstructorInspection */
 declare(strict_types = 1);
 
-namespace EasterEgg\FourOhFourButFound;
+namespace MichalSpacekCz\EasterEgg\FourOhFourButFound;
 
 use MichalSpacekCz\EasterEgg\FourOhFourButFound\FourOhFourButFound;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;

--- a/app/tests/EasterEgg/WinterIsComing/WinterIsComingTest.phpt
+++ b/app/tests/EasterEgg/WinterIsComing/WinterIsComingTest.phpt
@@ -4,7 +4,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace EasterEgg\WinterIsComing;
+namespace MichalSpacekCz\EasterEgg\WinterIsComing;
 
 use MichalSpacekCz\EasterEgg\WinterIsComing\WinterIsComing;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;

--- a/app/tests/Media/SlidesPlatformTest.phpt
+++ b/app/tests/Media/SlidesPlatformTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace Media;
+namespace MichalSpacekCz\Media;
 
 use MichalSpacekCz\Media\SlidesPlatform;
 use MichalSpacekCz\Test\TestCaseRunner;

--- a/app/tests/Media/VideoPlatformTest.phpt
+++ b/app/tests/Media/VideoPlatformTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace Media;
+namespace MichalSpacekCz\Media;
 
 use MichalSpacekCz\Media\VideoPlatform;
 use MichalSpacekCz\Test\TestCaseRunner;

--- a/app/tests/Presentation/Www/Talks/TalksDefaultTemplateParametersFactoryTest.phpt
+++ b/app/tests/Presentation/Www/Talks/TalksDefaultTemplateParametersFactoryTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace Presentation\Www\Talks;
+namespace MichalSpacekCz\Presentation\Www\Talks;
 
 use DateTime;
 use MichalSpacekCz\Presentation\Www\Talks\TalksDefaultTemplateParametersFactory;

--- a/app/tests/Presentation/Www/Talks/TalksTalkTemplateParametersFactoryTest.phpt
+++ b/app/tests/Presentation/Www/Talks/TalksTalkTemplateParametersFactoryTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace Presentation\Www\Talks;
+namespace MichalSpacekCz\Presentation\Www\Talks;
 
 use MichalSpacekCz\Media\SlidesPlatform;
 use MichalSpacekCz\Presentation\Www\Talks\Exceptions\DeprecatedEmbedSlideInUrlException;

--- a/app/tests/Pulse/Error/PulseErrorTest.phpt
+++ b/app/tests/Pulse/Error/PulseErrorTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace Pulse\Error;
+namespace MichalSpacekCz\Pulse\Error;
 
 use MichalSpacekCz\Pulse\Error\PulseError;
 use MichalSpacekCz\Test\Http\Response;

--- a/app/tests/Training/Mails/TrainingMailsTest.phpt
+++ b/app/tests/Training/Mails/TrainingMailsTest.phpt
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Training\Mails;
+namespace MichalSpacekCz\Training\Mails;
 
 use DateTime;
 use MichalSpacekCz\Templating\TemplateFactory;

--- a/app/tests/Training/Reviews/TrainingReviewsTest.phpt
+++ b/app/tests/Training/Reviews/TrainingReviewsTest.phpt
@@ -2,7 +2,7 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\Training\Preliminary;
+namespace MichalSpacekCz\Training\Reviews;
 
 use DateTimeImmutable;
 use MichalSpacekCz\DateTime\DateTimeFormat;

--- a/app/tests/User/UserSessionAdditionalDataTest.phpt
+++ b/app/tests/User/UserSessionAdditionalDataTest.phpt
@@ -4,7 +4,7 @@
 /** @noinspection PhpUndefinedFieldInspection */
 declare(strict_types = 1);
 
-namespace User;
+namespace MichalSpacekCz\User;
 
 use MichalSpacekCz\Test\PrivateProperty;
 use MichalSpacekCz\Test\Security\NullUserStorage;

--- a/app/tests/Utils/StringsTest.phpt
+++ b/app/tests/Utils/StringsTest.phpt
@@ -1,7 +1,7 @@
 <?php
 declare(strict_types = 1);
 
-namespace Utils;
+namespace MichalSpacekCz\Utils;
 
 use MichalSpacekCz\Test\NoOpTranslator;
 use MichalSpacekCz\Test\TestCaseRunner;


### PR DESCRIPTION
Test files kept drifting from the convention that a file's namespace mirrors its directory: an IDE generating the namespace without the `MichalSpacekCz` prefix, and the occasional copied test keeping the original's subpath. This fixes the existing strays and stops new ones automatically.

No new tooling was needed. `SlevomatCodingStandard.Files.TypeNameMatchesFileName` is already installed (via `spaze/coding-standard`), and `phpcs.xml` already scans `.phpt`, so enabling it is config only. It rides the existing `make phpcs` target and `phpcs` CI job, so there is nothing new to maintain. As a bonus it also enforces that a class name matches its filename.

The sniff is type-scoped (it checks classes, interfaces, traits, enums), so it does not look at the namespace of procedural files. The bin entry therefore only guards a future class placed in `bin/`, not today's procedural scripts, which is documented inline in `phpcs.xml`.