### PR TITLE
Show what a reauth confirmed and log every sensitive-page view in the security log

### DIFF
--- a/app/src/Form/Controls/PasskeyAuthenticationControls.php
+++ b/app/src/Form/Controls/PasskeyAuthenticationControls.php
@@ -65,10 +65,10 @@ final readonly class PasskeyAuthenticationControls
 	 * email). To confirm before merely *viewing* a sensitive page, gate the action with
 	 * Admin\BasePresenter::requireReauthentication() instead.
 	 */
-	public function addReauthTo(Form $form, ReauthKind $kind): void
+	public function addReauthTo(Form $form, ReauthKind $kind, ?SecurityEventType $operation = null): void
 	{
 		$this->addOptionsTo($form);
-		$form->onValidate[] = function (Form $form) use ($kind): void {
+		$form->onValidate[] = function (Form $form) use ($kind, $operation): void {
 			$values = $form->getUntrustedValues();
 			assert(is_string($values->credential));
 			$userId = (int)$this->user->getId();
@@ -76,26 +76,33 @@ final readonly class PasskeyAuthenticationControls
 				$passkeyName = $this->reauthentication->verify($values->credential);
 				// don't record a confirmation for a submit that another control already failed (the gated action won't run)
 				if (!$form->hasErrors()) {
-					$this->recordReauth($userId, $kind, true, $passkeyName);
+					$this->recordReauth($userId, $kind, true, $passkeyName, $operation);
 				}
 			} catch (PasskeyException $e) {
 				if ($e instanceof PasskeyServerException) {
 					Debugger::log($e, 'auth');
 				}
-				$this->recordReauth($userId, $kind, false, null);
+				$this->recordReauth($userId, $kind, false, null, $operation);
 				$form->addError($this->translator->translate('messages.reauth.failed'));
 			}
 		};
 	}
 
 
-	private function recordReauth(int $userId, ReauthKind $kind, bool $success, ?string $passkeyName): void
+	private function recordReauth(int $userId, ReauthKind $kind, bool $success, ?string $passkeyName, ?SecurityEventType $operation): void
 	{
 		$type = match ($kind) {
 			ReauthKind::Interval => $success ? SecurityEventType::ReauthIntervalSuccess : SecurityEventType::ReauthIntervalFailure,
 			ReauthKind::Inline => $success ? SecurityEventType::ReauthInlineSuccess : SecurityEventType::ReauthInlineFailure,
 		};
-		$details = $success ? ['passkey' => $passkeyName, 'interval' => $this->reauthentication->getTtl()] : [];
+		$details = [];
+		if ($operation !== null) {
+			$details['operation'] = $operation->value;
+		}
+		if ($success) {
+			$details['passkey'] = $passkeyName;
+			$details['interval'] = $this->reauthentication->getTtl();
+		}
 		$this->securityEventLogger->record($userId, $type, $details);
 	}
 

--- a/app/src/Form/User/AccountEmailFormFactory.php
+++ b/app/src/Form/User/AccountEmailFormFactory.php
@@ -44,7 +44,7 @@ final readonly class AccountEmailFormFactory
 		}
 		$form->addSubmit('save', $this->translator->translate('messages.account.email.save'));
 		$form->setHtmlAttribute('data-error-element', 'passkeyReauthError');
