### PR TITLE
Turn a failed passkey assertion into a handled error, not a 500

### DIFF
--- a/app/src/User/WebAuthn/PasskeyAuthenticator.php
+++ b/app/src/User/WebAuthn/PasskeyAuthenticator.php
@@ -36,7 +36,7 @@ use Webauthn\AuthenticatorAttestationResponse;
 use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\CredentialRecord;
-use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\Exception\WebauthnException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialCreationOptions;
 use Webauthn\PublicKeyCredentialParameters;
@@ -236,7 +236,7 @@ final readonly class PasskeyAuthenticator implements WebAuthnAuthenticator
 
 		try {
 			$credentialRecord = $this->assertionResponseValidator->check($credentialRecord, $assertionResponse, $options, $this->rpId, null);
-		} catch (AuthenticatorResponseVerificationException $e) {
+		} catch (WebauthnException $e) {
 			throw new PasskeyAuthenticationAssertionResponseValidatorException(previous: $e);
 		}
 

--- a/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
@@ -50,6 +50,7 @@ use Webauthn\AuthenticatorAttestationResponseValidator;
 use Webauthn\AuthenticatorSelectionCriteria;
 use Webauthn\CredentialRecord;
 use Webauthn\Exception\AuthenticatorResponseVerificationException;
+use Webauthn\Exception\CounterException;
 use Webauthn\PublicKeyCredential;
 use Webauthn\PublicKeyCredentialDescriptor;
 use Webauthn\TrustPath\EmptyTrustPath;
@@ -265,6 +266,26 @@ final class PasskeyAuthenticatorTest extends TestCase
 		Assert::exception(function () use ($passkeyAuthenticator): void {
 			$passkeyAuthenticator->verifyAuthentication($this->buildAssertionCredentialJson());
 		}, PasskeyAuthenticationAssertionResponseValidatorException::class);
+	}
+
+
+	public function testVerifyAuthenticationWrapsCounterExceptionAsAssertionFailure(): void
+	{
+		$credentialRecord = $this->buildCredentialRecord();
+		$assertionMock = new PasskeyAssertionResponseValidatorMock($credentialRecord);
+		$counterException = CounterException::create(1, 0, 'counter regression');
+		$assertionMock->willThrow($counterException);
+		$passkeyAuthenticator = $this->createPasskeyAuthenticator(
+			new PasskeyAttestationResponseValidatorMock($credentialRecord),
+			$assertionMock,
+			$this->serializer,
+		);
+		$passkeyAuthenticator->generateAuthenticationOptions();
+		$this->database->setFetchFieldDefaultResult($this->serializer->serialize($credentialRecord, 'json'));
+		$e = Assert::exception(function () use ($passkeyAuthenticator): void {
+			$passkeyAuthenticator->verifyAuthentication($this->buildAssertionCredentialJson());
+		}, PasskeyAuthenticationAssertionResponseValidatorException::class);
+		Assert::same($counterException, $e?->getPrevious());
 	}
 
 


### PR DESCRIPTION
The assertion validator's signature-counter check throws `CounterException` when the counter regresses (the cloned-authenticator / rollback signal). That extends `WebauthnException`, not `AuthenticatorResponseVerificationException`, so `verifyAssertion` never caught it and it surfaced as an uncaught 500 instead of a handled, logged authentication failure.

Catch `WebauthnException`, the base of every verification failure the validator raises (challenge, origin, RP ID hash, signature, user verification, counter), so any of them becomes the same graceful `PasskeyAuthenticationAssertionResponseValidatorException` the sign-in and reauth flows already handle. Non-webauthn errors still propagate, so a real bug can't hide behind a failed sign-in.