### PR TITLE
Install packages for `composer audit`, after the `vendor-dev` split 

### DIFF
--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -22,10 +22,18 @@ jobs:
 
   composer-audit:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version:
+          - "8.5"
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - uses: shivammathur/setup-php@7c071dfe9dc99bdf297fa79cb49ea005b9fcadbc # v2
+        with:
+          coverage: none
+          php-version: ${{ matrix.php-version }}
       - run: composer --working-dir=app/vendor-dev install
       - run: make --directory=app composer-audit
 

--- a/.github/workflows/vulns.yml
+++ b/.github/workflows/vulns.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - run: composer --working-dir=app/vendor-dev install
       - run: make --directory=app composer-audit
 
   npm-audit:


### PR DESCRIPTION
Otherwise, `make composer-audit` fails sometimes even silently.

Same fix as in #742.

Follow-up to #726