### PR TITLE
Notify the user out of band when their account email changes

### DIFF
--- a/app/src/Form/User/AccountEmailFormFactory.php
+++ b/app/src/Form/User/AccountEmailFormFactory.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Form\User;
 use Contributte\Translation\Translator;
 use MichalSpacekCz\Form\Controls\PasskeyAuthenticationControls;
 use MichalSpacekCz\Form\FormFactory;
+use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\UserAccounts;
 use Nette\Application\UI\Form;
 use Nette\Security\User;
@@ -19,6 +20,7 @@ final readonly class AccountEmailFormFactory
 		private User $user,
 		private Translator $translator,
 		private PasskeyAuthenticationControls $passkeyAuthenticationControls,
+		private UserSecurityNotifier $notifier,
 	) {
 	}
 
@@ -31,17 +33,19 @@ final readonly class AccountEmailFormFactory
 		$form = $this->factory->create();
 		$email = $form->addEmail('email', $this->translator->translate('messages.account.email.label'))
 			->setRequired($this->translator->translate('messages.account.email.required'));
-		$currentEmail = $this->userAccounts->getEmail((int)$this->user->getId());
+		$userId = (int)$this->user->getId();
+		$currentEmail = $this->userAccounts->getEmail($userId);
 		if ($currentEmail !== null) {
 			$email->setDefaultValue($currentEmail);
 		}
 		$form->addSubmit('save', $this->translator->translate('messages.account.email.save'));
 		$form->setHtmlAttribute('data-error-element', 'passkeyReauthError');
 		$this->passkeyAuthenticationControls->addReauthTo($form);
