### PR TITLE
Simplify the `passkey-add.php` script execution help

### DIFF
--- a/app/src/Presentation/Admin/Passkeys/register.latte
+++ b/app/src/Presentation/Admin/Passkeys/register.latte
@@ -8,7 +8,7 @@
 <div n:if="$registrationEnabled" class="flash info">{_messages.passkeys.register.enabled|format:'authentication.passkeys.registrationEnabled: false'}</div>
 <div n:if="!$registrationEnabled" class="flash notice">{_messages.passkeys.register.disabled|format:'authentication.passkeys.registrationEnabled: true','local.neon'}</div>
 <p>{_messages.passkeys.register.howTo}</p>
-<p><code>php bin/passkey-add.php &lt;username&gt;</code></p>
+<p><code>bin/passkey-add.php &lt;username&gt;</code></p>
 
 <h2>{_messages.passkeys.register.howItWorks.title}</h2>
 <ul>


### PR DESCRIPTION
It has an exec bit set, so no need to have `php`.

Follow-up #772