### PR TITLE
Email the user when a passkey is added or reset

### DIFF
--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -52,6 +52,9 @@ parameters:
 	securityTxtDirs:
 			www.michalspacek.cz.test: www.michalspacek.cz
 
+	mail:
+		securityNotificationsFrom: "Fred <fred@waldo.example>"
+
 	encryption:
 		keys:
 			password:

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -68,6 +68,8 @@ parameters:
 	# Added/changed in local.neon
 	contact:
 		phoneNumber: "123456789"
+	mail:
+		securityNotificationsFrom: "Foo <foo@bar.example>"
 	encryption:
 		keys:
 			password: []

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -207,6 +207,7 @@ services:
 	- MichalSpacekCz\User\Manager(usersTableName: %authentication.tables.users%)
 	- MichalSpacekCz\User\PermanentLogin\PermanentLogin(interval: %permanentLogin.interval%)
 	- MichalSpacekCz\User\UserAccounts(emailEncryption: @emailEncryption, usersTableName: %authentication.tables.users%)
+	- MichalSpacekCz\User\Notifications\UserSecurityNotifier(emailFrom: %mail.securityNotificationsFrom%)
 	- MichalSpacekCz\User\UserSessionAdditionalData
 	passkeyAuthentication: MichalSpacekCz\User\WebAuthn\PasskeyAuthenticator(rpId: %authentication.passkeys.rpId%, rpName: %authentication.passkeys.rpName%)
 	- MichalSpacekCz\User\WebAuthn\Authentication\Reauthentication(ttl: %authentication.passkeys.reauthTtl%)

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -23,6 +23,8 @@ parameters:
 			password: mspetest
 			email: mseetest
 			session: mssetest
+	mail:
+		securityNotificationsFrom: "Tests <foo@tests.example>"
 	awsLambda:
 		upcKeys:
 			url: "https://was.example/%s/%s"

--- a/app/src/Test/NullMailer.php
+++ b/app/src/Test/NullMailer.php
@@ -32,4 +32,10 @@ final class NullMailer implements Mailer
 		return $this->mail;
 	}
 
+
+	public function reset(): void
+	{
+		$this->mail = null;
+	}
+
 }

--- a/app/src/User/Notifications/UserSecurityNotifier.php
+++ b/app/src/User/Notifications/UserSecurityNotifier.php
@@ -1,0 +1,105 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\Notifications;
+
+use Contributte\Translation\Translator;
+use MichalSpacekCz\Application\LinkGenerator;
+use MichalSpacekCz\DateTime\DateTimeFactory;
+use MichalSpacekCz\Templating\DefaultTemplate;
+use MichalSpacekCz\Templating\TemplateFactory;
+use MichalSpacekCz\User\UserAccounts;
+use Nette\Http\IRequest;
+use Nette\Mail\Mailer;
+use Nette\Mail\Message;
+use Throwable;
+use Tracy\Debugger;
+
+/**
+ * Tells a user out of band when something security-sensitive happens to their account (a passkey is
+ * added or reset). Best-effort: a delivery failure is logged but never propagated, so it can't break
+ * the action that triggered it. A user with no email set is logged and skipped.
+ */
+final readonly class UserSecurityNotifier
+{
+
+	public function __construct(
+		private Mailer $mailer,
+		private TemplateFactory $templateFactory,
+		private Translator $translator,
+		private DateTimeFactory $dateTimeFactory,
+		private IRequest $httpRequest,
+		private LinkGenerator $linkGenerator,
+		private UserAccounts $userAccounts,
+		private string $emailFrom,
+	) {
+	}
+
+
+	public function passkeyAdded(int $userId, string $credentialName): void
+	{
+		try {
+			$address = $this->userAccounts->getEmail($userId);
+			if ($address === null) {
+				$this->logNoEmail($userId);
+				return;
+			}
+			$template = $this->createTemplate('passkeyAdded');
+			$template->credentialName = $credentialName;
+			$template->when = $this->dateTimeFactory->create();
+			$template->ipAddress = $this->httpRequest->getRemoteAddress();
+			$template->reviewUrl = $this->linkGenerator->link('//:Admin:Passkeys:default');
+			$this->send($address, 'messages.notifications.passkeyAdded.subject', $template);
+		} catch (Throwable $e) {
+			Debugger::log($e, 'auth');
+		}
+	}
+
+
+	public function passkeyReset(int $userId, string $credentialName, bool $otherAccessRevoked): void
+	{
+		try {
+			$address = $this->userAccounts->getEmail($userId);
+			if ($address === null) {
+				$this->logNoEmail($userId);
+				return;
+			}
+			$template = $this->createTemplate('passkeyReset');
+			$template->credentialName = $credentialName;
+			$template->when = $this->dateTimeFactory->create();
+			$template->ipAddress = $this->httpRequest->getRemoteAddress();
+			$template->reviewUrl = $this->linkGenerator->link('//:Admin:Passkeys:default');
+			$template->otherAccessRevoked = $otherAccessRevoked;
+			$this->send($address, 'messages.notifications.passkeyReset.subject', $template);
+		} catch (Throwable $e) {
+			Debugger::log($e, 'auth');
+		}
+	}
+
+
+	private function createTemplate(string $name): DefaultTemplate
+	{
+		$template = $this->templateFactory->createTemplate();
+		$template->setFile(__DIR__ . '/templates/' . $name . '.latte');
+		return $template;
+	}
+
+
+	private function send(string $address, string $subjectKey, DefaultTemplate $template): void
+	{
+		$mail = new Message();
+		$mail->setFrom($this->emailFrom)
+			->addTo($address)
+			->setSubject($this->translator->translate($subjectKey))
+			->setBody((string)$template)
+			->clearHeader('X-Mailer');
+		$this->mailer->send($mail);
+	}
+
+
+	private function logNoEmail(int $userId): void
+	{
+		Debugger::log("No email set for user {$userId}, skipping security notification", 'auth');
+	}
+
+}

