### PR TITLE
Reject non-integer identity ids everywhere, and ban the cast

### DIFF
--- a/app/disallowed-calls.neon
+++ b/app/disallowed-calls.neon
@@ -82,6 +82,14 @@ parameters:
 				- 'MichalSpacekCz\User\WebAuthn\Registration\PasskeyResetTokens::*'
 				- 'MichalSpacekCz\User\AuthTokens\AuthTokensRevoker::*' # account-recovery revoke deletes every token type on purpose, no per-type rule to honor
 		-
+			method: 'Nette\Security\User::getId()'
+			message: 'use MichalSpacekCz\User\Manager::getUserId() instead'
+			errorTip: 'it rejects a non-integer identity id instead of silently coercing it to 0'
+			allowIn:
+				- tests/*.phpt
+			allowInMethods:
+				- 'MichalSpacekCz\User\Manager::getUserId()'
+		-
 			method:
 				- 'MichalSpacekCz\Formatter\TexyFormatter::substitutePossiblyUnsafeHtml()'
 				- 'MichalSpacekCz\Formatter\TexyFormatter::translatePossiblyUnsafeHtml()'

--- a/app/phpstan-vendor.neon
+++ b/app/phpstan-vendor.neon
@@ -190,6 +190,11 @@ parameters:
 			message: 'use MichalSpacekCz\DateTime\DateTimeZoneFactory::get() instead, throws a more specific exception'
 			allowIn:
 				- vendor/*.php
+		-
+			method: 'Nette\Security\User::getId()'
+			message: 'use MichalSpacekCz\User\Manager::getUserId() instead'
+			allowIn:
+				- vendor/*.php
 	disallowedStaticCalls:
 		-
 			method: 'Tracy\Debugger::dump()'

--- a/app/src/Presentation/Admin/Info/InfoPresenter.php
+++ b/app/src/Presentation/Admin/Info/InfoPresenter.php
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Presentation\Admin\Info;
 
 use MichalSpacekCz\Application\SanitizedPhpInfo;
 use MichalSpacekCz\Presentation\Admin\BasePresenter;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use Nette\Utils\Html;
@@ -14,6 +15,7 @@ final class InfoPresenter extends BasePresenter
 
 	public function __construct(
 		private readonly SanitizedPhpInfo $phpInfo,
+		private readonly Manager $manager,
 		private readonly SecurityEventLogger $securityEventLogger,
 	) {
 		parent::__construct();
@@ -23,7 +25,7 @@ final class InfoPresenter extends BasePresenter
 	public function actionPhp(): void
 	{
 		$this->requireReauthentication();
-		$this->securityEventLogger->record((int)$this->getUser()->getId(), SecurityEventType::PageViewed, ['page' => $this->link('this')]);
+		$this->securityEventLogger->record($this->manager->getUserId($this->getUser()), SecurityEventType::PageViewed, ['page' => $this->link('this')]);
 		$this->template->pageTitle = 'phpinfo()';
 		$this->template->phpinfo = Html::el()->setHtml($this->phpInfo->getHtml());
 	}

--- a/app/src/User/SecurityActivity/SecurityActivity.php
+++ b/app/src/User/SecurityActivity/SecurityActivity.php
@@ -5,6 +5,8 @@ namespace MichalSpacekCz\User\SecurityActivity;
 
 use DateTimeInterface;
 use MichalSpacekCz\DateTime\DateTimeFactory;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
+use MichalSpacekCz\User\Manager;
 use Nette\Database\Explorer;
 use Nette\Security\User;
 use Nette\Utils\Json;
@@ -29,6 +31,7 @@ final readonly class SecurityActivity
 		private Explorer $database,
 		private DateTimeFactory $dateTimeFactory,
 		private User $user,
+		private Manager $manager,
 		private SymmetricKeyEncryption $securityEventEncryption,
 	) {
 	}
@@ -36,12 +39,13 @@ final readonly class SecurityActivity
 
 	/**
 	 * @return list<SecurityEvent>
+	 * @throws IdentityIdNotIntException
 	 */
 	public function getEventsForCurrentUser(): array
 	{
 		return $this->buildEvents($this->database->fetchAll(
 			self::SELECT . ' WHERE key_user = ? ORDER BY created DESC, id_security_event DESC',
-			(int)$this->user->getId(),
+			$this->manager->getUserId($this->user),
 		));
 	}
 

