### PR TITLE
Rename users.email to notification_email

### DIFF
--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -67,7 +67,7 @@ services:
 	- MichalSpacekCz\Form\Training\TrainingReviewFormFactory
 	- MichalSpacekCz\Form\Controls\PasskeyFormControls
 	- MichalSpacekCz\Form\Controls\PasskeyAuthenticationControls
-	- MichalSpacekCz\Form\User\AccountEmailFormFactory
+	- MichalSpacekCz\Form\User\AccountNotificationEmailFormFactory
 	- MichalSpacekCz\Form\User\PasskeyAuthenticateFormFactory
 	- MichalSpacekCz\Form\User\PasskeyReauthenticateFormFactory
 	- MichalSpacekCz\Form\User\PasskeyDeleteFormFactory

--- a/app/db/default.sql
+++ b/app/db/default.sql
@@ -517,7 +517,7 @@ CREATE TABLE `users` (
   `id_user` int unsigned NOT NULL AUTO_INCREMENT,
   `username` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
   `passkey_user_handle` varbinary(64) NOT NULL,
-  `email` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
+  `notification_email` text CHARACTER SET utf8mb4 COLLATE utf8mb4_0900_ai_ci,
   PRIMARY KEY (`id_user`),
   UNIQUE KEY `username_UNIQUE` (`username`),
   UNIQUE KEY `passkey_user_handle` (`passkey_user_handle`)

--- a/app/src/Form/User/AccountNotificationEmailFormFactory.php
+++ b/app/src/Form/User/AccountNotificationEmailFormFactory.php
@@ -16,7 +16,7 @@ use MichalSpacekCz\User\WebAuthn\Authentication\ReauthKind;
 use Nette\Application\UI\Form;
 use Nette\Security\User;
 
-final readonly class AccountEmailFormFactory
+final readonly class AccountNotificationEmailFormFactory
 {
 
 	public function __construct(
@@ -39,23 +39,23 @@ final readonly class AccountEmailFormFactory
 	public function create(callable $onSuccess): Form
 	{
 		$form = $this->factory->create();
-		$email = $form->addEmail('email', $this->translator->translate('messages.account.email.label'))
-			->setRequired($this->translator->translate('messages.account.email.required'));
+		$email = $form->addEmail('notificationEmail', $this->translator->translate('messages.account.notificationEmail.label'))
+			->setRequired($this->translator->translate('messages.account.notificationEmail.required'));
 		$userId = $this->manager->getUserId($this->user);
-		$currentEmail = $this->userAccounts->getEmail($userId);
+		$currentEmail = $this->userAccounts->getNotificationEmail($userId);
 		if ($currentEmail !== null) {
 			$email->setDefaultValue($currentEmail);
 		}
-		$form->addSubmit('save', $this->translator->translate('messages.account.email.save'));
+		$form->addSubmit('save', $this->translator->translate('messages.account.notificationEmail.save'));
 		$form->setHtmlAttribute('data-error-element', 'passkeyReauthError');
-		$this->passkeyAuthenticationControls->addReauthTo($form, ReauthKind::Inline, SecurityEventType::EmailChanged);
+		$this->passkeyAuthenticationControls->addReauthTo($form, ReauthKind::Inline, SecurityEventType::NotificationEmailChanged);
 		$form->onSuccess[] = function (Form $form) use ($onSuccess, $userId): void {
 			$values = $form->getValues();
-			assert(is_string($values->email));
-			$oldEmail = $this->userAccounts->changeEmail($userId, $values->email);
-			if ($oldEmail !== $values->email) {
-				$this->notifier->emailChanged($oldEmail, $values->email);
-				$this->securityEventLogger->record($userId, SecurityEventType::EmailChanged, ['from' => $oldEmail, 'to' => $values->email]);
+			assert(is_string($values->notificationEmail));
+			$oldEmail = $this->userAccounts->changeNotificationEmail($userId, $values->notificationEmail);
+			if ($oldEmail !== $values->notificationEmail) {
+				$this->notifier->notificationEmailChanged($oldEmail, $values->notificationEmail);
+				$this->securityEventLogger->record($userId, SecurityEventType::NotificationEmailChanged, ['from' => $oldEmail, 'to' => $values->notificationEmail]);
 			}
 			$onSuccess();
 		};

--- a/app/src/Presentation/Admin/Account/AccountPresenter.php
+++ b/app/src/Presentation/Admin/Account/AccountPresenter.php
@@ -4,7 +4,7 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Presentation\Admin\Account;
 
 use Contributte\Translation\Translator;
-use MichalSpacekCz\Form\User\AccountEmailFormFactory;
+use MichalSpacekCz\Form\User\AccountNotificationEmailFormFactory;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Admin\BasePresenter;
@@ -15,7 +15,7 @@ final class AccountPresenter extends BasePresenter
 {
 
 	public function __construct(
-		private readonly AccountEmailFormFactory $accountEmailFormFactory,
+		private readonly AccountNotificationEmailFormFactory $accountNotificationEmailFormFactory,
 		private readonly Translator $translator,
 		private readonly SecurityActivity $securityActivity,
 	) {
@@ -39,11 +39,11 @@ final class AccountPresenter extends BasePresenter
 	}
 
 
-	protected function createComponentEmail(): Form
+	protected function createComponentNotificationEmail(): Form
 	{
-		return $this->accountEmailFormFactory->create(
+		return $this->accountNotificationEmailFormFactory->create(
 			function (): void {
-				$this->flashMessage($this->translator->translate('messages.account.email.saved'));
+				$this->flashMessage($this->translator->translate('messages.account.notificationEmail.saved'));
 				$this->redirect('this');
 			},
 		);

--- a/app/src/Presentation/Admin/Account/default.latte
+++ b/app/src/Presentation/Admin/Account/default.latte
@@ -1,7 +1,7 @@
 {define #content}
 <div n:foreach="$flashes as $flash" class="flash {$flash->type}"><strong>{$flash->message}</strong></div>
 <div id="passkeyReauthError" class="flash error hidden"><strong>{_messages.reauth.failed}</strong></div>
-<p>{_messages.account.email.help}</p>
-{control email}
+<p>{_messages.account.notificationEmail.help}</p>
+{control notificationEmail}
 <p><a n:href="securityLog">{_messages.account.securityLog.title}</a></p>
 {/define}

--- a/app/src/User/Notifications/UserSecurityNotifier.php
+++ b/app/src/User/Notifications/UserSecurityNotifier.php
@@ -18,8 +18,8 @@ use Tracy\Debugger;
 
 /**
  * Tells a user out of band when something security-sensitive happens to their account: a passkey is
- * added or reset, or the account email is changed. Best-effort: a delivery failure is logged but never
- * propagated, so it can't break the action that triggered it. A user with no email set is logged and skipped.
+ * added or reset, or the notification email is changed. Best-effort: a delivery failure is logged but never
+ * propagated, so it can't break the action that triggered it. A user with no notification email set is logged and skipped.
  */
 final readonly class UserSecurityNotifier
 {
@@ -41,9 +41,9 @@ final readonly class UserSecurityNotifier
 	public function passkeyAdded(int $userId, string $credentialName): void
 	{
 		try {
-			$address = $this->userAccounts->getEmail($userId);
+			$address = $this->userAccounts->getNotificationEmail($userId);
 			if ($address === null) {
-				$this->logNoEmail($userId);
+				$this->logNoNotificationEmail($userId);
 				return;
 			}
 			$template = $this->createTemplate('passkeyAdded');
@@ -61,9 +61,9 @@ final readonly class UserSecurityNotifier
 	public function passkeyReset(int $userId, string $credentialName, bool $otherAccessRevoked): void
 	{
 		try {
-			$address = $this->userAccounts->getEmail($userId);
+			$address = $this->userAccounts->getNotificationEmail($userId);
 			if ($address === null) {
-				$this->logNoEmail($userId);
+				$this->logNoNotificationEmail($userId);
 				return;
 			}
 			$template = $this->createTemplate('passkeyReset');
@@ -83,39 +83,39 @@ final readonly class UserSecurityNotifier
 	 * Alerts the old address (so a hostile change is loud to whoever is losing access) and confirms
 	 * to the new one.
 	 */
-	public function emailChanged(?string $oldAddress, string $newAddress): void
+	public function notificationEmailChanged(?string $oldAddress, string $newAddress): void
 	{
 		if ($oldAddress === $newAddress) {
 			return;
 		}
 		if ($oldAddress !== null) {
-			$this->sendEmailChangedAlert($oldAddress, $newAddress);
+			$this->sendNotificationEmailChangedAlert($oldAddress, $newAddress);
 		}
-		$this->sendEmailChangedConfirmation($newAddress);
+		$this->sendNotificationEmailChangedConfirmation($newAddress);
 	}
 
 
-	private function sendEmailChangedAlert(string $oldAddress, string $newAddress): void
+	private function sendNotificationEmailChangedAlert(string $oldAddress, string $newAddress): void
 	{
 		try {
-			$template = $this->createTemplate('emailChanged');
+			$template = $this->createTemplate('notificationEmailChanged');
 			$template->newAddress = $newAddress;
 			$template->when = $this->dateTimeFactory->create();
 			$template->ipAddress = $this->httpRequest->getRemoteAddress();
 			$template->reviewUrl = $this->linkGenerator->link('//:Admin:Account:default');
-			$this->send($oldAddress, 'messages.notifications.emailChanged.subject', $template);
+			$this->send($oldAddress, 'messages.notifications.notificationEmailChanged.subject', $template);
 		} catch (Throwable $e) {
 			Debugger::log($e, 'auth');
 		}
 	}
 
 
-	private function sendEmailChangedConfirmation(string $newAddress): void
+	private function sendNotificationEmailChangedConfirmation(string $newAddress): void
 	{
 		try {
-			$template = $this->createTemplate('emailChangedConfirmation');
+			$template = $this->createTemplate('notificationEmailChangedConfirmation');
 			$template->when = $this->dateTimeFactory->create();
-			$this->send($newAddress, 'messages.notifications.emailChangedConfirmation.subject', $template);
+			$this->send($newAddress, 'messages.notifications.notificationEmailChangedConfirmation.subject', $template);
 		} catch (Throwable $e) {
 			Debugger::log($e, 'auth');
 		}
@@ -142,9 +142,9 @@ final readonly class UserSecurityNotifier
 	}
 
 
-	private function logNoEmail(int $userId): void
+	private function logNoNotificationEmail(int $userId): void
 	{
-		Debugger::log("No email set for user {$userId}, skipping security notification", 'auth');
+		Debugger::log("No notification email set for user {$userId}, skipping security notification", 'auth');
 	}
 
 }

--- a/app/src/User/Notifications/templates/notificationEmailChanged.latte
+++ b/app/src/User/Notifications/templates/notificationEmailChanged.latte
@@ -3,11 +3,11 @@
 {varType \DateTimeImmutable $when}
 {varType string|null $ipAddress}
 {varType string $reviewUrl}
-{_messages.notifications.emailChanged.intro}
+{_messages.notifications.notificationEmailChanged.intro}
 
 {_messages.notifications.field.newAddress}: {$newAddress}
 {_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}
 {if $ipAddress !== null}{_messages.notifications.field.from}: {$ipAddress}{/if}
 
-{_messages.notifications.emailChanged.ifNotYou}
+{_messages.notifications.notificationEmailChanged.ifNotYou}
 {$reviewUrl}

--- a/app/src/User/Notifications/templates/notificationEmailChangedConfirmation.latte
+++ b/app/src/User/Notifications/templates/notificationEmailChangedConfirmation.latte
@@ -1,5 +1,5 @@
 {contentType text}
 {varType \DateTimeImmutable $when}
-{_messages.notifications.emailChangedConfirmation.intro}
+{_messages.notifications.notificationEmailChangedConfirmation.intro}
 
 {_messages.notifications.field.when}: {$when|localeDay} {$when|date:'H:i'}

--- a/app/src/User/SecurityActivity/SecurityEventType.php
+++ b/app/src/User/SecurityActivity/SecurityEventType.php
@@ -6,10 +6,11 @@ namespace MichalSpacekCz\User\SecurityActivity;
 /**
  * The kinds of security-relevant account events recorded in the security_events table.
  *
- * The string value is a permanent serialization contract: it's stored verbatim in the database and the
- * log is never garbage-collected, so old rows keep their value forever. Add new cases freely, but never
- * rename or repurpose an existing value, and read with tryFrom() so an unknown value from an older row
- * degrades to its raw string instead of throwing.
+ * The string value is stored verbatim in the database and the log is never garbage-collected, so old
+ * rows keep their value forever. Add new cases freely and never repurpose an existing value for a
+ * different meaning. Renaming a value is only safe together with a migration that updates the stored
+ * rows in the same deploy; read with tryFrom() so any un-migrated value from an older row degrades to
+ * its raw string instead of throwing.
  */
 enum SecurityEventType: string
 {
@@ -27,7 +28,7 @@ enum SecurityEventType: string
 	case ReauthInlineSuccess = 'reauth.inline.success';
 	case ReauthInlineFailure = 'reauth.inline.failure';
 	case ResetRevokeFailed = 'reset.revoke.failed';
-	case EmailChanged = 'email.changed';
+	case NotificationEmailChanged = 'notification.email.changed';
 	case PageViewed = 'page.viewed';
 
 

--- a/app/src/User/UserAccounts.php
+++ b/app/src/User/UserAccounts.php
@@ -9,7 +9,7 @@ use Nette\Database\Explorer;
 use Spaze\Encryption\SymmetricKeyEncryption;
 
 /**
- * A user's own account settings, with the email encrypted at rest like other emails in the app.
+ * A user's own account settings, with the notification email encrypted at rest like other emails in the app.
  */
 final readonly class UserAccounts
 {
@@ -23,10 +23,10 @@ final readonly class UserAccounts
 	}
 
 
-	public function getEmail(int $userId): ?string
+	public function getNotificationEmail(int $userId): ?string
 	{
 		$encrypted = $this->typedDatabase->fetchFieldStringNullable(
-			'SELECT email FROM ?name WHERE id_user = ?',
+			'SELECT notification_email FROM ?name WHERE id_user = ?',
 			$this->usersTableName,
 			$userId,
 		);
@@ -34,33 +34,33 @@ final readonly class UserAccounts
 	}
 
 
-	public function setEmail(int $userId, string $email): void
+	public function setNotificationEmail(int $userId, string $email): void
 	{
 		$this->database->query(
 			'UPDATE ?name SET ? WHERE id_user = ?',
 			$this->usersTableName,
-			['email' => $this->emailEncryption->encrypt($email)],
+			['notification_email' => $this->emailEncryption->encrypt($email)],
 			$userId,
 		);
 	}
 
 
 	/**
-	 * @return string|null The previous email
+	 * @return string|null The previous notification email
 	 */
-	public function changeEmail(int $userId, string $newEmail): ?string
+	public function changeNotificationEmail(int $userId, string $newEmail): ?string
 	{
 		$this->database->beginTransaction();
 		try {
-			// lock the row so the old email can't change between this read and the write below
+			// lock the row so the old notification email can't change between this read and the write below
 			$encryptedOld = $this->typedDatabase->fetchFieldStringNullable(
-				'SELECT email FROM ?name WHERE id_user = ? FOR UPDATE',
+				'SELECT notification_email FROM ?name WHERE id_user = ? FOR UPDATE',
 				$this->usersTableName,
 				$userId,
 			);
 			// decrypt before the write so an undecryptable old value rolls back rather than committing then throwing
 			$oldEmail = $encryptedOld !== null ? $this->emailEncryption->decrypt($encryptedOld) : null;
-			$this->setEmail($userId, $newEmail);
+			$this->setNotificationEmail($userId, $newEmail);
 			$this->database->commit();
 		} catch (Exception $e) {
 			$this->database->rollBack();

--- a/app/src/lang/messages.cs_CZ.neon
+++ b/app/src/lang/messages.cs_CZ.neon
@@ -407,11 +407,11 @@ forms:
 	validateSlugParamsEasterEgg: "%label nemůže být '%value', protože to spustí Easter egg"
 account:
 	title: "Váš účet"
-	email:
-		label: "E-mail:"
-		required: "Zadejte svůj e-mail"
-		save: "Uložit e-mail"
-		saved: "E-mail uložen"
+	notificationEmail:
+		label: "Notifikační e-mail:"
+		required: "Zadejte svůj notifikační e-mail"
+		save: "Uložit notifikační e-mail"
+		saved: "Notifikační e-mail uložen"
 		help: "Pro bezpečnostní upozornění k vašemu účtu"
 	securityLog:
 		title: "Bezpečnostní log"
@@ -435,7 +435,7 @@ account:
 			reauthInlineSuccess: "Potvrzení identity"
 			reauthInlineFailure: "Neúspěšné potvrzení identity"
 			resetRevokeFailed: "Odebrání ostatního přístupu po resetu selhalo"
-			emailChanged: "Změna e-mailu účtu"
+			notificationEmailChanged: "Změna notifikačního e-mailu"
 			pageViewed: "Zobrazení citlivé stránky"
 			unknown: "Neznámý typ"
 notifications:
@@ -454,13 +454,13 @@ notifications:
 		otherAccessRevoked: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení proběhlo úspěšně."
 		otherAccessRevokeFailed: "Odebrání vašich ostatních passkeys a odhlášení aktivních přihlášení se nepodařilo úplně dokončit, takže některé z nich mohou mít stále přístup k vašemu účtu."
 		ifNotYou: "Pokud jste o reset nežádali, váš účet může být kompromitován. Přihlaste se a zkontrolujte své passkeys:"
-	emailChanged:
-		subject: "E-mailová adresa vašeho účtu byla změněna"
-		intro: "E-mailová adresa vašeho účtu byla změněna."
-		ifNotYou: "Pokud jste ji neměnili vy, váš účet může být kompromitován. Přihlaste se a zkontrolujte svůj účet:"
-	emailChangedConfirmation:
-		subject: "Toto je nyní e-mailová adresa vašeho účtu"
-		intro: "Tato adresa je nyní e-mailovou adresou vašeho účtu."
+	notificationEmailChanged:
+		subject: "Váš notifikační e-mail byl změněn"
+		intro: "Váš notifikační e-mail byl změněn."
+		ifNotYou: "Pokud jste ho neměnili vy, váš účet může být kompromitován. Přihlaste se a zkontrolujte svůj účet:"
+	notificationEmailChangedConfirmation:
+		subject: "Toto je nyní váš notifikační e-mail"
+		intro: "Tato adresa je nyní vaším notifikačním e-mailem."
 reauth:
 	title: "Potvrďte, že jste to vy"
 	prompt: "Pro pokračování potvrďte svou identitu pomocí passkey"

--- a/app/src/lang/messages.en_US.neon
+++ b/app/src/lang/messages.en_US.neon
@@ -407,12 +407,12 @@ forms:
 	validateSlugParamsEasterEgg: "%label can't be '%value', because that's used by an Easter egg"
 account:
 	title: "Your account"
-	email:
-		label: "Email:"
-		required: "Enter your email"
-		save: "Save email"
-		saved: "Email saved"
-		help: "Used for security alerts about your account"
+	notificationEmail:
+		label: "Notification email:"
+		required: "Enter your notification email"
+		save: "Save notification email"
+		saved: "Notification email saved"
+		help: "Used for security notifications about your account"
 	securityLog:
 		title: "Security log"
 		empty: "No events yet"
@@ -435,7 +435,7 @@ account:
 			reauthInlineSuccess: "Identity confirmed"
 			reauthInlineFailure: "Failed identity confirmation"
 			resetRevokeFailed: "Revoking other access after reset failed"
-			emailChanged: "Account email changed"
+			notificationEmailChanged: "Notification email changed"
 			pageViewed: "Sensitive page viewed"
 			unknown: "Unknown type"
 notifications:
@@ -454,13 +454,13 @@ notifications:
 		otherAccessRevoked: "Your other passkeys were removed and your active sessions signed out."
 		otherAccessRevokeFailed: "Your other passkeys couldn't all be removed or your active sessions signed out, so some may still have access to your account."
 		ifNotYou: "If you didn't request this, your account may be compromised. Sign in and review your passkeys:"
-	emailChanged:
-		subject: "Your account email was changed"
-		intro: "Your account email was changed."
+	notificationEmailChanged:
+		subject: "Your notification email was changed"
+		intro: "Your notification email was changed."
 		ifNotYou: "If you didn't change it, your account may be compromised. Sign in and review your account:"
-	emailChangedConfirmation:
-		subject: "This is now your account email"
-		intro: "This address is now the email for your account."
+	notificationEmailChangedConfirmation:
+		subject: "This is now your notification email"
+		intro: "This address is now your notification email."
 reauth:
 	title: "Confirm it's you"
 	prompt: "Confirm it's you with your passkey to continue"

--- a/app/tests/Form/Controls/PasskeyAuthenticationControlsTest.phpt
+++ b/app/tests/Form/Controls/PasskeyAuthenticationControlsTest.phpt
@@ -124,20 +124,20 @@ final class PasskeyAuthenticationControlsTest extends TestCase
 	public function testInlineRecordsTheGuardedOperation(): void
 	{
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
-		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::EmailChanged);
+		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::NotificationEmailChanged);
 
 		Arrays::invoke($form->onValidate, $form);
 
 		$encrypted = $this->database->getParamsArrayForQuery(self::INSERT)[0]['details'];
 		assert(is_string($encrypted));
-		Assert::same(['operation' => 'email.changed', 'passkey' => 'My Passkey', 'interval' => '5 minutes'], $this->decodeDetails($encrypted));
+		Assert::same(['operation' => 'notification.email.changed', 'passkey' => 'My Passkey', 'interval' => '5 minutes'], $this->decodeDetails($encrypted));
 	}
 
 
 	public function testFailedReauthStillNamesTheGuardedOperation(): void
 	{
 		$this->passkeyAuthenticator->willThrow(new PasskeyAuthenticationUnknownCredentialException('foo'));
-		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::EmailChanged);
+		$form = $this->createForm(ReauthKind::Inline, SecurityEventType::NotificationEmailChanged);
 
 		Arrays::invoke($form->onValidate, $form);
 
@@ -145,7 +145,7 @@ final class PasskeyAuthenticationControlsTest extends TestCase
 		Assert::same('reauth.inline.failure', $params[0]['action']);
 		$encrypted = $params[0]['details'];
 		assert(is_string($encrypted));
-		Assert::same(['operation' => 'email.changed'], $this->decodeDetails($encrypted));
+		Assert::same(['operation' => 'notification.email.changed'], $this->decodeDetails($encrypted));
 	}
 
 

--- a/app/tests/Form/User/AccountNotificationEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountNotificationEmailFormFactoryTest.phpt
@@ -32,14 +32,14 @@ require __DIR__ . '/../../bootstrap.php';
  *
  * @testCase
  */
-final class AccountEmailFormFactoryTest extends TestCase
+final class AccountNotificationEmailFormFactoryTest extends TestCase
 {
 
 	private bool $onSuccessCalled = false;
 
 
 	public function __construct(
-		private readonly AccountEmailFormFactory $formFactory,
+		private readonly AccountNotificationEmailFormFactory $formFactory,
 		private readonly ApplicationPresenter $applicationPresenter,
 		private readonly PasskeyAuthenticatorMock $passkeyAuthenticator,
 		private readonly PasskeySessionSection $session,
@@ -76,12 +76,12 @@ final class AccountEmailFormFactoryTest extends TestCase
 
 		Assert::true($this->onSuccessCalled);
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		Assert::notSame('me@example.com', $stored); // stored encrypted, never plaintext
 		Assert::same(['me@example.com' => null], $this->mailer->getMail()->getHeader('To')); // first-set confirms the new address
 		$events = array_map(fn(array $e): mixed => $e['action'], $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
-		Assert::contains('email.changed', $events); // recorded alongside the inline reauth event
+		Assert::contains('notification.email.changed', $events); // recorded alongside the inline reauth event
 	}
 
 
@@ -89,7 +89,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 	{
 		$this->user->login(new SimpleIdentity(42));
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
-		$this->seedCurrentEmail('old@example.com');
+		$this->seedCurrentNotificationEmail('old@example.com');
 		$form = $this->createForm('new@example.com', '{"id":"test","type":"public-key"}');
 
 		Arrays::invoke($form->onValidate, $form);
@@ -123,7 +123,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
 		$this->database->setFetchFieldDefaultResult(null);
 		$form = $this->createForm('new@example.com', '{"id":"test","type":"public-key"}');
-		$email = $form->getComponent('email');
+		$email = $form->getComponent('notificationEmail');
 		assert($email instanceof TextInput);
 		$email->addError('some other control failed validation');
 
@@ -140,7 +140,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 	{
 		$this->user->login(new SimpleIdentity(42));
 		$this->passkeyAuthenticator->setAuthenticationResult(new PasskeyAuthenticationResult(42, 'foo', 'cred-id', 'My Passkey'));
-		$this->seedCurrentEmail('me@example.com');
+		$this->seedCurrentNotificationEmail('me@example.com');
 		$form = $this->createForm('me@example.com', '{"id":"test","type":"public-key"}');
 
 		Arrays::invoke($form->onValidate, $form);
@@ -149,7 +149,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 		Assert::true($this->onSuccessCalled);
 		Assert::count(0, $this->mailer->getAllMails()); // resubmitting the same address notifies no one
 		$events = array_map(fn(array $e): mixed => $e['action'], $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
-		Assert::notContains('email.changed', $events); // and records no email-change event
+		Assert::notContains('notification.email.changed', $events); // and records no notification-email-change event
 	}
 
 
@@ -162,13 +162,13 @@ final class AccountEmailFormFactoryTest extends TestCase
 	}
 
 
-	private function seedCurrentEmail(string $address): void
+	private function seedCurrentNotificationEmail(string $address): void
 	{
-		$this->userAccounts->setEmail(42, $address);
+		$this->userAccounts->setNotificationEmail(42, $address);
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
-		$this->database->setFetchFieldDefaultResult($stored); // every getEmail() returns the seeded address until overwritten
+		$this->database->setFetchFieldDefaultResult($stored); // every getNotificationEmail() returns the seeded address until overwritten
 	}
 
 
@@ -178,7 +178,7 @@ final class AccountEmailFormFactoryTest extends TestCase
 			$this->onSuccessCalled = true;
 		});
 		$this->applicationPresenter->anchorForm($form);
-		$emailField = $form->getComponent('email');
+		$emailField = $form->getComponent('notificationEmail');
 		assert($emailField instanceof TextInput);
 		$emailField->setDefaultValue($email);
 		$credentialField = $form->getComponent('credential');
@@ -189,4 +189,4 @@ final class AccountEmailFormFactoryTest extends TestCase
 
 }
 
-TestCaseRunner::run(AccountEmailFormFactoryTest::class);
+TestCaseRunner::run(AccountNotificationEmailFormFactoryTest::class);

--- a/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
+++ b/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
@@ -39,7 +39,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testPasskeyAddedEmailsTheUser(): void
 	{
-		$this->seedEmail(42, 'owner@example.com');
+		$this->seedNotificationEmail(42, 'owner@example.com');
 
 		$this->notifier->passkeyAdded(42, '42Password <3');
 
@@ -52,7 +52,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testPasskeyResetEmailsTheUserAndConfirmsOtherAccessWasRevoked(): void
 	{
-		$this->seedEmail(42, 'owner@example.com');
+		$this->seedNotificationEmail(42, 'owner@example.com');
 
 		$this->notifier->passkeyReset(42, '42Password <3', true);
 
@@ -65,7 +65,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testPasskeyResetTellsTheUserWhenOtherAccessCouldNotBeRevoked(): void
 	{
-		$this->seedEmail(42, 'owner@example.com');
+		$this->seedNotificationEmail(42, 'owner@example.com');
 
 		$this->notifier->passkeyReset(42, '42Password <3', false);
 
@@ -85,7 +85,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testRecipientLookupFailureIsSwallowed(): void
 	{
-		$this->database->setFetchFieldDefaultResult('not-a-valid-ciphertext'); // getEmail()'s decryption throws
+		$this->database->setFetchFieldDefaultResult('not-a-valid-ciphertext'); // getNotificationEmail()'s decryption throws
 
 		$this->notifier->passkeyAdded(42, '42Password <3'); // best-effort: the failure must not propagate
 
@@ -95,7 +95,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testEmailChangeAlertsTheOldAddressAndConfirmsTheNew(): void
 	{
-		$this->notifier->emailChanged('old@example.com', 'new@example.com');
+		$this->notifier->notificationEmailChanged('old@example.com', 'new@example.com');
 
 		$mails = $this->mailer->getAllMails();
 		Assert::count(2, $mails);
@@ -111,7 +111,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testFirstEmailSetOnlyConfirmsTheNewAddress(): void
 	{
-		$this->notifier->emailChanged(null, 'new@example.com');
+		$this->notifier->notificationEmailChanged(null, 'new@example.com');
 
 		$mails = $this->mailer->getAllMails();
 		Assert::count(1, $mails);
@@ -121,7 +121,7 @@ final class UserSecurityNotifierTest extends TestCase
 
 	public function testUnchangedEmailNotifiesNothing(): void
 	{
-		$this->notifier->emailChanged('same@example.com', 'same@example.com');
+		$this->notifier->notificationEmailChanged('same@example.com', 'same@example.com');
 
 		Assert::count(0, $this->mailer->getAllMails());
 	}
@@ -131,7 +131,7 @@ final class UserSecurityNotifierTest extends TestCase
 	{
 		$this->mailer->willThrowOnce(new SendException('alert delivery failed')); // only the first send, the alert
 
-		$this->notifier->emailChanged('old@example.com', 'new@example.com'); // best-effort: must not propagate
+		$this->notifier->notificationEmailChanged('old@example.com', 'new@example.com'); // best-effort: must not propagate
 
 		$mails = $this->mailer->getAllMails();
 		Assert::count(1, $mails); // the failed alert is swallowed and doesn't suppress the confirmation
@@ -139,11 +139,11 @@ final class UserSecurityNotifierTest extends TestCase
 	}
 
 
-	private function seedEmail(int $userId, string $address): void
+	private function seedNotificationEmail(int $userId, string $address): void
 	{
-		$this->userAccounts->setEmail($userId, $address);
+		$this->userAccounts->setNotificationEmail($userId, $address);
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->addFetchFieldResult($stored);
 	}

--- a/app/tests/User/SecurityActivity/SecurityEventLoggerTest.phpt
+++ b/app/tests/User/SecurityActivity/SecurityEventLoggerTest.phpt
@@ -73,7 +73,7 @@ final class SecurityEventLoggerTest extends TestCase
 	{
 		$this->database->willThrow(new Exception('database is down'));
 		Assert::noError(function (): void {
-			$this->securityEventLogger->record(42, SecurityEventType::EmailChanged, ['to' => 'new@example.com']);
+			$this->securityEventLogger->record(42, SecurityEventType::NotificationEmailChanged, ['to' => 'new@example.com']);
 		});
 	}
 

--- a/app/tests/User/UserAccountsTest.phpt
+++ b/app/tests/User/UserAccountsTest.phpt
@@ -32,56 +32,56 @@ final class UserAccountsTest extends TestCase
 	}
 
 
-	public function testGetEmailNullWhenUnset(): void
+	public function testGetNotificationEmailNullWhenUnset(): void
 	{
 		$this->database->setFetchFieldDefaultResult(null);
-		Assert::null($this->userAccounts->getEmail(42));
+		Assert::null($this->userAccounts->getNotificationEmail(42));
 	}
 
 
-	public function testEmailIsStoredEncryptedAndReadBackDecrypted(): void
+	public function testNotificationEmailIsStoredEncryptedAndReadBackDecrypted(): void
 	{
-		$this->userAccounts->setEmail(42, 'me@example.com');
+		$this->userAccounts->setNotificationEmail(42, 'me@example.com');
 
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		Assert::notSame('me@example.com', $stored); // stored as ciphertext, never plaintext
 
 		$this->database->setFetchFieldDefaultResult($stored);
-		Assert::same('me@example.com', $this->userAccounts->getEmail(42)); // decrypts back to the original
+		Assert::same('me@example.com', $this->userAccounts->getNotificationEmail(42)); // decrypts back to the original
 	}
 
 
-	public function testChangeEmailReturnsOldAndWritesNewInOneTransaction(): void
+	public function testChangeNotificationEmailReturnsOldAndWritesNewInOneTransaction(): void
 	{
-		$this->userAccounts->setEmail(42, 'old@example.com');
-		$encryptedOld = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['email'];
+		$this->userAccounts->setNotificationEmail(42, 'old@example.com');
+		$encryptedOld = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['notification_email'];
 		assert(is_string($encryptedOld));
 		$this->database->reset();
 		$this->database->setFetchFieldDefaultResult($encryptedOld); // the locked read returns the old ciphertext
 
-		$old = $this->userAccounts->changeEmail(42, 'new@example.com');
+		$old = $this->userAccounts->changeNotificationEmail(42, 'new@example.com');
 
-		Assert::same('old@example.com', $old); // previous email, decrypted from the locked read
+		Assert::same('old@example.com', $old); // previous notification email, decrypted from the locked read
 		Assert::same(DatabaseTransactionStatus::Committed, $this->database->transactionStatus); // read + write committed together
-		$stored = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['email'];
+		$stored = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['notification_email'];
 		assert(is_string($stored));
-		Assert::notSame('new@example.com', $stored); // new email stored encrypted
+		Assert::notSame('new@example.com', $stored); // new notification email stored encrypted
 	}
 
 
-	public function testChangeEmailRollsBackWhenOldValueCannotBeDecrypted(): void
+	public function testChangeNotificationEmailRollsBackWhenOldValueCannotBeDecrypted(): void
 	{
 		$this->database->setFetchFieldDefaultResult('not-a-valid-ciphertext'); // the locked read returns an undecryptable old value
 
 		Assert::exception(function (): void {
-			$this->userAccounts->changeEmail(42, 'new@example.com');
+			$this->userAccounts->changeNotificationEmail(42, 'new@example.com');
 		}, InvalidNumberOfComponentsException::class);
 
-		// the old value is decrypted before the write, so a bad one aborts the transaction instead of committing the new email then throwing
+		// the old value is decrypted before the write, so a bad one aborts the transaction instead of committing the new notification email then throwing
 		Assert::same(DatabaseTransactionStatus::RolledBack, $this->database->transactionStatus);
-		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')); // the new email was never written
+		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')); // the new notification email was never written
 	}
 
 }

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -114,7 +114,7 @@ final class PasskeyAddTest extends TestCase
 	{
 		$userId = 1337;
 		$this->setUpToken(42, $userId, 'foo');
-		$this->seedEmail($userId, 'owner@example.com');
+		$this->seedNotificationEmail($userId, 'owner@example.com');
 
 		$this->createPasskeyAdd()->register('{"id":"test","type":"public-key"}', 'My Passkey', 'selector:secret');
 
@@ -122,11 +122,11 @@ final class PasskeyAddTest extends TestCase
 	}
 
 
-	private function seedEmail(int $userId, string $address): void
+	private function seedNotificationEmail(int $userId, string $address): void
 	{
-		$this->userAccounts->setEmail($userId, $address);
+		$this->userAccounts->setNotificationEmail($userId, $address);
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->setFetchFieldDefaultResult($stored);
 	}

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
@@ -100,7 +100,7 @@ final class PasskeyResetTest extends TestCase
 		$userId = 1337;
 		$this->setUpToken(42, $userId, 'foo');
 		$this->database->addFetchFieldResult(1); // the revoke's kept-credential check runs before the notify, so it consumes this first
-		$this->seedEmail($userId, 'owner@example.com'); // then the notify's getEmail() reads the queued ciphertext
+		$this->seedNotificationEmail($userId, 'owner@example.com'); // then the notify's getNotificationEmail() reads the queued ciphertext
 
 		$this->createPasskeyReset()->register('{"id":"test","type":"public-key"}', 'My Passkey', 'selector:secret');
 
@@ -108,11 +108,11 @@ final class PasskeyResetTest extends TestCase
 	}
 
 
-	private function seedEmail(int $userId, string $address): void
+	private function seedNotificationEmail(int $userId, string $address): void
 	{
-		$this->userAccounts->setEmail($userId, $address);
+		$this->userAccounts->setNotificationEmail($userId, $address);
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
-		$stored = $params[0]['email'];
+		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->addFetchFieldResult($stored);
 	}


### PR DESCRIPTION
The column and the `EmailChanged` security event only ever concerned the address used for security notifications about the account, but naming them `email` / `email.changed` read like a login or identity email and made readers (and LLMs) treat them as more load-bearing than they are.

Renames the column, the `UserAccounts` accessors, the form factory and its control, the translation keys, the user-facing text (labels included), and the `EmailChanged` event through and through: the enum case and value, the notifier methods, the notification templates, and the log label key.

Not backward compatible, so both migrations run with this deploy:

```sql
ALTER TABLE users RENAME COLUMN email TO notification_email;
UPDATE security_events SET action = 'notification.email.changed' WHERE action = 'email.changed';
```