### PR TITLE
Require API endpoints to declare their access

### DIFF
--- a/app/src/Api/Endpoint/EndpointAccess.php
+++ b/app/src/Api/Endpoint/EndpointAccess.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+use MichalSpacekCz\Presentation\Api\BasePresenter;
+use ReflectionAttribute;
+use ReflectionClass;
+
+final class EndpointAccess
+{
+
+	/**
+	 * Whether the endpoint declares its access with exactly one EndpointAccessAttribute. False for none
+	 * (undeclared) or more than one (a contradictory declaration).
+	 */
+	public static function isDeclared(BasePresenter $presenter): bool
+	{
+		return count(new ReflectionClass($presenter)->getAttributes(EndpointAccessAttribute::class, ReflectionAttribute::IS_INSTANCEOF)) === 1;
+	}
+
+}

--- a/app/src/Api/Endpoint/EndpointAccessAttribute.php
+++ b/app/src/Api/Endpoint/EndpointAccessAttribute.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+/**
+ * Implemented by attributes that declare an API endpoint's access. EndpointAccess::isDeclared() matches any
+ * implementer via IS_INSTANCEOF, so a new access attribute needs no change to the check or base presenter.
+ */
+interface EndpointAccessAttribute
+{
+}

--- a/app/src/Api/Endpoint/EndpointAllowsPublicAccess.php
+++ b/app/src/Api/Endpoint/EndpointAllowsPublicAccess.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+use Attribute;
+
+/**
+ * Marks an API endpoint intentionally reachable without auth; the deliberate opt-out from the base presenter's default-deny.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class EndpointAllowsPublicAccess implements EndpointAccessAttribute
+{
+}

--- a/app/src/Api/Endpoint/EndpointRequiresAuthentication.php
+++ b/app/src/Api/Endpoint/EndpointRequiresAuthentication.php
@@ -1,0 +1,14 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+use Attribute;
+
+/**
+ * Marks an API endpoint that requires authentication — enforced by the endpoint itself, only declared by this attribute.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class EndpointRequiresAuthentication implements EndpointAccessAttribute
+{
+}

--- a/app/src/Api/Endpoint/NotAnEndpoint.php
+++ b/app/src/Api/Endpoint/NotAnEndpoint.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+use Attribute;
+
+/**
+ * Marks a presenter under the Api module that is not a routed endpoint (e.g. a framework error presenter),
+ * so it is exempt from the access declaration real endpoints must carry.
+ *
+ * Deliberately not an EndpointAccessAttribute, so the gate can't mistake it for a real one.
+ */
+#[Attribute(Attribute::TARGET_CLASS)]
+final class NotAnEndpoint
+{
+}

--- a/app/src/Presentation/Api/BasePresenter.php
+++ b/app/src/Presentation/Api/BasePresenter.php
@@ -3,9 +3,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Api;
 
+use MichalSpacekCz\Api\Endpoint\EndpointAccess;
+use MichalSpacekCz\Api\Endpoint\EndpointAccessAttribute;
 use MichalSpacekCz\Http\Robots\Robots;
 use MichalSpacekCz\Http\Robots\RobotsRule;
 use MichalSpacekCz\Presentation\Www\BasePresenter as WwwBasePresenter;
+use Nette\Application\BadRequestException;
+use Nette\Http\IResponse;
 use Override;
 
 abstract class BasePresenter extends WwwBasePresenter
@@ -24,10 +28,34 @@ abstract class BasePresenter extends WwwBasePresenter
 
 
 	#[Override]
