### PR TITLE
Drop a redundant comment from the account-email notify test

### DIFF
--- a/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
@@ -91,7 +91,6 @@ final class AccountEmailFormFactoryTest extends TestCase
 		Arrays::invoke($form->onValidate, $form);
 		Arrays::invoke($form->onSuccess, $form);
 
-		// an alert to the OLD address only happens if onSuccess read the old email before setEmail overwrote it
 		$mails = $this->mailer->getAllMails();
 		Assert::count(2, $mails);
 		Assert::same(['old@example.com' => null], $mails[0]->getHeader('To'));


### PR DESCRIPTION
The method name and the seed-old / submit-new / assert-alert-to-old body already say what the test checks, and the "read the old email before the write" rationale stopped applying once the form captures the prefill at build and reuses it, so the line only restated the test.

Follow-up to #778