### PR TITLE
Passkey/reauth followups to make it correct by design, not by accident

### DIFF
--- a/app/src/Form/Controls/PasskeyAuthenticationControls.php
+++ b/app/src/Form/Controls/PasskeyAuthenticationControls.php
@@ -74,8 +74,8 @@ final readonly class PasskeyAuthenticationControls
 			$userId = (int)$this->user->getId();
 			try {
 				$passkeyName = $this->reauthentication->verify($values->credential);
-				// don't record a confirmation for a submit that another control already failed (the gated action won't run)
 				if (!$form->hasErrors()) {
+					$this->reauthentication->recordFreshAuth();
 					$this->recordReauth($userId, $kind, true, $passkeyName, $operation);
 				}
 			} catch (PasskeyException $e) {

--- a/app/src/Form/Controls/PasskeyAuthenticationControls.php
+++ b/app/src/Form/Controls/PasskeyAuthenticationControls.php
@@ -4,6 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Form\Controls;
 
 use Contributte\Translation\Translator;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use MichalSpacekCz\User\WebAuthn\Authentication\Reauthentication;
@@ -34,6 +35,7 @@ final readonly class PasskeyAuthenticationControls
 		private Reauthentication $reauthentication,
 		private Translator $translator,
 		private User $user,
+		private Manager $manager,
 		private SecurityEventLogger $securityEventLogger,
 	) {
 	}