-	protected function startup(): void
+	final protected function startup(): void
 	{
 		parent::startup();
 		$this->robots->setHeader([RobotsRule::NoIndex, RobotsRule::NoFollow]);
+		$this->checkAccessAttribute();
+		$this->startupApi();
+	}
+
+
+	/**
+	 * Runs after the access check; override this instead of startup().
+	 */
+	protected function startupApi(): void
+	{
+	}
+
+
+	/**
+	 * Require exactly one access attribute (one implementing EndpointAccessAttribute), so a newly added
+	 * presenter is closed by default (none declared) and a contradictory declaration (more than one) is rejected.
+	 *
+	 * @throws BadRequestException
+	 */
+	private function checkAccessAttribute(): void
+	{
+		if (!EndpointAccess::isDeclared($this)) {
+			throw new BadRequestException(sprintf('%s must declare exactly one access attribute implementing %s', $this::class, EndpointAccessAttribute::class), IResponse::S403_Forbidden);
+		}
 	}
 
 }

--- a/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
+++ b/app/src/Presentation/Api/Certificates/CertificatesPresenter.php
@@ -3,6 +3,7 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Api\Certificates;
 
+use MichalSpacekCz\Api\Endpoint\EndpointRequiresAuthentication;
 use MichalSpacekCz\Http\HttpInput;
 use MichalSpacekCz\Presentation\Api\BasePresenter;
 use MichalSpacekCz\Tls\CertificateFactory;
@@ -13,6 +14,7 @@ use Override;
 use Throwable;
 use Tracy\Debugger;
 