--- a/app/src/User/WebAuthn/Passkeys.php
+++ b/app/src/User/WebAuthn/Passkeys.php
@@ -7,6 +7,8 @@ use DateTimeInterface;
 use Exception;
 use MichalSpacekCz\Database\TypedDatabase;
 use MichalSpacekCz\DateTime\DateTimeFactory;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use MichalSpacekCz\User\WebAuthn\Exceptions\PasskeyCredentialNotFoundException;
@@ -24,6 +26,7 @@ final readonly class Passkeys
 		private TypedDatabase $typedDatabase,
 		private DateTimeFactory $dateTimeFactory,
 		private User $user,
+		private Manager $manager,
 		private PasskeySessionSection $passkeySessionSection,
 		private SecurityEventLogger $securityEventLogger,
 		private string $passkeysTableName,
@@ -33,6 +36,7 @@ final readonly class Passkeys
 
 	/**
 	 * @return list<RegisteredPasskey>
+	 * @throws IdentityIdNotIntException
 	 */
 	public function getPasskeys(): array
 	{
@@ -51,7 +55,7 @@ final readonly class Passkeys
 			ORDER BY last_used DESC,
 		 	created DESC',
 			$this->passkeysTableName,
-			(int)$this->user->getId(),
+			$this->manager->getUserId($this->user),
 		);
 		$now = $this->dateTimeFactory->create();
 		$items = [];