-		$this->passkeyAuthenticationControls->addReauthTo($form, ReauthKind::Inline);
+		$this->passkeyAuthenticationControls->addReauthTo($form, ReauthKind::Inline, SecurityEventType::EmailChanged);
 		$form->onSuccess[] = function (Form $form) use ($onSuccess, $userId): void {
 			$values = $form->getValues();
 			assert(is_string($values->email));

--- a/app/src/Presentation/Admin/Account/securityLog.latte
+++ b/app/src/Presentation/Admin/Account/securityLog.latte
@@ -19,8 +19,8 @@
 		{foreach $events as $event}
 		<tr>
 			<td>{$event->created|localeDay}<br><small>{$event->created|date:'H:i:s'}</small></td>
-			<td><strong>{$event->labelKey()|translate}</strong><br><small>{$event->ip ?? '?'}</small></td>
-			<td>{if $event->userAgent !== null}{$event->userAgent|replace: 'Mozilla/5.0 (', ''|truncateMiddle: 30, $event->userAgent}{else}?{/if}</td>
+			<td><strong>{$event->labelKey()|translate}</strong><br><small>{$event->action}</small></td>
+			<td>{if $event->userAgent !== null}{$event->userAgent|replace: 'Mozilla/5.0 (', ''|truncateMiddle: 30, $event->userAgent}{else}?{/if}<br><small>{$event->ip ?? '?'}</small></td>
 			<td><small>{foreach $event->details as $key => $value}{$key}: {$value ?? ''}{sep}<br>{/sep}{/foreach}</small></td>
 		</tr>
 		{/foreach}

--- a/app/src/Presentation/Admin/Info/InfoPresenter.php
+++ b/app/src/Presentation/Admin/Info/InfoPresenter.php
@@ -5,6 +5,8 @@ namespace MichalSpacekCz\Presentation\Admin\Info;
 
 use MichalSpacekCz\Application\SanitizedPhpInfo;
 use MichalSpacekCz\Presentation\Admin\BasePresenter;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use Nette\Utils\Html;
 
 final class InfoPresenter extends BasePresenter
@@ -12,6 +14,7 @@ final class InfoPresenter extends BasePresenter
 
 	public function __construct(
 		private readonly SanitizedPhpInfo $phpInfo,
+		private readonly SecurityEventLogger $securityEventLogger,
 	) {
 		parent::__construct();
 	}
@@ -20,6 +23,7 @@ final class InfoPresenter extends BasePresenter
 	public function actionPhp(): void
 	{
 		$this->requireReauthentication();
+		$this->securityEventLogger->record((int)$this->getUser()->getId(), SecurityEventType::PageViewed, ['page' => $this->link('this')]);
 		$this->template->pageTitle = 'phpinfo()';
 		$this->template->phpinfo = Html::el()->setHtml($this->phpInfo->getHtml());
 	}

--- a/app/src/User/SecurityActivity/SecurityEvent.php
+++ b/app/src/User/SecurityActivity/SecurityEvent.php
@@ -26,12 +26,9 @@ final readonly class SecurityEvent
 	}
 
 
-	/**
-	 * @return string Translation key for the label, or the raw action when the type is no longer known
-	 */
 	public function labelKey(): string
 	{
-		return $this->type?->labelKey() ?? $this->action;
+		return $this->type?->labelKey() ?? 'messages.account.securityLog.event.unknown';
 	}
 
 }

--- a/app/src/User/SecurityActivity/SecurityEventType.php
+++ b/app/src/User/SecurityActivity/SecurityEventType.php
@@ -27,6 +27,7 @@ enum SecurityEventType: string
 	case ReauthInlineFailure = 'reauth.inline.failure';
 	case ResetRevokeFailed = 'reset.revoke.failed';
 	case EmailChanged = 'email.changed';