--- a/app/src/User/Notifications/templates/passkeyAdded.latte
+++ b/app/src/User/Notifications/templates/passkeyAdded.latte
@@ -1,0 +1,13 @@
+{contentType text}
+{varType string $credentialName}
+{varType \DateTimeImmutable $when}
+{varType string|null $ipAddress}
+{varType string $reviewUrl}
+{_messages.notifications.passkeyAdded.intro}
+
+{_messages.notifications.field.name}: {$credentialName}
+{_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}
+{if $ipAddress !== null}{_messages.notifications.field.from}: {$ipAddress}{/if}
+
+{_messages.notifications.passkeyAdded.ifNotYou}
+{$reviewUrl}

--- a/app/src/User/Notifications/templates/passkeyReset.latte
+++ b/app/src/User/Notifications/templates/passkeyReset.latte
@@ -1,0 +1,16 @@
+{contentType text}
+{varType string $credentialName}
+{varType \DateTimeImmutable $when}
+{varType string|null $ipAddress}
+{varType string $reviewUrl}
+{varType bool $otherAccessRevoked}
+{_messages.notifications.passkeyReset.intro}
+
+{_messages.notifications.field.name}: {$credentialName}
+{_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}
+{if $ipAddress !== null}{_messages.notifications.field.from}: {$ipAddress}{/if}
+
+{if $otherAccessRevoked}{_messages.notifications.passkeyReset.otherAccessRevoked}{else}{_messages.notifications.passkeyReset.otherAccessRevokeFailed}{/if}
+
+{_messages.notifications.passkeyReset.ifNotYou}
+{$reviewUrl}

--- a/app/src/User/WebAuthn/Registration/PasskeyAdd.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyAdd.php
@@ -14,4 +14,13 @@ final readonly class PasskeyAdd extends PasskeyRegistration
 		return true;
 	}
 
+
+	#[Override]
+	public function register(string $credentialJson, string $name, string $token): PasskeyRegistrationResult
+	{
+		$result = parent::register($credentialJson, $name, $token);
+		$this->notifier->passkeyAdded($result->userId, $name);
+		return $result;
+	}
+
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationDisabledException;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationInvalidOrExpiredTokenException;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationUserMismatchException;
@@ -25,6 +26,7 @@ abstract readonly class PasskeyRegistration
 		private PasskeyRegistrationTokens $registrationTokens,
 		private WebAuthnAuthenticator $passkeyAuthenticator,
 		private User $user,
+		protected UserSecurityNotifier $notifier,
 	) {
 	}
 

