### PR TITLE
Name the sending site in the security notification emails

### DIFF
--- a/app/src/User/Notifications/UserSecurityNotifier.php
+++ b/app/src/User/Notifications/UserSecurityNotifier.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\User\Notifications;
 
 use Contributte\Translation\Translator;
 use MichalSpacekCz\Application\LinkGenerator;
+use MichalSpacekCz\Application\WebApplication;
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Templating\DefaultTemplate;
 use MichalSpacekCz\Templating\TemplateFactory;
@@ -31,6 +32,7 @@ final readonly class UserSecurityNotifier
 		private IRequest $httpRequest,
 		private LinkGenerator $linkGenerator,
 		private UserAccounts $userAccounts,
+		private WebApplication $application,
 		private string $emailFrom,
 	) {
 	}
@@ -133,7 +135,7 @@ final readonly class UserSecurityNotifier
 		$mail = new Message();
 		$mail->setFrom($this->emailFrom)
 			->addTo($address)
-			->setSubject($this->translator->translate($subjectKey))
+			->setSubject($this->application->getFqdn() . ': ' . $this->translator->translate($subjectKey))
 			->setBody((string)$template)
 			->clearHeader('X-Mailer');
 		$this->mailer->send($mail);

--- a/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
+++ b/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
@@ -101,6 +101,9 @@ final class UserSecurityNotifierTest extends TestCase
 		Assert::count(2, $mails);
 		Assert::same(['old@example.com' => null], $mails[0]->getHeader('To'));
 		Assert::contains('new@example.com', $mails[0]->getBody()); // the old address learns where the email went
+		$subject = $mails[0]->getSubject();
+		assert(is_string($subject));
+		Assert::contains('www.domain.example', $subject);
 		Assert::same(['new@example.com' => null], $mails[1]->getHeader('To'));
 		Assert::notContains('old@example.com', $mails[1]->getBody()); // the new address must not learn the old one
 	}


### PR DESCRIPTION
A recipient couldn't tell which site an alert came from or which account it was about: only the `From` header and, on some, a review link hinted at it. Now every passkey/email-change notification names the site in its subject, taken from the current domain's FQDN (`WebApplication::getFqdn()`, e.g. `admin.michalspacek.cz`), so it's visible right in the inbox. The email-change confirmation, which previously had neither a link nor a name, is identifiable too.