+	case PageViewed = 'page.viewed';
 
 
 	/**

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -418,8 +418,8 @@ account:
 		empty: "Zatím žádné události"
 		column:
 			when: "Kdy"
-			event: "Událost (IP adresa)"
-			userAgent: "User agent"
+			event: "Událost a typ"
+			userAgent: "User agent a IP adresa"
 			details: "Detaily"
 		event:
 			passkeyAddInitiated: "Zahájeno přidání passkey"
@@ -431,10 +431,12 @@ account:
 			signInSuccess: "Přihlášení"
 			reauthIntervalSuccess: "Potvrzení identity pro zobrazení"
 			reauthIntervalFailure: "Neúspěšné potvrzení identity pro zobrazení"
-			reauthInlineSuccess: "Potvrzení identity pro změnu"
-			reauthInlineFailure: "Neúspěšné potvrzení identity pro změnu"
+			reauthInlineSuccess: "Potvrzení identity"
+			reauthInlineFailure: "Neúspěšné potvrzení identity"
 			resetRevokeFailed: "Odebrání ostatního přístupu po resetu selhalo"
 			emailChanged: "Změna e-mailu účtu"
+			pageViewed: "Zobrazení citlivé stránky"
+			unknown: "Neznámý typ"
 notifications:
 	field:
 		name: "Název passkey"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -418,8 +418,8 @@ account:
 		empty: "No events yet"
 		column:
 			when: "When"
-			event: "Event (IP address)"
-			userAgent: "User agent"
+			event: "Event and type"
+			userAgent: "User agent and IP address"
 			details: "Details"
 		event:
 			passkeyAddInitiated: "Passkey add initiated"
@@ -431,10 +431,12 @@ account:
 			signInSuccess: "Signed in"
 			reauthIntervalSuccess: "Identity confirmed for viewing"
 			reauthIntervalFailure: "Failed identity confirmation for viewing"
-			reauthInlineSuccess: "Identity confirmed for a change"
-			reauthInlineFailure: "Failed identity confirmation for a change"
+			reauthInlineSuccess: "Identity confirmed"
+			reauthInlineFailure: "Failed identity confirmation"
 			resetRevokeFailed: "Revoking other access after reset failed"
 			emailChanged: "Account email changed"
+			pageViewed: "Sensitive page viewed"
+			unknown: "Unknown type"
 notifications:
 	field:
 		name: "Passkey name"

--- a/app/tests/Form/Controls/PasskeyAuthenticationControlsTest.phpt
+++ b/app/tests/Form/Controls/PasskeyAuthenticationControlsTest.phpt
@@ -11,6 +11,7 @@ use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\SecurityActivity\SecurityActivity;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use MichalSpacekCz\User\WebAuthn\Authentication\Exceptions\PasskeyAuthenticationUnknownCredentialException;
 use MichalSpacekCz\User\WebAuthn\Authentication\PasskeyAuthenticationResult;
 use MichalSpacekCz\User\WebAuthn\Authentication\ReauthKind;
@@ -120,6 +121,34 @@ final class PasskeyAuthenticationControlsTest extends TestCase
 	}
 
 
+	public function testInlineRecordsTheGuardedOperation(): void
+	{
+		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
+		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::EmailChanged);
+
+		Arrays::invoke($form->onValidate, $form);
+
+		$encrypted = $this->database->getParamsArrayForQuery(self::INSERT)[0]['details'];
+		assert(is_string($encrypted));
+		Assert::same(['operation' => 'email.changed', 'passkey' => 'My Passkey', 'interval' => '5 minutes'], $this->decodeDetails($encrypted));
+	}
+
+
+	public function testFailedReauthStillNamesTheGuardedOperation(): void
+	{
+		$this->passkeyAuthenticator->willThrow(new PasskeyAuthenticationUnknownCredentialException('foo'));
+		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::EmailChanged);
+
+		Arrays::invoke($form->onValidate, $form);
+
+		$params = $this->database->getParamsArrayForQuery(self::INSERT);
+		Assert::same('reauth.inline.failure', $params[0]['action']);
+		$encrypted = $params[0]['details'];
+		assert(is_string($encrypted));
+		Assert::same(['operation' => 'email.changed'], $this->decodeDetails($encrypted));
+	}
+
+
 	public function testUserMismatchRecordsFailureAndIsLoggedForTheOperator(): void
 	{
 		// a valid assertion, but it resolves to a different account than the signed-in one (42)
@@ -133,10 +162,10 @@ final class PasskeyAuthenticationControlsTest extends TestCase
 	}
 
 
-	private function createForm(ReauthKind $kind): Form
+	private function createForm(ReauthKind $kind, ?SecurityEventType $operation = null): Form
 	{
 		$form = $this->formFactory->create();
-		$this->controls->addReauthTo($form, $kind);
+		$this->controls->addReauthTo($form, $kind, $operation);
 		$this->applicationPresenter->anchorForm($form);
 		$field = $form->getComponent('credential');
 		assert($field instanceof HiddenField);

--- a/app/tests/Presentation/Admin/Info/InfoPresenterTest.phpt
+++ b/app/tests/Presentation/Admin/Info/InfoPresenterTest.phpt
@@ -4,9 +4,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Admin\Info;
 
+use DateTimeImmutable;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\DateTime\DateTimeMachineFactory;
 use MichalSpacekCz\Test\Http\Request as HttpRequestMock;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\WebAuthn\Authentication\Reauthentication;
 use MichalSpacekCz\User\WebAuthn\Session\PasskeySessionSection;
 use Nette\Application\Request;
 use Nette\Application\Responses\RedirectResponse;
@@ -33,6 +37,9 @@ final class InfoPresenterTest extends TestCase
 		private readonly ApplicationPresenter $applicationPresenter,
 		private readonly User $user,
 		private readonly PasskeySessionSection $session,
+		private readonly Reauthentication $reauthentication,
+		private readonly DateTimeMachineFactory $dateTime,
+		private readonly Database $database,
 		HttpRequestMock $httpRequest,
 	) {
 		$httpRequest->setMethod(IRequest::Get);
@@ -44,6 +51,8 @@ final class InfoPresenterTest extends TestCase
 	{
 		$this->session->removeAll();
 		$this->user->logout();
+		$this->dateTime->setDateTime(null);
+		$this->database->reset();
 	}
 
 
@@ -56,6 +65,29 @@ final class InfoPresenterTest extends TestCase
 
 		assert($response instanceof RedirectResponse);
 		Assert::contains('reauth', $response->getUrl()); // requireReauthentication() sent the user to Admin:Reauth
+	}
+
+
+	public function testConfirmedSessionLogsEachView(): void
+	{
+		$this->dateTime->setDateTime(new DateTimeImmutable('2026-06-20 12:00:00'));
+		$this->user->login(new SimpleIdentity(42));
+		$this->reauthentication->recordFreshAuth();
+
+		$presenter = $this->applicationPresenter->createUiPresenter('Admin:Info', 'Info', 'php');
+		$presenter->autoCanonicalize = false; // otherwise run() redirects to canonicalize the URL before reaching actionPhp
+		$request = new Request('Admin:Info', IRequest::Get, ['action' => 'php']);
+
+		$presenter->run($request);
+		Assert::count(1, $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
+
+		$presenter->run($request);
+		$params = $this->database->getParamsArrayForQuery('INSERT INTO security_events');
+		Assert::count(2, $params);
+		foreach ($params as $insert) {
+			Assert::same('page.viewed', $insert['action']);
+			Assert::notNull($insert['details']);
+		}
 	}
 
 }

--- a/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
+++ b/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
@@ -77,7 +77,7 @@ final class SecurityActivityTest extends TestCase
 	}
 
 
-	public function testUnknownActionDegradesToRawString(): void
+	public function testUnknownActionDegradesToUnknownLabel(): void
 	{
 		$this->database->setFetchAllDefaultResult([[
 			'action' => 'passkey.teleported', // a value no current SecurityEventType knows
@@ -91,8 +91,8 @@ final class SecurityActivityTest extends TestCase
 		$events = $this->securityActivity->getEventsForCurrentUser();
 
 		Assert::null($events[0]->type);
-		Assert::same('passkey.teleported', $events[0]->action);
-		Assert::same('passkey.teleported', $events[0]->labelKey()); // falls back to the raw action, never throws
+		Assert::same('passkey.teleported', $events[0]->action); // the raw action is kept
+		Assert::same('messages.account.securityLog.event.unknown', $events[0]->labelKey()); // labelled generically, never throws
 		Assert::same([], $events[0]->details);
 		Assert::null($events[0]->ip);
 		Assert::null($events[0]->userAgent);


### PR DESCRIPTION
A reauth confirmation recorded no context, so it could not say what was confirmed. An inline reauth now records the operation it guards as that action's event id, e.g. `email.changed`. This matters most when the reauth fails: there is no follow-up event then, so the recorded operation is the only trace of what was attempted. The label drops the vague "for an operation" now that the detail names the specific one; the interval (viewing) labels keep "for viewing" because they carry no such detail.

Viewing the reauth-gated phpinfo page now records a `page.viewed` event naming the page. It fires on every render rather than only when the reauth gate runs, because inside the freshness window the gate is skipped: recording only at the gate would miss repeat views, and a session hijacked mid-window would read phpinfo with nothing logged.

Follow-up to #782