--- a/app/src/User/WebAuthn/Registration/PasskeyReset.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyReset.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User\WebAuthn\Registration;
 
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyResetRevokeFailedException;
 use MichalSpacekCz\User\WebAuthn\WebAuthnAuthenticator;
 use Nette\Security\User;
@@ -15,9 +16,10 @@ final readonly class PasskeyReset extends PasskeyRegistration
 		PasskeyRegistrationTokens $registrationTokens,
 		WebAuthnAuthenticator $passkeyAuthenticator,
 		User $user,
+		UserSecurityNotifier $notifier,
 		private PasskeyResetRevoker $revoker,
 	) {
-		parent::__construct($registrationTokens, $passkeyAuthenticator, $user);
+		parent::__construct($registrationTokens, $passkeyAuthenticator, $user, $notifier);
 	}
 
 
@@ -39,10 +41,11 @@ final readonly class PasskeyReset extends PasskeyRegistration
 		$result = parent::register($credentialJson, $name, $token);
 		try {
 			$this->revoker->revoke($result->userId, $result->keepCredentialId);
-			return $result;
 		} catch (PasskeyResetRevokeFailedException $e) {
-			return $result->withRevokeFailure($e);
+			$result = $result->withRevokeFailure($e);
 		}
+		$this->notifier->passkeyReset($result->userId, $name, $result->revokeFailure === null);
+		return $result;
 	}
 
 }

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -413,6 +413,21 @@ account:
 		save: "Uložit e-mail"
 		saved: "E-mail uložen"
 		help: "Pro bezpečnostní upozornění k vašemu účtu"
+notifications:
+	field:
+		name: "Název passkey"
+		when: "Kdy"
+		from: "IP adresa"
+	passkeyAdded:
+		subject: "Do vašeho účtu byl přidán nový passkey"
+		intro: "Do vašeho účtu byl přidán nový passkey."
+		ifNotYou: "Pokud jste tento passkey nepřidávali vy, přihlaste se a odeberte ho:"
+	passkeyReset:
+		subject: "Vaše passkeys byly resetovány"
+		intro: "Do vašeho účtu byl pomocí obnovení účtu (resetu) zaregistrován nový passkey."
+		otherAccessRevoked: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení proběhlo úspěšně."
+		otherAccessRevokeFailed: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení se nepodařilo úplně dokončit, takže některé z nich mohou mít stále přístup k vašemu účtu."
+		ifNotYou: "Pokud jste o reset nežádali, váš účet může být kompromitován. Přihlaste se a zkontrolujte své passkeys:"
 reauth:
 	title: "Potvrďte, že jste to vy"
 	prompt: "Pro pokračování potvrďte svou identitu pomocí passkey"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -413,6 +413,21 @@ account:
 		save: "Save email"
 		saved: "Email saved"
 		help: "Used for security alerts about your account"
+notifications:
+	field:
+		name: "Passkey name"
+		when: "When"
+		from: "IP address"
+	passkeyAdded:
+		subject: "A new passkey was added to your account"
+		intro: "A new passkey was added to your account."
+		ifNotYou: "If you didn't add this passkey, sign in and remove it:"
+	passkeyReset:
+		subject: "Your passkeys were reset"
+		intro: "A new passkey was registered to your account using account recovery (reset)."
+		otherAccessRevoked: "Your other passkeys were removed and your active sessions signed out."
+		otherAccessRevokeFailed: "Your other passkeys couldn't all be removed or your active sessions signed out, so some may still have access to your account."
+		ifNotYou: "If you didn't request this, your account may be compromised. Sign in and review your passkeys:"
 reauth:
 	title: "Confirm it's you"
 	prompt: "Confirm it's you with your passkey to continue"

--- a/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
+++ b/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
@@ -14,6 +14,7 @@ use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\WebAuthn\PasskeyStorage;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationAttestationResponseValidatorException;
 use MichalSpacekCz\User\WebAuthn\Registration\PasskeyAdd;
@@ -55,6 +56,7 @@ final class PasskeyRegistrationFormFactoryTest extends TestCase
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
 		private readonly PasskeyStorage $passkeyStorage,
+		private readonly UserSecurityNotifier $notifier,
 	) {
 	}
 
