### PR TITLE
Escape the Fetch Metadata header value in the Texy placeholder

### DIFF
--- a/app/src/Formatter/Placeholders/FetchMetadataTexyFormatterPlaceholder.php
+++ b/app/src/Formatter/Placeholders/FetchMetadataTexyFormatterPlaceholder.php
@@ -51,13 +51,18 @@ final readonly class FetchMetadataTexyFormatterPlaceholder implements TexyFormat
 		}
 		$result = [];
 		foreach ($headers as $header => $value) {
+			$line = Html::el()->addText("{$header}: ");
 			if ($value === null) {
-				$value = Html::el('em')
-					->addText('[')
-					->addText($this->translator->translate('messages.httpHeaders.headerNotSent'))
-					->addText(']');
+				$line->addHtml(
+					Html::el('em')
+						->addText('[')
+						->addText($this->translator->translate('messages.httpHeaders.headerNotSent'))
+						->addText(']'),
+				);
+			} else {
+				$line->addText($value);
 			}
-			$result[] = "{$header}: {$value}";
+			$result[] = (string)$line;
 		}
 		return implode("\n", $result);
 	}

--- a/app/tests/Formatter/Placeholders/FetchMetadataTexyFormatterPlaceholderTest.phpt
+++ b/app/tests/Formatter/Placeholders/FetchMetadataTexyFormatterPlaceholderTest.phpt
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Formatter\Placeholders;
+
+use Contributte\Translation\Translator;
+use MichalSpacekCz\Http\FetchMetadata\FetchMetadataHeader;
+use MichalSpacekCz\Test\Http\Request;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class FetchMetadataTexyFormatterPlaceholderTest extends TestCase
+{
+
+	public function __construct(
+		private readonly Request $httpRequest,
+		private readonly Translator $translator,
+		private readonly FetchMetadataTexyFormatterPlaceholder $placeholder,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->httpRequest->reset();
+	}
+
+
+	public function testReplaceEscapesHeaderValueSoMarkupCannotSurvive(): void
+	{
+		$this->httpRequest->setHeader(FetchMetadataHeader::Dest->value, '<img src=x onerror=alert(1)>');
+		Assert::same(
+			'Sec-Fetch-Dest: &lt;img src=x onerror=alert(1)&gt;',
+			$this->placeholder->replace(FetchMetadataHeader::Dest->value),
+		);
+	}
+
+
+	public function testReplaceKeepsNotSentMarkerAsHtmlWhenHeaderAbsent(): void
+	{
+		// A header the browser did not send renders as a real <em> "[not sent]" marker, not escaped literal text.
+		$notSent = $this->translator->translate('messages.httpHeaders.headerNotSent');
+		Assert::same(
+			"Sec-Fetch-Site: <em>[{$notSent}]</em>",
+			$this->placeholder->replace(FetchMetadataHeader::Site->value),
+		);
+	}
+
+}
+
+TestCaseRunner::run(FetchMetadataTexyFormatterPlaceholderTest::class);


### PR DESCRIPTION
The `FETCH_METADATA` placeholder reflects a live `Sec-Fetch-*` request header into a post, and the non-null value path spliced it in as a raw string. Placeholder substitution runs after Texy and its result is rendered through `Html::el()->setHtml()`, so `allowedTags = Texy::NONE` (which only guards the Texy pass, inside the cache) never sees it: a header value carrying markup would reach the page unescaped. The `$value === null` branch just above already built escaped `Html`, and the sibling `TrainingDate` placeholder uses `setText()`, so the value path was the lone unescaped spot.

Build each line as an `Html` fragment so the header name and value both go through `addText()` while the not-sent marker stays a real `<em>`. Rendered output is unchanged for legitimate header values.

Real risk is low (`Sec-Fetch-*` are forbidden header names a victim's browser sets itself, the value is never stored, and the nonce CSP blocks injected inline script), but the reflection is still a first-layer escaping gap, and escaping it makes the placeholder correct by construction rather than by the caller's headers happening to be benign.