### PR TITLE
Scope auth-token `deleteById()` to the owning user

### DIFF
--- a/app/src/User/AuthTokens/UserAuthTokens.php
+++ b/app/src/User/AuthTokens/UserAuthTokens.php
@@ -115,9 +115,9 @@ final readonly class UserAuthTokens
 	}
 
 
-	public function deleteById(int $tokenId, UserAuthTokenType $type): int
+	public function deleteById(int $tokenId, UserAuthTokenType $type, int $userId): int
 	{
-		return $this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?', $tokenId, $type->value)->getRowCount() ?? 0;
+		return $this->database->query('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ? AND key_user = ?', $tokenId, $type->value, $userId)->getRowCount() ?? 0;
 	}
 
 

--- a/app/src/User/WebAuthn/Registration/PasskeyAddTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyAddTokens.php
@@ -85,9 +85,9 @@ final readonly class PasskeyAddTokens implements UserAuthTokenLifetime, PasskeyR
 
 
 	#[Override]
-	public function deleteById(int $tokenId): int
+	public function deleteById(int $tokenId, int $userId): int
 	{
-		return $this->tokens->deleteById($tokenId, $this->getTokenType());
+		return $this->tokens->deleteById($tokenId, $this->getTokenType(), $userId);
 	}
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistration.php
@@ -103,7 +103,7 @@ abstract readonly class PasskeyRegistration
 
 	private function consumeToken(UserAuthToken $userAuthToken): bool
 	{
-		return $this->registrationTokens->deleteById($userAuthToken->getId()) > 0;
+		return $this->registrationTokens->deleteById($userAuthToken->getId(), $userAuthToken->getUserId()) > 0;
 	}
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyRegistrationTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyRegistrationTokens.php
@@ -37,6 +37,6 @@ interface PasskeyRegistrationTokens
 	public function verify(string $value): ?UserAuthToken;
 
 
-	public function deleteById(int $tokenId): int;
+	public function deleteById(int $tokenId, int $userId): int;
 
 }

--- a/app/src/User/WebAuthn/Registration/PasskeyResetTokens.php
+++ b/app/src/User/WebAuthn/Registration/PasskeyResetTokens.php
@@ -80,9 +80,9 @@ final readonly class PasskeyResetTokens implements UserAuthTokenLifetime, Passke
 
 
 	#[Override]
-	public function deleteById(int $tokenId): int
+	public function deleteById(int $tokenId, int $userId): int
 	{
-		return $this->tokens->deleteById($tokenId, $this->getTokenType());
+		return $this->tokens->deleteById($tokenId, $this->getTokenType(), $userId);
 	}
 
 }

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -66,8 +66,8 @@ final class PasskeyAddTest extends TestCase
 		Assert::same('mockPasskeyCredentialId', $result->keepCredentialId);
 		Assert::null($result->revokeFailure); // add keeps the user's other passkeys, so it never revokes
 		Assert::same(
-			[$tokenId, UserAuthTokenType::AdminPasskeyAdd->value],
-			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),
+			[$tokenId, UserAuthTokenType::AdminPasskeyAdd->value, $userId],
+			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ? AND key_user = ?'),
 		);
 		Assert::same('passkey.add.finished', $this->database->getParamsArrayForQuery('INSERT INTO security_events')[0]['action']);
 	}

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTokensTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTokensTest.phpt
@@ -85,13 +85,13 @@ final class PasskeyAddTokensTest extends TestCase
 	}
 
 
-	public function testDeleteByIdQueriesAdminAddType(): void
+	public function testDeleteByIdQueriesAdminAddTypeScopedToUser(): void
 	{
 		$this->database->setResultSet(new ResultSet(1));
-		Assert::same(1, $this->getTokens(true)->deleteById(42));
+		Assert::same(1, $this->getTokens(true)->deleteById(42, 1337));
 		Assert::same(
-			[42, UserAuthTokenType::AdminPasskeyAdd->value],
-			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),
+			[42, UserAuthTokenType::AdminPasskeyAdd->value, 1337],
+			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ? AND key_user = ?'),
 		);
 	}
 

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTokensTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTokensTest.phpt
@@ -85,13 +85,13 @@ final class PasskeyResetTokensTest extends TestCase
 	}
 
 
-	public function testDeleteByIdQueriesAdminResetType(): void
+	public function testDeleteByIdQueriesAdminResetTypeScopedToUser(): void
 	{
 		$this->database->setResultSet(new ResultSet(1));
-		Assert::same(1, $this->getTokens(true)->deleteById(42));
+		Assert::same(1, $this->getTokens(true)->deleteById(42, 1337));
 		Assert::same(
-			[42, UserAuthTokenType::AdminPasskeyReset->value],
-			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ?'),
+			[42, UserAuthTokenType::AdminPasskeyReset->value, 1337],
+			$this->database->getParamsForQuery('DELETE FROM auth_tokens WHERE id_auth_token = ? AND type = ? AND key_user = ?'),
 		);
 	}
 


### PR DESCRIPTION
`UserAuthTokens::deleteById()` deleted by token id and type only, with no `key_user` predicate, unlike its user-keyed siblings. It is safe today because the only caller consumes a token whose secret was just verified, so the id is never attacker-chosen.

Adding the owning user's id to the predicate makes single-use token consumption correct by construction rather than by caller discipline: a future caller that ever forwarded a request-supplied id could not delete another user's token.