+#[EndpointRequiresAuthentication]
 final class CertificatesPresenter extends BasePresenter
 {
 
@@ -26,9 +28,8 @@ final class CertificatesPresenter extends BasePresenter
 
 
 	#[Override]
-	protected function startup(): void
+	protected function startupApi(): void
 	{
-		parent::startup();
 		try {
 			$this->certificates->authenticate($this->httpInput->getPostString('user') ?? '', $this->httpInput->getPostString('key') ?? '');
 		} catch (AuthenticationException) {

--- a/app/src/Presentation/Api/Company/CompanyPresenter.php
+++ b/app/src/Presentation/Api/Company/CompanyPresenter.php
@@ -3,12 +3,14 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Api\Company;
 
+use MichalSpacekCz\Api\Endpoint\EndpointAllowsPublicAccess;
 use MichalSpacekCz\CompanyInfo\CompanyInfo;
 use MichalSpacekCz\Http\FetchMetadata\ResourceIsolationPolicyCrossSite;
 use MichalSpacekCz\Http\SecurityHeaders\CrossOriginResourceSharing;
 use MichalSpacekCz\Presentation\Api\BasePresenter;
 use Nette\Application\BadRequestException;
 
+#[EndpointAllowsPublicAccess]
 final class CompanyPresenter extends BasePresenter
 {
 

--- a/app/src/Presentation/Api/Error/ErrorPresenter.php
+++ b/app/src/Presentation/Api/Error/ErrorPresenter.php
@@ -3,10 +3,12 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Api\Error;
 
+use MichalSpacekCz\Api\Endpoint\NotAnEndpoint;
 use MichalSpacekCz\Presentation\Www\BaseErrorPresenter;
 use Nette\Application\BadRequestException;
 use Nette\Http\IResponse;
 
+#[NotAnEndpoint]
 final class ErrorPresenter extends BaseErrorPresenter
 {
 

--- a/app/src/Presentation/Api/ErrorGeneric/ErrorGenericPresenter.php
+++ b/app/src/Presentation/Api/ErrorGeneric/ErrorGenericPresenter.php
@@ -3,12 +3,14 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Presentation\Api\ErrorGeneric;
 
+use MichalSpacekCz\Api\Endpoint\NotAnEndpoint;
 use MichalSpacekCz\Application\Error\AppError;
 use Nette\Application\IPresenter;
 use Nette\Application\Request;
 use Nette\Application\Response;
 use Override;
 
+#[NotAnEndpoint]
 final readonly class ErrorGenericPresenter implements IPresenter
 {
 

--- a/app/tests/Api/Endpoint/EndpointAccessTest.phpt
+++ b/app/tests/Api/Endpoint/EndpointAccessTest.phpt
@@ -1,0 +1,100 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Api\Endpoint;
+
+use MichalSpacekCz\Presentation\Api\BasePresenter;
+use MichalSpacekCz\Presentation\Api\Certificates\CertificatesPresenter;
+use MichalSpacekCz\Presentation\Api\Company\CompanyPresenter;
+use MichalSpacekCz\Test\TestCaseRunner;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+use SplFileInfo;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class EndpointAccessTest extends TestCase
+{
+
+	/**
+	 * Every concrete presenter under the Api module is either a gated endpoint (extends the base and declares
+	 * exactly one access attribute) or explicitly #[NotAnEndpoint]; a mis-based or undeclared one fails here.
+	 */
+	public function testEveryApiPresenterIsGatedOrMarkedNotAnEndpoint(): void
+	{
+		$gated = [];
+		foreach ($this->findApiPresenterClasses() as $class) {
+			$reflection = new ReflectionClass($class);
+			if ($reflection->isAbstract()) {
+				continue; // the Api base presenter itself
+			}
+			if (is_subclass_of($class, BasePresenter::class)) {
+				$gated[] = $class;
+				Assert::count(1, $reflection->getAttributes(EndpointAccessAttribute::class, ReflectionAttribute::IS_INSTANCEOF), "{$class} must declare exactly one access attribute");
+			} else {
+				Assert::count(1, $reflection->getAttributes(NotAnEndpoint::class), "{$class} is under Presentation/Api but does not extend its BasePresenter, so the access gate never runs for it; mark it #[NotAnEndpoint] or extend the base");
+			}
+		}
+		Assert::contains(CompanyPresenter::class, $gated);
+		Assert::contains(CertificatesPresenter::class, $gated);
+	}
+
+
+	public function testIsDeclaredIsTrueForExactlyOneAccessAttribute(): void
+	{
+		$one = new #[EndpointAllowsPublicAccess] class extends BasePresenter {
+		};
+		$two = new #[EndpointAllowsPublicAccess] #[EndpointRequiresAuthentication] class extends BasePresenter {
+		};
+		$none = new class extends BasePresenter {
+		};
+		Assert::true(EndpointAccess::isDeclared($one)); // exactly one access attribute
+		Assert::false(EndpointAccess::isDeclared($two)); // two -> not exactly one
+		Assert::false(EndpointAccess::isDeclared($none)); // none declared
+	}
+
+
+	public function testBaseStartupIsFinalSoTheAccessCheckCannotBeSkipped(): void
+	{
+		Assert::true(new ReflectionMethod(BasePresenter::class, 'startup')->isFinal());
+	}
+
+
+	/**
+	 * @return list<class-string>
+	 */
+	private function findApiPresenterClasses(): array
+	{
+		$apiDir = realpath(__DIR__ . '/../../../src/Presentation/Api');
+		if ($apiDir === false) {
+			throw new RuntimeException('Could not resolve app/src/Presentation/Api/ directory');
+		}
+		$found = [];
+		foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($apiDir)) as $file) {
+			if (!$file instanceof SplFileInfo || !$file->isFile() || !str_ends_with($file->getFilename(), 'Presenter.php')) {
+				continue;
+			}
+			$realPath = realpath($file->getPathname());
+			if ($realPath === false) {
+				continue;
+			}
+			$relative = substr($realPath, strlen($apiDir) + 1, -strlen('.php'));
+			$class = 'MichalSpacekCz\\Presentation\\Api\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+			if (class_exists($class)) {
+				$found[] = $class;
+			}
+		}
+		return $found;
+	}
+
+}
+
+TestCaseRunner::run(EndpointAccessTest::class);


### PR DESCRIPTION
The `Api` base presenter authenticated nothing and left each endpoint to guard itself, so the module was default-allow: a newly added `Api` presenter would ship publicly reachable unless its author remembered to add a check. Both endpoints today are correct (`Certificates` authenticates with a shared secret, `Company` is deliberately public), so nothing is exposed, but relying on the author to remember is fragile as the API grows.

Now the base denies any endpoint that has not declared its access, so a new one is closed until its author consciously marks it public or authenticated. The marker is an attribute implementing a shared interface, so adding another kind of access later needs no change to the check, and a test fails if any endpoint declares none.