@@ -81,6 +85,7 @@ final readonly class Passkeys
 
 	/**
 	 * @throws PasskeyCredentialNotFoundException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function getCredentialNameById(Uuid $id): string
 	{
@@ -88,7 +93,7 @@ final readonly class Passkeys
 			'SELECT name FROM ?name WHERE id_passkey = ? AND key_user = ?',
 			$this->passkeysTableName,
 			$id->toBinary(),
-			(int)$this->user->getId(),
+			$this->manager->getUserId($this->user),
 		);
 		if ($name === null) {
 			throw new PasskeyCredentialNotFoundException();
@@ -99,10 +104,11 @@ final readonly class Passkeys
 
 	/**
 	 * @throws PasskeyCredentialNotFoundException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function renameCredential(Uuid $id, string $name): void
 	{
-		$userId = (int)$this->user->getId();
+		$userId = $this->manager->getUserId($this->user);
 		$found = true;
 		$this->database->beginTransaction();
 		try {
@@ -141,6 +147,7 @@ final readonly class Passkeys
 	/**
 	 * @throws PasskeyCredentialNotFoundException
 	 * @throws PasskeyCredentialSignedInWithException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function deleteCredential(Uuid $id): void
 	{
@@ -151,7 +158,7 @@ final readonly class Passkeys
 			'DELETE FROM ?name WHERE id_passkey = ? AND key_user = ? AND (? IS NULL OR credential_id != ?)',
 			$this->passkeysTableName,
 			$idBinary,
-			(int)$this->user->getId(),
+			$this->manager->getUserId($this->user),
 			$currentCredentialId,
 			$currentCredentialId,
 		)->getRowCount();
@@ -161,7 +168,7 @@ final readonly class Passkeys
 				'SELECT 1 FROM ?name WHERE id_passkey = ? AND key_user = ?',
 				$this->passkeysTableName,
 				$idBinary,
-				(int)$this->user->getId(),
+				$this->manager->getUserId($this->user),
 			);
 			if ($exists !== null) {
 				throw new PasskeyCredentialSignedInWithException();
@@ -169,7 +176,7 @@ final readonly class Passkeys
 				throw new PasskeyCredentialNotFoundException();
 			}
 		}
-		$this->securityEventLogger->record((int)$this->user->getId(), SecurityEventType::PasskeyDeleted, ['passkey' => $name]);
+		$this->securityEventLogger->record($this->manager->getUserId($this->user), SecurityEventType::PasskeyDeleted, ['passkey' => $name]);
 	}
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\User\WebAuthn\Registration;
 
 use MichalSpacekCz\User\AuthTokens\UserAuthToken;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\WebAuthn\Registration\Exceptions\PasskeyRegistrationDisabledException;
@@ -27,6 +29,7 @@ abstract readonly class PasskeyRegistration
 		private PasskeyRegistrationTokens $registrationTokens,
 		private WebAuthnAuthenticator $passkeyAuthenticator,
 		private User $user,
+		private Manager $manager,
 		protected UserSecurityNotifier $notifier,
 		protected SecurityEventLogger $securityEventLogger,
 	) {
@@ -43,6 +46,7 @@ abstract readonly class PasskeyRegistration
 	 * @throws PasskeyRegistrationDisabledException
 	 * @throws PasskeyRegistrationInvalidOrExpiredTokenException
 	 * @throws PasskeyRegistrationUserMismatchException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function generateRegistrationOptions(string $token): string
 	{
@@ -62,6 +66,7 @@ abstract readonly class PasskeyRegistration
 	 * @throws PasskeyRegistrationDisabledException
 	 * @throws PasskeyRegistrationInvalidOrExpiredTokenException
 	 * @throws PasskeyRegistrationUserMismatchException
+	 * @throws IdentityIdNotIntException
 	 */
 	public function register(string $credentialJson, string $name, string $token): PasskeyRegistrationResult
 	{
@@ -78,6 +83,7 @@ abstract readonly class PasskeyRegistration
 	 * @throws PasskeyRegistrationDisabledException
 	 * @throws PasskeyRegistrationInvalidOrExpiredTokenException
 	 * @throws PasskeyRegistrationUserMismatchException
+	 * @throws IdentityIdNotIntException
 	 */
 	private function getUserAuthToken(string $token): UserAuthToken
 	{
@@ -87,7 +93,7 @@ abstract readonly class PasskeyRegistration
 		}
 		// When signed in, the token must be the signed-in user's, so a leaked link can't register a
 		// passkey onto someone else's account; logged out (reset recovery) there is no one to match.
-		$loggedInUserId = $this->user->isLoggedIn() ? (int) $this->user->getId() : null;
+		$loggedInUserId = $this->user->isLoggedIn() ? $this->manager->getUserId($this->user) : null;
 		if ($loggedInUserId !== null && $userAuthToken->getUserId() !== $loggedInUserId) {
 			throw new PasskeyRegistrationUserMismatchException();
 		}

--- a/app/src/User/WebAuthn/Registration/PasskeyReset.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyReset.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\User\WebAuthn\Registration;
 
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
@@ -19,11 +20,12 @@ final readonly class PasskeyReset extends PasskeyRegistration
 		PasskeyRegistrationTokens $registrationTokens,
 		WebAuthnAuthenticator $passkeyAuthenticator,
 		User $user,
+		Manager $manager,
 		UserSecurityNotifier $notifier,
 		SecurityEventLogger $securityEventLogger,
 		private PasskeyResetRevoker $revoker,
 	) {
-		parent::__construct($registrationTokens, $passkeyAuthenticator, $user, $notifier, $securityEventLogger);
+		parent::__construct($registrationTokens, $passkeyAuthenticator, $user, $manager, $notifier, $securityEventLogger);
 	}
 
 

--- a/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
+++ b/app/tests/Form/User/PasskeyRegistrationFormFactoryTest.phpt
@@ -14,6 +14,7 @@ use MichalSpacekCz\Test\Database\ResultSet;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\WebAuthn\PasskeyStorage;
@@ -55,6 +56,7 @@ final class PasskeyRegistrationFormFactoryTest extends TestCase
 		private readonly Translator $translator,
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
+		private readonly Manager $manager,
 		private readonly PasskeyStorage $passkeyStorage,
 		private readonly UserSecurityNotifier $notifier,
 		private readonly SecurityEventLogger $securityEventLogger,