@@ -138,14 +140,14 @@ final class PasskeyRegistrationFormFactoryTest extends TestCase
 	private function createPasskeyAdd(): PasskeyAdd
 	{
 		$addTokens = new PasskeyAddTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user);
+		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->notifier);
 	}
 
 
 	private function createPasskeyReset(): PasskeyReset
 	{
 		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, new PasskeyResetRevoker($this->passkeyStorage, []));
+		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, new PasskeyResetRevoker($this->passkeyStorage, []));
 	}
 
 

--- a/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
+++ b/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
@@ -1,0 +1,106 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\User\Notifications;
+
+use LogicException;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullMailer;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\UserAccounts;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class UserSecurityNotifierTest extends TestCase
+{
+
+	public function __construct(
+		private readonly UserSecurityNotifier $notifier,
+		private readonly Database $database,
+		private readonly NullMailer $mailer,
+		private readonly UserAccounts $userAccounts,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->mailer->reset();
+	}
+
+
+	public function testPasskeyAddedEmailsTheUser(): void
+	{
+		$this->seedEmail(42, 'owner@example.com');
+
+		$this->notifier->passkeyAdded(42, '42Password <3');
+
+		$mail = $this->mailer->getMail();
+		Assert::same(['owner@example.com' => null], $mail->getHeader('To'));
+		Assert::contains('42Password <3', $mail->getBody());
+		Assert::contains('https://admin.rizek.test/passkeys', $mail->getBody());
+	}
+
+
+	public function testPasskeyResetEmailsTheUserAndConfirmsOtherAccessWasRevoked(): void
+	{
+		$this->seedEmail(42, 'owner@example.com');
+
+		$this->notifier->passkeyReset(42, '42Password <3', true);
+
+		$mail = $this->mailer->getMail();
+		Assert::same(['owner@example.com' => null], $mail->getHeader('To'));
+		Assert::contains('42Password <3', $mail->getBody());
+		Assert::contains('messages.notifications.passkeyReset.otherAccessRevoked', $mail->getBody());
+	}
+
+
+	public function testPasskeyResetTellsTheUserWhenOtherAccessCouldNotBeRevoked(): void
+	{
+		$this->seedEmail(42, 'owner@example.com');
+
+		$this->notifier->passkeyReset(42, '42Password <3', false);
+
+		Assert::contains('messages.notifications.passkeyReset.otherAccessRevokeFailed', $this->mailer->getMail()->getBody());
+	}
+
+
+	public function testUserWithoutEmailIsSkipped(): void
+	{
+		$this->database->setFetchFieldDefaultResult(null);
+
+		$this->notifier->passkeyAdded(42, '42Password <3');
+
+		Assert::exception(fn() => $this->mailer->getMail(), LogicException::class); // nothing was sent
+	}
+
+
+	public function testRecipientLookupFailureIsSwallowed(): void
+	{
+		$this->database->setFetchFieldDefaultResult('not-a-valid-ciphertext'); // getEmail()'s decryption throws
+
+		$this->notifier->passkeyAdded(42, '42Password <3'); // best-effort: the failure must not propagate
+
+		Assert::exception(fn() => $this->mailer->getMail(), LogicException::class); // nothing was sent
+	}
+
+
+	private function seedEmail(int $userId, string $address): void
+	{
+		$this->userAccounts->setEmail($userId, $address);
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$stored = $params[0]['email'];
+		assert(is_string($stored));
+		$this->database->addFetchFieldResult($stored);
+	}
+
+}
+
+TestCaseRunner::run(UserSecurityNotifierTest::class);

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -6,10 +6,13 @@ namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
+use MichalSpacekCz\User\UserAccounts;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationInvalidOrExpiredTokenException;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationUserMismatchException;
 use Nette\Security\SimpleIdentity;
@@ -29,6 +32,9 @@ final class PasskeyAddTest extends TestCase
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
+		private readonly UserSecurityNotifier $notifier,
+		private readonly UserAccounts $userAccounts,
+		private readonly NullMailer $mailer,
 	) {
 	}
 
@@ -37,6 +43,7 @@ final class PasskeyAddTest extends TestCase
 	protected function tearDown(): void
 	{
 		$this->database->reset();
+		$this->mailer->reset();
 		$this->user->logout();
 	}
 
