### PR TITLE
Enforce user verification when registering a passkey

### DIFF
--- a/app/src/Test/User/WebAuthn/PasskeyAttestationResponseValidatorMock.php
+++ b/app/src/Test/User/WebAuthn/PasskeyAttestationResponseValidatorMock.php
@@ -16,6 +16,9 @@ final class PasskeyAttestationResponseValidatorMock extends AuthenticatorAttesta
 	use WillThrow;
 
 
+	private ?PublicKeyCredentialCreationOptions $lastCreationOptions = null;
+
+
 	/**
 	 * @noinspection PhpMissingParentConstructorInspection Intentionally
 	 * @phpstan-ignore constructor.missingParentCall
@@ -31,8 +34,15 @@ final class PasskeyAttestationResponseValidatorMock extends AuthenticatorAttesta
 		PublicKeyCredentialCreationOptions $publicKeyCredentialCreationOptions,
 		string $host,
 	): CredentialRecord {
+		$this->lastCreationOptions = $publicKeyCredentialCreationOptions;
 		$this->maybeThrow();
 		return $this->credentialRecord;
+	}
+
+
+	public function getLastCreationOptions(): ?PublicKeyCredentialCreationOptions
+	{
+		return $this->lastCreationOptions;
 	}
 
 }

--- a/app/src/User/WebAuthn/PasskeyAuthenticator.php
+++ b/app/src/User/WebAuthn/PasskeyAuthenticator.php
@@ -133,6 +133,9 @@ final readonly class PasskeyAuthenticator implements WebAuthnAuthenticator
 			PublicKeyCredentialUserEntity::create('', $userHandle, ''),
 			$challenge,
 			$this->getPubKeyCredParams(),
+			AuthenticatorSelectionCriteria::create(
+				userVerification: AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+			),
 			excludeCredentials: $this->passkeyStorage->getDescriptorsByUserId($userId),
 		);
 

--- a/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
@@ -47,6 +47,7 @@ use Tester\Assert;
 use Tester\TestCase;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponseValidator;
+use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
 use Webauthn\PublicKeyCredential;
@@ -479,6 +480,28 @@ final class PasskeyAuthenticatorTest extends TestCase
 		Assert::count(1, $params);
 		Assert::same(42, $params[0]['key_user']);
 		Assert::same('My Key', $params[0]['name']);
+	}
+
+
+	public function testVerifyRegistrationRequiresUserVerification(): void
+	{
+		$credentialRecord = $this->buildCredentialRecord();
+		$attestationMock = new PasskeyAttestationResponseValidatorMock($credentialRecord);
+		$passkeyAuthenticator = $this->createPasskeyAuthenticator(
+			$attestationMock,
+			new PasskeyAssertionResponseValidatorMock($credentialRecord),
+			$this->serializer,
+		);
+		$this->passkeySessionSection->setRegChallenge(random_bytes(32));
+		$this->database->addFetchFieldResult('user-handle');
+
+		$passkeyAuthenticator->verifyRegistration($this->buildAttestationCredentialJson(), 'My Key', 42);
+
+		$options = $attestationMock->getLastCreationOptions();
+		Assert::same(
+			AuthenticatorSelectionCriteria::USER_VERIFICATION_REQUIREMENT_REQUIRED,
+			$options?->authenticatorSelection?->userVerification,
+		);
 	}
 
 


### PR DESCRIPTION
Registration options ask the authenticator for user verification (`generateRegistrationOptions` sets `userVerification: required`), but `verifyRegistration` built the options it hands to the attestation validator without any `AuthenticatorSelectionCriteria`. The validator's user-verification check reads `options.authenticatorSelection?->userVerification` and returns early when it's null, so the requirement declared at registration time was never actually enforced on the response: a passkey could be registered without user verification.

Only user verification is set on the verify side, not the resident-key requirement, because webauthn-lib has no resident-key ceremony step (discoverability is a client hint the server can't verify), so repeating it there would be a no-op.