@@ -71,7 +73,7 @@ final readonly class PasskeyAuthenticationControls
 		$form->onValidate[] = function (Form $form) use ($kind, $operation): void {
 			$values = $form->getUntrustedValues();
 			assert(is_string($values->credential));
-			$userId = (int)$this->user->getId();
+			$userId = $this->manager->getUserId($this->user);
 			try {
 				$passkeyName = $this->reauthentication->verify($values->credential);
 				if (!$form->hasErrors()) {

--- a/app/src/Form/User/AccountEmailFormFactory.php
+++ b/app/src/Form/User/AccountEmailFormFactory.php
@@ -6,6 +6,8 @@ namespace MichalSpacekCz\Form\User;
 use Contributte\Translation\Translator;
 use MichalSpacekCz\Form\Controls\PasskeyAuthenticationControls;
 use MichalSpacekCz\Form\FormFactory;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
@@ -21,6 +23,7 @@ final readonly class AccountEmailFormFactory
 		private FormFactory $factory,
 		private UserAccounts $userAccounts,
 		private User $user,
+		private Manager $manager,
 		private Translator $translator,
 		private PasskeyAuthenticationControls $passkeyAuthenticationControls,
 		private UserSecurityNotifier $notifier,
@@ -31,13 +34,14 @@ final readonly class AccountEmailFormFactory
 
 	/**
 	 * @param callable(): void $onSuccess
+	 * @throws IdentityIdNotIntException
 	 */
 	public function create(callable $onSuccess): Form
 	{
 		$form = $this->factory->create();
 		$email = $form->addEmail('email', $this->translator->translate('messages.account.email.label'))
 			->setRequired($this->translator->translate('messages.account.email.required'));
-		$userId = (int)$this->user->getId();
+		$userId = $this->manager->getUserId($this->user);
 		$currentEmail = $this->userAccounts->getEmail($userId);
 		if ($currentEmail !== null) {
 			$email->setDefaultValue($currentEmail);

--- a/app/src/User/WebAuthn/Authentication/Reauthentication.php
+++ b/app/src/User/WebAuthn/Authentication/Reauthentication.php
@@ -65,8 +65,10 @@ final readonly class Reauthentication
 
 
 	/**
-	 * Check the passkey the user just used and, only if it is their own, mark their identity as
-	 * confirmed. This stops someone else's passkey from confirming identity for this session.
+	 * Check the passkey is the current user's own and return its name; rejects someone else's so it can't
+	 * confirm identity for this session. Deliberately does not refresh the freshness window itself: the
+	 * caller does that only when the guarded submit succeeds, so a submit that then fails leaves no fresh
+	 * window behind.
 	 *
 	 * @throws PasskeyAuthenticationException
 	 * @throws PasskeyReauthenticationUserMismatchException
@@ -78,7 +80,6 @@ final readonly class Reauthentication
 		if ($result->userId !== $signedInUserId) {
 			throw new PasskeyReauthenticationUserMismatchException($signedInUserId, $result->userId);
 		}
-		$this->recordFreshAuth();
 		return $result->credentialName;
 	}
 

--- a/app/src/User/WebAuthn/Authentication/Reauthentication.php
+++ b/app/src/User/WebAuthn/Authentication/Reauthentication.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\User\WebAuthn\Authentication;
 
 use MichalSpacekCz\DateTime\DateTimeFactory;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\WebAuthn\Authentication\Exceptions\PasskeyAuthenticationException;
 use MichalSpacekCz\User\WebAuthn\Authentication\Exceptions\PasskeyReauthenticationUserMismatchException;
 use MichalSpacekCz\User\WebAuthn\Session\PasskeySessionSection;
@@ -23,6 +25,7 @@ final readonly class Reauthentication
 		private PasskeySessionSection $passkeySessionSection,
 		private DateTimeFactory $dateTimeFactory,
 		private User $user,
+		private Manager $manager,
 		private string $ttl,
 	) {
 	}
@@ -72,11 +75,12 @@ final readonly class Reauthentication
 	 *
 	 * @throws PasskeyAuthenticationException
 	 * @throws PasskeyReauthenticationUserMismatchException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function verify(string $credentialJson): string
 	{
 		$result = $this->passkeyAuthenticator->verifyAssertion($credentialJson);
-		$signedInUserId = (int)$this->user->getId();
+		$signedInUserId = $this->manager->getUserId($this->user);
 		if ($result->userId !== $signedInUserId) {
 			throw new PasskeyReauthenticationUserMismatchException($signedInUserId, $result->userId);
 		}

--- a/app/src/User/WebAuthn/PasskeyAuthenticator.php
+++ b/app/src/User/WebAuthn/PasskeyAuthenticator.php
@@ -29,7 +29,6 @@ use Nette\Security\User;
 use Override;
 use Symfony\Component\Serializer\Exception\ExceptionInterface;
 use Symfony\Component\Serializer\SerializerInterface;
-use Throwable;
 use Webauthn\AuthenticatorAssertionResponse;
 use Webauthn\AuthenticatorAssertionResponseValidator;
 use Webauthn\AuthenticatorAttestationResponse;
@@ -141,7 +140,7 @@ final readonly class PasskeyAuthenticator implements WebAuthnAuthenticator
 
 		try {
 			$credentialRecord = $this->attestationResponseValidator->check($attestationResponse, $options, $this->rpId);
-		} catch (Throwable $e) {
+		} catch (WebauthnException $e) {
 			throw new PasskeyRegistrationAttestationResponseValidatorException(previous: $e);
 		}
 		try {

--- a/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
@@ -9,6 +9,7 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\UserAccounts;
 use MichalSpacekCz\User\WebAuthn\Authentication\PasskeyAuthenticationResult;
 use MichalSpacekCz\User\WebAuthn\Session\PasskeySessionSection;
@@ -149,6 +150,15 @@ final class AccountEmailFormFactoryTest extends TestCase
 		Assert::count(0, $this->mailer->getAllMails()); // resubmitting the same address notifies no one
 		$events = array_map(fn(array $e): mixed => $e['action'], $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
 		Assert::notContains('email.changed', $events); // and records no email-change event
+	}
+
+
+	public function testRejectsNonIntegerIdentity(): void
+	{
+		$this->user->login(new SimpleIdentity('not-an-int'));
+		Assert::exception(function (): void {
+			$this->createForm('me@example.com', '{"id":"test","type":"public-key"}');
+		}, IdentityIdNotIntException::class);
 	}
 
 

--- a/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountEmailFormFactoryTest.phpt
@@ -70,6 +70,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 
 		Arrays::invoke($form->onValidate, $form);
 		Assert::false($form->hasErrors());
+		Assert::notNull($this->session->getReauthAt()); // a successful confirmation refreshes the freshness window
 		Arrays::invoke($form->onSuccess, $form);
 
 		Assert::true($this->onSuccessCalled);
@@ -127,8 +128,10 @@ final class AccountEmailFormFactoryTest extends TestCase
 
 		Arrays::invoke($form->onValidate, $form);
 
-		// the passkey verified, but another control failed so the save won't run: don't record a confirmation for it
+		// the passkey verified, but another control failed so the save won't run: it isn't a confirmation,
+		// so it's neither logged nor left as a refreshed freshness window
 		Assert::same([], $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
+		Assert::null($this->session->getReauthAt());
 	}
 
 

--- a/app/tests/User/WebAuthn/Authentication/ReauthenticationTest.phpt
+++ b/app/tests/User/WebAuthn/Authentication/ReauthenticationTest.phpt
@@ -9,6 +9,7 @@ use MichalSpacekCz\Test\DateTime\DateTimeMachineFactory;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\Test\User\WebAuthn\ReauthenticationRedirectorMock;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\WebAuthn\Authentication\Exceptions\PasskeyReauthenticationUserMismatchException;
 use MichalSpacekCz\User\WebAuthn\Session\PasskeySessionSection;
 use Nette\Security\SimpleIdentity;
@@ -83,11 +84,21 @@ final class ReauthenticationTest extends TestCase
 		$this->user->login(new SimpleIdentity(42));
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(99, 'someone-else', 'cred-id', 'My Passkey'));
 
-		Assert::exception(
-			fn() => $this->reauthentication->verify('{}'),
-			PasskeyReauthenticationUserMismatchException::class,
-		);
+		Assert::exception(function (): void {
+			$this->reauthentication->verify('{}');
+		}, PasskeyReauthenticationUserMismatchException::class);
 		Assert::false($this->reauthentication->isFreshAuth());
+	}
+
+
+	public function testVerifyRejectsNonIntegerIdentity(): void
+	{
+		$this->user->login(new SimpleIdentity('not-an-int'));
+		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
+
+		Assert::exception(function (): void {
+			$this->reauthentication->verify('{"id":"test","type":"public-key"}');
+		}, IdentityIdNotIntException::class);
 	}
 
 
@@ -107,10 +118,9 @@ final class ReauthenticationTest extends TestCase
 	{
 		$redirector = new ReauthenticationRedirectorMock();
 
-		Assert::exception(
-			fn() => $this->reauthentication->requireFreshAuth($redirector),
-			RuntimeException::class,
-		);
+		Assert::exception(function () use ($redirector): void {
+			$this->reauthentication->requireFreshAuth($redirector);
+		}, RuntimeException::class);
 		Assert::true($redirector->redirected); // not confirmed recently, sent to reauth
 	}
 

--- a/app/tests/User/WebAuthn/Authentication/ReauthenticationTest.phpt
+++ b/app/tests/User/WebAuthn/Authentication/ReauthenticationTest.phpt
@@ -67,15 +67,13 @@ final class ReauthenticationTest extends TestCase
 	}
 
 
-	public function testVerifyRecordsReauthForSignedInUser(): void
+	public function testVerifyReturnsPasskeyNameAndDoesNotRefreshWindowItself(): void
 	{
-		$this->dateTime->setDateTime(new DateTimeImmutable('2026-06-20 12:00:00'));
 		$this->user->login(new SimpleIdentity(42));
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
 
-		$this->reauthentication->verify('{"id":"test","type":"public-key"}');
-
-		Assert::true($this->reauthentication->isFreshAuth());
+		Assert::same('My Passkey', $this->reauthentication->verify('{"id":"test","type":"public-key"}'));
+		Assert::false($this->reauthentication->isFreshAuth()); // the caller refreshes the window, and only on a successful submit
 	}
 
 

--- a/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyAuthenticatorTest.phpt
@@ -8,7 +8,6 @@ use CBOR\ByteStringObject;
 use CBOR\MapItem;
 use CBOR\MapObject;
 use CBOR\TextStringObject;
-use Exception;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Serializer\SerializerMock;
 use MichalSpacekCz\Test\TestCaseRunner;
@@ -40,6 +39,7 @@ use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Nette\Utils\Json;
 use Override;
+use RuntimeException;
 use Symfony\Component\Serializer\Exception\NotEncodableValueException;
 use Symfony\Component\Serializer\SerializerInterface;
 use Symfony\Component\Uid\Uuid;
@@ -374,7 +374,7 @@ final class PasskeyAuthenticatorTest extends TestCase
 	{
 		$credentialRecord = $this->buildCredentialRecord();
 		$attestationMock = new PasskeyAttestationResponseValidatorMock($credentialRecord);
-		$attestationMock->willThrow(new Exception('test'));
+		$attestationMock->willThrow(AuthenticatorResponseVerificationException::create('test'));
 		$passkeyAuthenticator = $this->createPasskeyAuthenticator(
 			$attestationMock,
 			new PasskeyAssertionResponseValidatorMock($credentialRecord),
@@ -385,6 +385,24 @@ final class PasskeyAuthenticatorTest extends TestCase
 		Assert::exception(function () use ($passkeyAuthenticator): void {
 			$passkeyAuthenticator->verifyRegistration($this->buildAttestationCredentialJson(), 'key', 1);
 		}, PasskeyRegistrationAttestationResponseValidatorException::class);
+	}
+
+
+	public function testVerifyRegistrationLetsNonWebauthnErrorsPropagate(): void
+	{
+		$credentialRecord = $this->buildCredentialRecord();
+		$attestationMock = new PasskeyAttestationResponseValidatorMock($credentialRecord);
+		$attestationMock->willThrow(new RuntimeException('a bug, not a verification failure'));
+		$passkeyAuthenticator = $this->createPasskeyAuthenticator(
+			$attestationMock,
+			new PasskeyAssertionResponseValidatorMock($credentialRecord),
+			$this->serializer,
+		);
+		$this->passkeySessionSection->setRegChallenge(random_bytes(32));
+		$this->database->addFetchFieldResult('handle');
+		Assert::exception(function () use ($passkeyAuthenticator): void {
+			$passkeyAuthenticator->verifyRegistration($this->buildAttestationCredentialJson(), 'key', 1);
+		}, RuntimeException::class);
 	}
 
 


### PR DESCRIPTION
Four low-severity follow-ups from reviewing the passkey, reauth, and account code. Each closes a spot where the code happened to behave correctly but wasn't guaranteed to:

- the account-email form and other places reject a non-integer identity instead of quietly coercing it and acting on user 0;
- an inline passkey confirmation refreshes the reauth freshness window only when the action it guards succeeds, so a failed submit leaves no unearned, unlogged fresh session;
- passkey registration lets a genuine bug surface instead of disguising it as an attestation failure.

Nothing here is exploitable on its own; it's first-layer soundness.