### PR TITLE
Explain the permanent-login cookie's `__Secure-` prefix

### DIFF
--- a/app/src/User/PermanentLogin/PermanentLogin.php
+++ b/app/src/User/PermanentLogin/PermanentLogin.php
@@ -111,6 +111,7 @@ final readonly class PermanentLogin implements UserAuthTokenLifetime
 
 	private function setCookie(string $value): void
 	{
+		// Uses the __Secure- cookie prefix because __Host- requires Path=/, but this cookie is intentionally path-scoped to the sign-in path
 		$this->cookies->set(CookieName::PermanentLogin, $value, $this->interval, $this->authCookiesPath, sameSite: 'Strict');
 	}
 


### PR DESCRIPTION
Record why the permanent-login cookie uses `__Secure-` rather than the stricter `__Host-`: the cookie is deliberately path-scoped to the sign-in endpoint, and `__Host-` would force `Path=/`. Host-only scoping is preserved by never passing a domain.