@@ -142,14 +144,14 @@ final class PasskeyRegistrationFormFactoryTest extends TestCase
 	private function createPasskeyAdd(): PasskeyAdd
 	{
 		$addTokens = new PasskeyAddTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, $this->securityEventLogger);
+		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->manager, $this->notifier, $this->securityEventLogger);
 	}
 
 
 	private function createPasskeyReset(): PasskeyReset
 	{
 		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, $this->securityEventLogger, new PasskeyResetRevoker($this->passkeyStorage, []));
+		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->manager, $this->notifier, $this->securityEventLogger, new PasskeyResetRevoker($this->passkeyStorage, []));
 	}
 
 

--- a/app/tests/User/ManagerTest.phpt
+++ b/app/tests/User/ManagerTest.phpt
@@ -10,6 +10,7 @@ use MichalSpacekCz\Database\TypedDatabase;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\Http\Request;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Override;
@@ -53,6 +54,22 @@ final class ManagerTest extends TestCase
 			Assert::same($username, $identity->username);
 		}
 		Assert::same($username, $identity->getData()['username']);
+	}
+
+
+	public function testGetUserIdReturnsIntForIntIdentity(): void
+	{
+		$this->user->login(new SimpleIdentity(1337));
+		Assert::same(1337, $this->getManager()->getUserId($this->user));
+	}
+
+
+	public function testGetUserIdRejectsNonIntegerIdentity(): void
+	{
+		$this->user->login(new SimpleIdentity('not-an-int'));
+		Assert::exception(function (): void {
+			$this->getManager()->getUserId($this->user);
+		}, IdentityIdNotIntException::class);
 	}
 
 

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -12,6 +12,7 @@ use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokenType;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\UserAccounts;
@@ -34,6 +35,7 @@ final class PasskeyAddTest extends TestCase
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
+		private readonly Manager $manager,
 		private readonly UserSecurityNotifier $notifier,
 		private readonly SecurityEventLogger $securityEventLogger,
 		private readonly UserAccounts $userAccounts,
@@ -145,7 +147,7 @@ final class PasskeyAddTest extends TestCase
 	private function createPasskeyAdd(): PasskeyAdd
 	{
 		$addTokens = new PasskeyAddTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
-		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, $this->securityEventLogger);
+		return new PasskeyAdd($addTokens, $this->passkeyAuthenticator, $this->user, $this->manager, $this->notifier, $this->securityEventLogger);
 	}
 
 }

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
@@ -11,6 +11,7 @@ use MichalSpacekCz\Test\NullMailer;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\User\WebAuthn\PasskeyAuthenticatorMock;
 use MichalSpacekCz\User\AuthTokens\UserAuthTokens;
+use MichalSpacekCz\User\Manager;
 use MichalSpacekCz\User\Notifications\UserSecurityNotifier;
 use MichalSpacekCz\User\SecurityActivity\SecurityEventLogger;
 use MichalSpacekCz\User\UserAccounts;
@@ -32,6 +33,7 @@ final class PasskeyResetTest extends TestCase
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
 		private readonly DateTimeFactory $dateTimeFactory,
 		private readonly User $user,
+		private readonly Manager $manager,
 		private readonly PasskeyStorage $passkeyStorage,
 		private readonly UserSecurityNotifier $notifier,
 		private readonly SecurityEventLogger $securityEventLogger,
@@ -132,7 +134,7 @@ final class PasskeyResetTest extends TestCase
 	{
 		$resetTokens = new PasskeyResetTokens(new UserAuthTokens($this->database, 'users'), $this->dateTimeFactory, true, '5 minutes');
 		$revoker = new PasskeyResetRevoker($this->passkeyStorage, []);
-		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->notifier, $this->securityEventLogger, $revoker);
+		return new PasskeyReset($resetTokens, $this->passkeyAuthenticator, $this->user, $this->manager, $this->notifier, $this->securityEventLogger, $revoker);
 	}
 
 }


### PR DESCRIPTION
The guard's reject behavior is now tested in `ManagerTest`, and the PHPStan disallowed calls rule guarantees every caller uses it, so per-site rejection tests aren't needed.