-		$form->onSuccess[] = function (Form $form) use ($onSuccess): void {
+		$form->onSuccess[] = function (Form $form) use ($onSuccess, $userId, $currentEmail): void {
 			$values = $form->getValues();
 			assert(is_string($values->email));
-			$this->userAccounts->setEmail((int)$this->user->getId(), $values->email);
+			$this->userAccounts->setEmail($userId, $values->email);
+			$this->notifier->emailChanged($currentEmail, $values->email);
 			$onSuccess();
 		};
 		return $form;

--- a/app/src/Test/NullMailer.php
+++ b/app/src/Test/NullMailer.php
@@ -11,31 +11,43 @@ use Override;
 final class NullMailer implements Mailer
 {
 
-	private ?Message $mail = null;
+	use WillThrow;
 
 
-	/**
-	 * @throws void
-	 */
+	/** @var list<Message> */
+	private array $allMails = [];
+
+
 	#[Override]
 	public function send(Message $mail): void
 	{
-		$this->mail = $mail;
+		$this->maybeThrow();
+		$this->allMails[] = $mail;
 	}
 
 
 	public function getMail(): Message
 	{
-		if ($this->mail === null) {
+		if ($this->allMails === []) {
 			throw new LogicException('Send mail first with send()');
 		}
-		return $this->mail;
+		return $this->allMails[array_key_last($this->allMails)];
+	}
+
+
+	/**
+	 * @return list<Message>
+	 */
+	public function getAllMails(): array
+	{
+		return $this->allMails;
 	}
 
 
 	public function reset(): void
 	{
-		$this->mail = null;
+		$this->allMails = [];
+		$this->wontThrow();
 	}
 
 }

--- a/app/src/Test/WillThrow.php
+++ b/app/src/Test/WillThrow.php
@@ -12,6 +12,8 @@ trait WillThrow
 	/** @var Exception|(Closure(): Exception)|null */
 	private Exception|Closure|null $willThrow = null;
 
+	private ?Exception $willThrowOnce = null;
+
 
 	/**
 	 * @param Exception|Closure(): Exception $e
@@ -22,17 +24,32 @@ trait WillThrow
 	}
 
 
+	/**
+	 * Throws on the next maybeThrow() only, then is consumed. Can be combined with willThrow() to
+	 * throw this on the first call and then keep throwing that.
+	 */
+	public function willThrowOnce(Exception $e): void
+	{
+		$this->willThrowOnce = $e;
+	}
+
+
 	public function wontThrow(): void
 	{
 		$this->willThrow = null;
+		$this->willThrowOnce = null;
 	}
 
 
 	private function maybeThrow(): void
 	{
-		if ($this->willThrow !== null) {
-			$e = $this->willThrow instanceof Closure ? ($this->willThrow)() : $this->willThrow;
+		if ($this->willThrowOnce !== null) {
+			$e = $this->willThrowOnce;
+			$this->willThrowOnce = null;
 			throw $e;
+		}
+		if ($this->willThrow !== null) {
+			throw $this->willThrow instanceof Closure ? ($this->willThrow)() : $this->willThrow;
 		}
 	}
 

--- a/app/src/User/Notifications/UserSecurityNotifier.php
+++ b/app/src/User/Notifications/UserSecurityNotifier.php
@@ -16,9 +16,9 @@ use Throwable;
 use Tracy\Debugger;
 
 /**
- * Tells a user out of band when something security-sensitive happens to their account (a passkey is
- * added or reset). Best-effort: a delivery failure is logged but never propagated, so it can't break
- * the action that triggered it. A user with no email set is logged and skipped.
+ * Tells a user out of band when something security-sensitive happens to their account: a passkey is
+ * added or reset, or the account email is changed. Best-effort: a delivery failure is logged but never
+ * propagated, so it can't break the action that triggered it. A user with no email set is logged and skipped.
  */
 final readonly class UserSecurityNotifier
 {
@@ -71,6 +71,49 @@ final readonly class UserSecurityNotifier
 			$template->reviewUrl = $this->linkGenerator->link('//:Admin:Passkeys:default');
 			$template->otherAccessRevoked = $otherAccessRevoked;
 			$this->send($address, 'messages.notifications.passkeyReset.subject', $template);
+		} catch (Throwable $e) {
+			Debugger::log($e, 'auth');
+		}
+	}
+
+
+	/**
+	 * Alerts the old address (so a hostile change is loud to whoever is losing access) and confirms
+	 * to the new one.
+	 */
+	public function emailChanged(?string $oldAddress, string $newAddress): void
+	{
+		if ($oldAddress === $newAddress) {
+			return;
+		}
+		if ($oldAddress !== null) {
+			$this->sendEmailChangedAlert($oldAddress, $newAddress);
+		}
+		$this->sendEmailChangedConfirmation($newAddress);
+	}
+
+
+	private function sendEmailChangedAlert(string $oldAddress, string $newAddress): void
+	{
+		try {
+			$template = $this->createTemplate('emailChanged');
+			$template->newAddress = $newAddress;
+			$template->when = $this->dateTimeFactory->create();
+			$template->ipAddress = $this->httpRequest->getRemoteAddress();
+			$template->reviewUrl = $this->linkGenerator->link('//:Admin:Account:default');
+			$this->send($oldAddress, 'messages.notifications.emailChanged.subject', $template);
+		} catch (Throwable $e) {
+			Debugger::log($e, 'auth');
+		}
+	}
+
+
+	private function sendEmailChangedConfirmation(string $newAddress): void
+	{
+		try {
+			$template = $this->createTemplate('emailChangedConfirmation');
+			$template->when = $this->dateTimeFactory->create();
+			$this->send($newAddress, 'messages.notifications.emailChangedConfirmation.subject', $template);
 		} catch (Throwable $e) {
 			Debugger::log($e, 'auth');
 		}

--- a/app/src/User/Notifications/templates/emailChanged.latte
+++ b/app/src/User/Notifications/templates/emailChanged.latte
@@ -1,0 +1,13 @@
+{contentType text}
+{varType string $newAddress}
+{varType \DateTimeImmutable $when}
+{varType string|null $ipAddress}
+{varType string $reviewUrl}
+{_messages.notifications.emailChanged.intro}
+
+{_messages.notifications.field.newAddress}: {$newAddress}
+{_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}
+{if $ipAddress !== null}{_messages.notifications.field.from}: {$ipAddress}{/if}
+
+{_messages.notifications.emailChanged.ifNotYou}
+{$reviewUrl}

--- a/app/src/User/Notifications/templates/emailChangedConfirmation.latte
+++ b/app/src/User/Notifications/templates/emailChangedConfirmation.latte
@@ -1,0 +1,5 @@
+{contentType text}
+{varType \DateTimeImmutable $when}
+{_messages.notifications.emailChangedConfirmation.intro}
+
+{_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -416,6 +416,7 @@ account:
 notifications:
 	field:
 		name: "Název passkey"
+		newAddress: "Nová adresa"
 		when: "Kdy"
 		from: "IP adresa"
 	passkeyAdded:
@@ -428,6 +429,13 @@ notifications:
 		otherAccessRevoked: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení proběhlo úspěšně."
 		otherAccessRevokeFailed: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení se nepodařilo úplně dokončit, takže některé z nich mohou mít stále přístup k vašemu účtu."
 		ifNotYou: "Pokud jste o reset nežádali, váš účet může být kompromitován. Přihlaste se a zkontrolujte své passkeys:"
+	emailChanged:
+		subject: "E-mailová adresa vašeho účtu byla změněna"
+		intro: "E-mailová adresa vašeho účtu byla změněna."
+		ifNotYou: "Pokud jste ji neměnili vy, váš účet může být kompromitován. Přihlaste se a zkontrolujte svůj účet:"
+	emailChangedConfirmation:
+		subject: "Toto je nyní e-mailová adresa vašeho účtu"
+		intro: "Tato adresa je nyní e-mailovou adresou vašeho účtu."
 reauth:
 	title: "Potvrďte, že jste to vy"
 	prompt: "Pro pokračování potvrďte svou identitu pomocí passkey"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -416,6 +416,7 @@ account:
 notifications:
 	field:
 		name: "Passkey name"
+		newAddress: "New address"
 		when: "When"
 		from: "IP address"
 	passkeyAdded:
@@ -428,6 +429,13 @@ notifications:
 		otherAccessRevoked: "Your other passkeys were removed and your active sessions signed out."
 		otherAccessRevokeFailed: "Your other passkeys couldn't all be removed or your active sessions signed out, so some may still have access to your account."
 		ifNotYou: "If you didn't request this, your account may be compromised. Sign in and review your passkeys:"
+	emailChanged:
+		subject: "Your account email was changed"
+		intro: "Your account email was changed."
+		ifNotYou: "If you didn't change it, your account may be compromised. Sign in and review your account:"
+	emailChangedConfirmation:
+		subject: "This is now your account email"
+		intro: "This address is now the email for your account."
 reauth:
 	title: "Confirm it's you"
 	prompt: "Confirm it's you with your passkey to continue"

--- a/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
@@ -6,8 +6,10 @@ namespace MichalSpacekCz\Form\User;
 
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
+use MichalSpacekCz\User\UserAccounts;
 use MichalSpacekCz\User\WebAuthn\Authentication\PasskeyAuthenticationResult;
 use MichalSpacekCz\User\WebAuthn\Session\PasskeySessionSection;
 use Nette\Application\UI\Form;
@@ -42,6 +44,8 @@ final class AccountEmailFormFactoryTest extends TestCase
 		private readonly PasskeySessionSection $session,
 		private readonly User $user,
 		private readonly Database $database,
+		private readonly NullMailer $mailer,
+		private readonly UserAccounts $userAccounts,
 	) {
 	}
 
@@ -52,6 +56,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 		$this->session->removeAll();
 		$this->user->logout();
 		$this->database->reset();
+		$this->mailer->reset();
 		$this->onSuccessCalled = false;
 	}
 
@@ -72,6 +77,25 @@ final class AccountEmailFormFactoryTest extends TestCase
 		$stored = $params[0]['email'];
 		assert(is_string($stored));
 		Assert::notSame('me@example.com', $stored); // stored encrypted, never plaintext
+		Assert::same(['me@example.com' => null], $this->mailer->getMail()->getHeader('To')); // first-set confirms the new address
+	}
+
+
+	public function testCapturesTheOldEmailBeforeOverwriting(): void
+	{
+		$this->user->login(new SimpleIdentity(42));
+		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id'));
+		$this->seedCurrentEmail('old@example.com');
+		$form = $this->createForm('new@example.com', '{"id":"test","type":"public-key"}');
+
+		Arrays::invoke($form->onValidate, $form);
+		Arrays::invoke($form->onSuccess, $form);
+
+		// an alert to the OLD address only happens if onSuccess read the old email before setEmail overwrote it
+		$mails = $this->mailer->getAllMails();
+		Assert::count(2, $mails);
+		Assert::same(['old@example.com' => null], $mails[0]->getHeader('To'));
+		Assert::same(['new@example.com' => null], $mails[1]->getHeader('To'));
 	}
 
 
@@ -87,6 +111,16 @@ final class AccountEmailFormFactoryTest extends TestCase
 		Assert::true($form->hasErrors());
 		Assert::false($this->onSuccessCalled);
 		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')); // not saved
+	}
+
+
+	private function seedCurrentEmail(string $address): void
+	{
+		$this->userAccounts->setEmail(42, $address);
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$stored = $params[0]['email'];
+		assert(is_string($stored));
+		$this->database->setFetchFieldDefaultResult($stored); // every getEmail() returns the seeded address until overwritten
 	}
 
 

