### PR TITLE
Move the training-mail _From_ address into config

### DIFF
--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -54,6 +54,7 @@ parameters:
 
 	mail:
 		securityNotificationsFrom: "Fred <fred@waldo.example>"
+		trainingFrom: "Barney <barney@plugh.example>"
 
 	encryption:
 		keys:

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -70,6 +70,7 @@ parameters:
 		phoneNumber: "123456789"
 	mail:
 		securityNotificationsFrom: "Foo <foo@bar.example>"
+		trainingFrom: "Bar <bar@qux.example>"
 	encryption:
 		keys:
 			password: []

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -186,7 +186,7 @@ services:
 	trainingFilesStorage: MichalSpacekCz\Training\Files\TrainingFilesStorage
 	- MichalSpacekCz\Training\FreeSeats
 	- MichalSpacekCz\Training\Mails\TrainingMailMessageFactory
-	- MichalSpacekCz\Training\Mails\TrainingMails(emailFrom: 'Michal Špaček <mail@michalspacek.cz>', phoneNumber: %contact.phoneNumber%)
+	- MichalSpacekCz\Training\Mails\TrainingMails(emailFrom: %mail.trainingFrom%, phoneNumber: %contact.phoneNumber%)
 	- MichalSpacekCz\Training\Preliminary\PreliminaryTrainings
 	- MichalSpacekCz\Training\Prices(vatRate: %vatRate%)
 	- MichalSpacekCz\Training\Resolver\Vrana

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -25,6 +25,7 @@ parameters:
 			session: mssetest
 	mail:
 		securityNotificationsFrom: "Tests <foo@tests.example>"
+		trainingFrom: "Tests <bar@tests.example>"
 	awsLambda:
 		upcKeys:
 			url: "https://was.example/%s/%s"


### PR DESCRIPTION
`services.neon` hardcoded it while the security-notification sender already lives in a `mail.*` parameter set per environment. Give the training mails the same treatment via a `mail.trainingFrom` parameter (real value in local.neon), so both sender addresses are configured the same way and can differ between dev and prod instead of one being baked into the committed config.