### PR TITLE
Narrow the security log table by folding the IP into the Event column

### DIFF
--- a/app/public/www.michalspacek.cz/i/css/screen.css
+++ b/app/public/www.michalspacek.cz/i/css/screen.css
@@ -308,7 +308,7 @@ td.dateCell { width: 80px; }
 td.nameCell { width: 200px; }
 .truncateMiddle {
 	display: inline-flex;
-	max-width: 32em;
+	max-width: 26em;
 }
 .truncateMiddle > span:first-child {
 	overflow: hidden;

--- a/app/src/Presentation/Admin/Account/securityLog.latte
+++ b/app/src/Presentation/Admin/Account/securityLog.latte
@@ -11,7 +11,6 @@
 		<tr>
 			<th>{_messages.account.securityLog.column.when}</th>
 			<th>{_messages.account.securityLog.column.event}</th>
-			<th>{_messages.account.securityLog.column.ip}</th>
 			<th>{_messages.account.securityLog.column.userAgent}</th>
 			<th>{_messages.account.securityLog.column.details}</th>
 		</tr>
@@ -19,9 +18,8 @@
 	<tbody>
 		{foreach $events as $event}
 		<tr>
-			<td>{$event->created|localeDay} <small>{$event->created|date:'H:i'}</small></td>
-			<td><strong>{$event->labelKey()|translate}</strong></td>
-			<td><small>{$event->ip ?? '?'}</small></td>
+			<td>{$event->created|localeDay}<br><small>{$event->created|date:'H:i:s'}</small></td>
+			<td><strong>{$event->labelKey()|translate}</strong><br><small>{$event->ip ?? '?'}</small></td>
 			<td>{if $event->userAgent !== null}{$event->userAgent|replace: 'Mozilla/5.0 (', ''|truncateMiddle: 30, $event->userAgent}{else}?{/if}</td>
 			<td><small>{foreach $event->details as $key => $value}{$key}: {$value ?? ''}{sep}<br>{/sep}{/foreach}</small></td>
 		</tr>

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -418,8 +418,7 @@ account:
 		empty: "Zatím žádné události"
 		column:
 			when: "Kdy"
-			event: "Událost"
-			ip: "IP adresa"
+			event: "Událost (IP adresa)"
 			userAgent: "User agent"
 			details: "Detaily"
 		event:

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -418,8 +418,7 @@ account:
 		empty: "No events yet"
 		column:
 			when: "When"
-			event: "Event"
-			ip: "IP address"
+			event: "Event (IP address)"
 			userAgent: "User agent"
 			details: "Details"
 		event:


### PR DESCRIPTION
The five-column table was too wide, and an IPv6 address forced its own column as wide as the whole address (and an address has no spaces, so it cannot wrap to fit). Dropping the dedicated IP column and showing the address on a second line under the event label keeps the IP visible while removing a whole column from the width, and lets the IPv6 lean on the event column's existing width instead of adding to it; the header becomes "Event (IP address)". The "When" column likewise puts the time on its own line, now with seconds since there is room, the user agent stays middle-truncated a touch narrower, and details stay one per line.

Follow-up to #782