--- a/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
+++ b/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
@@ -9,6 +9,7 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\User\UserAccounts;
+use Nette\Mail\SendException;
 use Override;
 use Tester\Assert;
 use Tester\TestCase;
@@ -89,6 +90,49 @@ final class UserSecurityNotifierTest extends TestCase
 		$this->notifier->passkeyAdded(42, '42Password <3'); // best-effort: the failure must not propagate
 
 		Assert::exception(fn() => $this->mailer->getMail(), LogicException::class); // nothing was sent
+	}
+
+
+	public function testEmailChangeAlertsTheOldAddressAndConfirmsTheNew(): void
+	{
+		$this->notifier->emailChanged('old@example.com', 'new@example.com');
+
+		$mails = $this->mailer->getAllMails();
+		Assert::count(2, $mails);
+		Assert::same(['old@example.com' => null], $mails[0]->getHeader('To'));
+		Assert::contains('new@example.com', $mails[0]->getBody()); // the old address learns where the email went
+		Assert::same(['new@example.com' => null], $mails[1]->getHeader('To'));
+		Assert::notContains('old@example.com', $mails[1]->getBody()); // the new address must not learn the old one
+	}
+
+
+	public function testFirstEmailSetOnlyConfirmsTheNewAddress(): void
+	{
+		$this->notifier->emailChanged(null, 'new@example.com');
+
+		$mails = $this->mailer->getAllMails();
+		Assert::count(1, $mails);
+		Assert::same(['new@example.com' => null], $mails[0]->getHeader('To'));
+	}
+
+
+	public function testUnchangedEmailNotifiesNothing(): void
+	{
+		$this->notifier->emailChanged('same@example.com', 'same@example.com');
+
+		Assert::count(0, $this->mailer->getAllMails());
+	}
+
+
+	public function testEmailChangeStillConfirmsTheNewAddressWhenAlertingTheOldFails(): void
+	{
+		$this->mailer->willThrowOnce(new SendException('alert delivery failed')); // only the first send, the alert
+
+		$this->notifier->emailChanged('old@example.com', 'new@example.com'); // best-effort: must not propagate
+
+		$mails = $this->mailer->getAllMails();
+		Assert::count(1, $mails); // the failed alert is swallowed and doesn't suppress the confirmation
+		Assert::same(['new@example.com' => null], $mails[0]->getHeader('To'));
 	}
 
 


### PR DESCRIPTION
If the account email changes, the old address has to hear about it: whoever is losing control of the account still holds that mailbox, so an alert there makes a hostile change loud even when prevention was bypassed. On a change we alert the old address (showing where the email went, with a link to review the account) and confirm to the new one, both reusing the `UserSecurityNotifier` from the passkey tripwire. The new-address confirmation deliberately omits the old address so a change to an attacker's address can't leak the victim's previous one.

In the admin this is notification-only, since the email isn't load-bearing yet. The public app will instead have to require confirming the new address before it takes effect, because there the email drives passkey resets and magic-link login.

Follow-ups:
- #779