### PR TITLE
Make single-use passkey registration tokens atomic under concurrency

### DIFF
--- a/app/src/User/AuthTokens/UserAuthTokens.php
+++ b/app/src/User/AuthTokens/UserAuthTokens.php
@@ -115,9 +115,9 @@ final readonly class UserAuthTokens
 	}
 
 
-	public function deleteById(int $tokenId, UserAuthTokenType $type): void
+	public function deleteById(int $tokenId, UserAuthTokenType $type): int
 	{
-		$this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?', $tokenId, $type->value);
+		return $this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?', $tokenId, $type->value)->getRowCount() ?? 0;
 	}
 
 

--- a/app/src/User/WebAuthn/Registration/PasskeyAddTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyAddTokens.php
@@ -85,9 +85,9 @@ final readonly class PasskeyAddTokens implements UserAuthTokenLifetime, PasskeyR
 
 
 	#[Override]
-	public function deleteById(int $tokenId): void
+	public function deleteById(int $tokenId): int
 	{
-		$this->tokens->deleteById($tokenId, $this->getTokenType());
+		return $this->tokens->deleteById($tokenId, $this->getTokenType());
 	}
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
@@ -66,7 +66,9 @@ abstract readonly class PasskeyRegistration
 	public function register(string $credentialJson, string $name, string $token): PasskeyRegistrationResult
 	{
 		$userAuthToken = $this->getUserAuthToken($token);
-		$this->cleanupToken($userAuthToken);
+		if (!$this->consumeToken($userAuthToken)) {
+			throw new PasskeyRegistrationInvalidOrExpiredTokenException();
+		}
 		$keepCredentialId = $this->passkeyAuthenticator->verifyRegistration($credentialJson, $name, $userAuthToken->getUserId());
 		return new PasskeyRegistrationResult($userAuthToken->getUsername(), $userAuthToken->getUserId(), $keepCredentialId);
 	}
@@ -93,9 +95,9 @@ abstract readonly class PasskeyRegistration
 	}
 
 
-	private function cleanupToken(UserAuthToken $userAuthToken): void
+	private function consumeToken(UserAuthToken $userAuthToken): bool
 	{
-		$this->registrationTokens->deleteById($userAuthToken->getId());
+		return $this->registrationTokens->deleteById($userAuthToken->getId()) > 0;
 	}
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistrationTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistrationTokens.php
@@ -37,6 +37,6 @@ interface PasskeyRegistrationTokens
 	public function verify(string $value): ?UserAuthToken;
 
 
-	public function deleteById(int $tokenId): void;
+	public function deleteById(int $tokenId): int;
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyResetTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyResetTokens.php
@@ -80,9 +80,9 @@ final readonly class PasskeyResetTokens implements UserAuthTokenLifetime, Passke
 
 
 	#[Override]
-	public function deleteById(int $tokenId): void
+	public function deleteById(int $tokenId): int
 	{
-		$this->tokens->deleteById($tokenId, $this->getTokenType());
+		return $this->tokens->deleteById($tokenId, $this->getTokenType());
 	}
 
 }

--- a/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
+++ b/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
@@ -10,6 +10,7 @@ use MichalSpacekCz\Form\Controls\PasskeyFormControls;
 use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\ResultSet;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
@@ -134,6 +135,7 @@ final class PasskeyRegistrationFormFactoryTest extends TestCase
 			'userId' => $userId,
 			'username' => $username,
 		]);
+		$this->database->setResultSet(new ResultSet(1)); // consuming the token deletes its one row
 	}
 
 

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\ResultSet;
 use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
@@ -88,6 +89,16 @@ final class PasskeyAddTest extends TestCase
 	}
 
 
+	public function testRegisterAbortsWhenTokenAlreadyConsumedByAConcurrentRequest(): void
+	{
+		$this->setUpToken(42, 1337, 'foo');
+		$this->database->setResultSet(new ResultSet(0)); // another request already deleted the token row, so our delete affects nothing
+		Assert::exception(function (): void {
+			$this->createPasskeyAdd()->register('{"id":"test","type":"public-key"}', 'My Passkey', 'selector:secret');
+		}, PasskeyRegistrationInvalidOrExpiredTokenException::class);
+	}
+
+
 	public function testGenerateRegistrationOptionsExcludesExistingCredentials(): void
 	{
 		$this->setUpToken(42, 1337, 'foo');
@@ -127,6 +138,7 @@ final class PasskeyAddTest extends TestCase
 			'userId' => $userId,
 			'username' => $username,
 		]);
+		$this->database->setResultSet(new ResultSet(1)); // consuming the token deletes its one row
 	}
 
 

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTokensTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTokensTest.phpt
@@ -87,7 +87,8 @@ final class PasskeyAddTokensTest extends TestCase
 
 	public function testDeleteByIdQueriesAdminAddType(): void
 	{
-		$this->getTokens(true)->deleteById(42);
+		$this->database->setResultSet(new ResultSet(1));
+		Assert::same(1, $this->getTokens(true)->deleteById(42));
 		Assert::same(
 			[42, UserAuthTokenType::AdminPasskeyAdd->value],
 			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\ResultSet;
 use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
@@ -123,6 +124,7 @@ final class PasskeyResetTest extends TestCase
 			'userId' => $userId,
 			'username' => $username,
 		]);
+		$this->database->setResultSet(new ResultSet(1)); // consuming the token deletes its one row
 	}
 
 

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTokensTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTokensTest.phpt
@@ -87,7 +87,8 @@ final class PasskeyResetTokensTest extends TestCase
 
 	public function testDeleteByIdQueriesAdminResetType(): void
 	{
-		$this->getTokens(true)->deleteById(42);
+		$this->database->setResultSet(new ResultSet(1));
+		Assert::same(1, $this->getTokens(true)->deleteById(42));
 		Assert::same(
 			[42, UserAuthTokenType::AdminPasskeyReset->value],
 			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),


### PR DESCRIPTION
Registering a passkey verified the token with a SELECT and then deleted it with a separate DELETE. Two requests racing the same registration link could both pass the SELECT before either DELETE ran, so both would go on to register a passkey: the token was single-use only when requests didn't overlap.

Let the DELETE elect the winner. `deleteById` now returns the number of rows it removed, and `register()` stops with the invalid-or-expired-token error when that is zero, because a concurrent request already consumed the row. Only the request whose DELETE actually removes the token proceeds; the database serializes the deletes, so exactly one sees a row.

The consume-before-verify order is unchanged: the token is still deleted before the credential is checked, so a link can't be replayed even when the credential verification that follows fails.