### PR TITLE
Don't show the inline passkey form's validation modal twice

### DIFF
--- a/app/public/www.michalspacek.cz/i/js/passkey-authenticate.js
+++ b/app/public/www.michalspacek.cz/i/js/passkey-authenticate.js
@@ -9,7 +9,7 @@ App.ready(document, function () {
 		} else {
 			form.addEventListener('submit', function (event) {
 				event.preventDefault();
-				if (Nette.validateForm(form)) {
+				if (Nette.validateForm(form, true)) {
 					runCeremony(form);
 				}
 			});


### PR DESCRIPTION
The account email form carries two `submit` handlers: netteForms' own, which validates and shows the `netteFormsModal` error dialog, and `passkey-authenticate.js`'s, which validates to decide whether to start the passkey ceremony. Both called `Nette.validateForm(form)`, which displays errors, so submitting with an empty field popped the dialog twice whenever our handler ran before netteForms' one (the two scripts load `async`, so their order isn't fixed). The `onlyCheck` argument makes our handler test validity without displaying anything, leaving netteForms' handler to show the single modal.

Follow-up to #774