### PR TITLE
Record permanent-login auto sign-ins in the security event log

### DIFF
--- a/app/src/Form/User/PasskeyAuthenticateFormFactory.php
+++ b/app/src/Form/User/PasskeyAuthenticateFormFactory.php
@@ -52,7 +52,7 @@ final readonly class PasskeyAuthenticateFormFactory
 				$result = $this->passkeyAuthenticator->verifyAuthentication($values->credential);
 				$this->user->setExpiration('30 minutes', true);
 				$this->user->login($this->authenticator->getIdentity($result->userId, $result->username));
-				$this->permanentLogin->regenerate($this->user);
+				$this->permanentLogin->regenerate();
 				// Signing in with a passkey also counts as confirming identity, so sensitive actions won't immediately ask again.
 				$this->reauthentication->recordFreshAuth();
 				$this->securityEventLogger->record($result->userId, SecurityEventType::SignInSuccess, ['user' => $result->username, 'passkey' => $result->credentialName]);

--- a/app/src/Form/User/RegenerateTokensFormFactory.php
+++ b/app/src/Form/User/RegenerateTokensFormFactory.php
@@ -7,7 +7,6 @@ use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use Nette\Forms\Form;
 use Nette\Http\Session;
-use Nette\Security\User;
 use Nette\Utils\Html;
 
 final readonly class RegenerateTokensFormFactory
@@ -17,7 +16,6 @@ final readonly class RegenerateTokensFormFactory
 		private FormFactory $factory,
 		private Session $sessionHandler,
 		private PermanentLogin $permanentLogin,
-		private User $user,
 	) {
 	}
 
@@ -38,7 +36,7 @@ final readonly class RegenerateTokensFormFactory
 				$this->sessionHandler->regenerateId();
 			}
 			if ($values->permanent) {
-				$this->permanentLogin->regenerate($this->user);
+				$this->permanentLogin->regenerate();
 			}
 			$onSuccess('Tokeny přegenerovány');
 		};