@@ -87,6 +94,28 @@ final class PasskeyAddTest extends TestCase
 	}
 
 
+	public function testRegisterNotifiesTheUserByEmail(): void
+	{
+		$userId = 1337;
+		$this->setUpToken(42, $userId, 'foo');
+		$this->seedEmail($userId, 'owner@example.com');
+
+		$this->createPasskeyAdd()->register('{"id":"test","type":"public-key"}', 'My Passkey', 'selector:secret');
+
+		Assert::same(['owner@example.com' => null], $this->mailer->getMail()->getHeader('To'));
+	}
+
+
+	private function seedEmail(int $userId, string $address): void
+	{
+		$this->userAccounts->setEmail($userId, $address);
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$stored = $params[0]['email'];
+		assert(is_string($stored));
+		$this->database->setFetchFieldDefaultResult($stored);
+	}
+
+
 	private function setUpToken(int $tokenId, int $userId, string $username): void
 	{
 		$this->database->setFetchDefaultResult([
@@ -101,7 +130,7 @@ final class PasskeyAddTest extends TestCase
 	private function createPasskeyAdd(): PasskeyAdd
 	{
 		$addTokens = new PasskeyAddTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user);
+		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->notifier);
 	}
 
 }

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
@@ -6,9 +6,12 @@ namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
+use MichalSpacekCz\User\UserAccounts;
 use MichalSpacekCz\User\WebAuthn\PasskeyStorage;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyResetRevokeFailedException;
 use Nette\Security\User;
@@ -28,6 +31,9 @@ final class PasskeyResetTest extends TestCase
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
 		private readonly PasskeyStorage $passkeyStorage,
+		private readonly UserSecurityNotifier $notifier,
+		private readonly UserAccounts $userAccounts,
+		private readonly NullMailer $mailer,
 	) {
 	}
 
@@ -36,6 +42,7 @@ final class PasskeyResetTest extends TestCase
 	protected function tearDown(): void
 	{
 		$this->database->reset();
+		$this->mailer->reset();
 		$this->user->logout();
 	}
 
@@ -79,6 +86,29 @@ final class PasskeyResetTest extends TestCase
 	}
 
 
+	public function testRegisterNotifiesTheUserByEmail(): void
+	{
+		$userId = 1337;
+		$this->setUpToken(42, $userId, 'foo');
+		$this->database->addFetchFieldResult(1); // the revoke's kept-credential check runs before the notify, so it consumes this first
+		$this->seedEmail($userId, 'owner@example.com'); // then the notify's getEmail() reads the queued ciphertext
+
+		$this->createPasskeyReset()->register('{"id":"test","type":"public-key"}', 'My Passkey', 'selector:secret');
+
+		Assert::same(['owner@example.com' => null], $this->mailer->getMail()->getHeader('To'));
+	}
+
+
+	private function seedEmail(int $userId, string $address): void
+	{
+		$this->userAccounts->setEmail($userId, $address);
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$stored = $params[0]['email'];
+		assert(is_string($stored));
+		$this->database->addFetchFieldResult($stored);
+	}
+
+
 	private function setUpToken(int $tokenId, int $userId, string $username): void
 	{
 		$this->database->setFetchDefaultResult([
@@ -94,7 +124,7 @@ final class PasskeyResetTest extends TestCase
 	{
 		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
 		$revoker = new PasskeyResetRevoker($this->passkeyStorage, []);
-		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $revoker);
+		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, $revoker);
 	}
 
 }


### PR DESCRIPTION
This closes the #731 notification: adding a passkey, or a reset that enrolls a new one and revokes the rest, is exactly the account-takeover step worth hearing about out of band, so the owner can react even when prevention failed. The alert goes to the per-user `users.email` added in #774.

`UserSecurityNotifier` sends it, best-effort: a delivery failure (or a user with no email) is logged to `auth` and never breaks the registration, since the passkey is already saved by then. `PasskeyAdd` and `PasskeyReset` call it after `parent::register()`, keeping the add/reset distinction as two messages. The body is translated rather than hardcoded Czech so the notifier is ready for the public app that will reuse it, and it tells the recipient what to do, with a link to the passkeys page, because a link-free "reply to us" is no remediation at all.