--- a/app/src/Presentation/Admin/Sign/SignPresenter.php
+++ b/app/src/Presentation/Admin/Sign/SignPresenter.php
@@ -11,7 +11,6 @@ use MichalSpacekCz\Http\HttpInput;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Www\BasePresenter;
-use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\PermanentLogin\PermanentLogin;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationDisabledException;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationInvalidOrExpiredTokenException;
@@ -32,7 +31,6 @@ final class SignPresenter extends BasePresenter
 
 
 	public function __construct(
-		private readonly Manager $authenticator,
 		private readonly PermanentLogin $permanentLogin,
 		private readonly SignInHoneypotFormFactory $signInHoneypotFormFactory,
 		private readonly PasskeyAuthenticateFormFactory $passkeyAuthenticateFormFactory,
@@ -57,10 +55,7 @@ final class SignPresenter extends BasePresenter
 	{
 		$this->addPermissionsPolicy(PermissionsPolicyDirective::PublicKeyCredentialsGet, PermissionsPolicyOrigin::Self);
 		$this->sessionHandler->start();
-		$token = $this->permanentLogin->verify();
-		if ($token !== null) {
-			$this->user->login($this->authenticator->getIdentity($token->getUserId(), $token->getUsername()));
-			$this->permanentLogin->regenerate($this->user);
+		if ($this->permanentLogin->signIn()) {
 			$this->restoreRequest($this->backlink);
 			$this->redirect('Homepage:');
 		}
@@ -130,7 +125,7 @@ final class SignPresenter extends BasePresenter
 
 	public function actionOut(): never
 	{
-		$this->permanentLogin->clear($this->user);
+		$this->permanentLogin->clear();
 		$this->user->logout();
 		$this->flashMessage('Byli jste odhlášeni');
 		$this->redirect('in');

--- a/app/src/User/PermanentLogin/PermanentLogin.php
+++ b/app/src/User/PermanentLogin/PermanentLogin.php
@@ -13,6 +13,8 @@ use MichalSpacekCz\User\AuthTokens\UserAuthTokenLifetime;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
 use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use Nette\Http\Url;
 use Nette\Security\User;
 use Override;
@@ -27,6 +29,8 @@ final readonly class PermanentLogin implements UserAuthTokenLifetime
 		private UserAuthTokens $tokens,
 		private Cookies $cookies,
 		private Manager $manager,
+		private User $user,
+		private SecurityEventLogger $securityEventLogger,
 		private DateTimeFactory $dateTimeFactory,
 		LinkGenerator $linkGenerator,
 		private string $interval,
@@ -56,9 +60,9 @@ final readonly class PermanentLogin implements UserAuthTokenLifetime
 	}
 
 
-	public function clear(User $user): void
+	public function clear(): void
 	{
-		$this->tokens->deleteAllForUser($this->manager->getUserId($user), $this->getTokenType());
+		$this->tokens->deleteAllForUser($this->manager->getUserId($this->user), $this->getTokenType());
 		$this->cookies->delete(CookieName::PermanentLogin, $this->authCookiesPath);
 	}
 
@@ -66,10 +70,29 @@ final readonly class PermanentLogin implements UserAuthTokenLifetime
 	/**
 	 * @throws Exception
 	 */
-	public function regenerate(User $user): void
+	public function regenerate(): void
 	{
-		$value = $this->tokens->replaceForUser($this->manager->getUserId($user), $this->getTokenType());
+		$value = $this->tokens->replaceForUser($this->manager->getUserId($this->user), $this->getTokenType());
 		$this->setCookie($value);
+	}
+
+
+	/**
+	 * Signing in from the permanent-login cookie is deliberately not a reauth, so a step-up reauth is still
+	 * required afterwards.
+	 *
+	 * @throws Exception
+	 */
+	public function signIn(): bool
+	{
+		$token = $this->verify();
+		if ($token === null) {
+			return false;
+		}
+		$this->user->login($this->manager->getIdentity($token->getUserId(), $token->getUsername()));
+		$this->regenerate();
+		$this->securityEventLogger->record($token->getUserId(), SecurityEventType::SignInPermanent, ['user' => $token->getUsername()]);
+		return true;
 	}
 
 

--- a/app/src/User/SecurityActivity/SecurityEventType.php
+++ b/app/src/User/SecurityActivity/SecurityEventType.php
@@ -21,6 +21,7 @@ enum SecurityEventType: string
 	case PasskeyRenamed = 'passkey.renamed';
 	case PasskeyDeleted = 'passkey.deleted';
 	case SignInSuccess = 'signin.success';
+	case SignInPermanent = 'signin.permanent';
 	case ReauthIntervalSuccess = 'reauth.interval.success';
 	case ReauthIntervalFailure = 'reauth.interval.failure';
 	case ReauthInlineSuccess = 'reauth.inline.success';

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -429,6 +429,7 @@ account:
 			passkeyRenamed: "Passkey přejmenován"
 			passkeyDeleted: "Passkey smazán"
 			signInSuccess: "Přihlášení"
+			signInPermanent: "Automatické přihlášení"
 			reauthIntervalSuccess: "Potvrzení identity pro zobrazení"
 			reauthIntervalFailure: "Neúspěšné potvrzení identity pro zobrazení"
 			reauthInlineSuccess: "Potvrzení identity"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -429,6 +429,7 @@ account:
 			passkeyRenamed: "Passkey renamed"
 			passkeyDeleted: "Passkey deleted"
 			signInSuccess: "Signed in"
+			signInPermanent: "Signed in automatically"
 			reauthIntervalSuccess: "Identity confirmed for viewing"
 			reauthIntervalFailure: "Failed identity confirmation for viewing"
 			reauthInlineSuccess: "Identity confirmed"

--- a/app/tests/Presentation/Admin/Sign/SignPresenterTest.phpt
+++ b/app/tests/Presentation/Admin/Sign/SignPresenterTest.phpt
@@ -1,0 +1,88 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Presentation\Admin\Sign;
+
+use MichalSpacekCz\Http\Cookies\CookieName;
+use MichalSpacekCz\Test\Application\ApplicationPresenter;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Http\Request as HttpRequestMock;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
+use Nette\Application\Request;
+use Nette\Application\Responses\RedirectResponse;
+use Nette\Http\IRequest;
+use Nette\Security\User;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../../bootstrap.php';
+
+/**
+ * A valid permanent-login (remember-me) cookie signs the user back in without an interactive passkey
+ * ceremony. That auto-resume is a security-relevant sign-in and must be recorded in the security log,
+ * with its own event type so it stays distinguishable from an interactive sign-in (a stolen cookie
+ * manifests as an auto-resume, never as an interactive one).
+ *
+ * @testCase
+ */
+final class SignPresenterTest extends TestCase
+{
+
+	public function __construct(
+		private readonly ApplicationPresenter $applicationPresenter,
+		private readonly Database $database,
+		private readonly HttpRequestMock $httpRequest,
+		private readonly User $user,
+	) {
+		$this->httpRequest->setMethod(IRequest::Get);
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->user->logout();
+	}
+
+
+	public function testPermanentLoginResumeIsLogged(): void
+	{
+		$token = 'sometoken';
+		$this->database->setFetchDefaultResult([
+			'id' => 1,
+			'token' => hash('sha512', $token),
+			'userId' => 42,
+			'username' => 'spaze',
+		]);
+		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "selector:{$token}");
+
+		$presenter = $this->applicationPresenter->createUiPresenter('Admin:Sign', 'Sign', 'in');
+		$presenter->autoCanonicalize = false;
+		$response = $presenter->run(new Request('Admin:Sign', IRequest::Get, ['action' => 'in']));
+
+		Assert::type(RedirectResponse::class, $response);
+
+		$inserts = $this->database->getParamsArrayForQuery('INSERT INTO security_events');
+		Assert::count(1, $inserts);
+		Assert::same(SecurityEventType::SignInPermanent->value, $inserts[0]['action']);
+		Assert::same(42, $inserts[0]['key_user']);
+		Assert::notNull($inserts[0]['details']);
+	}
+
+
+	public function testPlainVisitWithoutCookieLogsNothing(): void
+	{
+		$presenter = $this->applicationPresenter->createUiPresenter('Admin:Sign', 'Sign', 'in');
+		$presenter->autoCanonicalize = false;
+		$presenter->run(new Request('Admin:Sign', IRequest::Get, ['action' => 'in']));
+
+		Assert::count(0, $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
+	}
+
+}
+
+TestCaseRunner::run(SignPresenterTest::class);

--- a/app/tests/User/PermanentLogin/PermanentLoginTest.phpt
+++ b/app/tests/User/PermanentLogin/PermanentLoginTest.phpt
@@ -18,6 +18,8 @@ use MichalSpacekCz\User\AuthTokens\UserAuthToken;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
 use MichalSpacekCz\User\Manager;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
+use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Override;
@@ -39,6 +41,7 @@ final class PermanentLoginTest extends TestCase
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly LinkGenerator $linkGenerator,
 		private readonly User $user,
+		private readonly SecurityEventLogger $securityEventLogger,
 	) {
 	}
 
@@ -84,6 +87,35 @@ final class PermanentLoginTest extends TestCase
 	}
 
 
+	public function testSignInWithoutValidTokenDoesNothing(): void
+	{
+		Assert::false($this->getPermanentLogin()->signIn());
+		Assert::false($this->user->isLoggedIn());
+		Assert::count(0, $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
+	}
+
+
+	public function testSignInLogsInRotatesAndRecordsEvent(): void
+	{
+		$token = 'sometoken';
+		$this->database->setFetchDefaultResult([
+			'id' => 1,
+			'token' => hash('sha512', $token),
+			'userId' => 42,
+			'username' => 'spaze',
+		]);
+		$this->httpRequest->setCookie(CookieName::PermanentLogin->value, "selector:{$token}");
+
+		Assert::true($this->getPermanentLogin()->signIn());
+		Assert::same(42, $this->user->getId());
+
+		$inserts = $this->database->getParamsArrayForQuery('INSERT INTO security_events');
+		Assert::count(1, $inserts);
+		Assert::same(SecurityEventType::SignInPermanent->value, $inserts[0]['action']);
+		Assert::same(42, $inserts[0]['key_user']);
+	}
+
+
 	public function testGetCookieLifetime(): void
 	{
 		Assert::same('14 days', $this->getPermanentLogin()->getCookieLifetime());
@@ -107,7 +139,7 @@ final class PermanentLoginTest extends TestCase
 		$userId = 1337;
 		$this->user->login(new SimpleIdentity($userId));
 		$this->cookies->set(CookieName::PermanentLogin, 'goodbye', '14 days');
-		$this->getPermanentLogin()->clear($this->user);
+		$this->getPermanentLogin()->clear();
 
 		Assert::same(
 			[$userId, UserAuthTokenType::PermanentLogin->value],
@@ -121,7 +153,7 @@ final class PermanentLoginTest extends TestCase
 	{
 		$manager = new Manager($this->typedDatabase, $this->httpRequest, 'users');
 		$tokens = new UserAuthTokens($this->database, 'users');
-		return new PermanentLogin($tokens, $this->cookies, $manager, $this->dateTimeFactory, $this->linkGenerator, '14 days');
+		return new PermanentLogin($tokens, $this->cookies, $manager, $this->user, $this->securityEventLogger, $this->dateTimeFactory, $this->linkGenerator, '14 days');
 	}
 
 }


### PR DESCRIPTION
The security event log already records every interactive sign-in, sensitive page view, and reauth, but the permanent-login (remember-me) auto-resume logged the user straight in without recording anything. The log therefore understated real sign-in activity, and under the multi-admin design a session re-established from a stolen `__Secure-permanent` cookie left no attributable entry.

The auto-resume gets its own `SecurityEventType::SignInPermanent` rather than reusing `signin.success`, so a cookie resume stays distinguishable from an interactive sign-in: a stolen cookie surfaces as an auto-resume, never as an interactive ceremony.

The resume (verify the cookie, log in, rotate the token, record the event) moves into `PermanentLogin::signIn()` where it belongs, so the presenter no longer orchestrates it or depends on `Manager` and the logger. With `PermanentLogin` holding the `User` service, `signIn()`, `regenerate()`, and `clear()` no longer take it as an argument.