### PR TITLE
Require same-origin for the logout action

### DIFF
--- a/app/src/Application/ActionMethodAttributes.php
+++ b/app/src/Application/ActionMethodAttributes.php
@@ -1,0 +1,42 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use Nette\Application\UI\Presenter;
+use ReflectionAttribute;
+use ReflectionException;
+use ReflectionMethod;
+
+final class ActionMethodAttributes
+{
+
+	/**
+	 * Finds an attribute on the action or render method of the presenter's current action,
+	 * so with the current action `foo`, on either actionFoo() or renderFoo().
+	 *
+	 * @template T of object
+	 * @param class-string<T> $attribute
+	 * @return ReflectionAttribute<T>|null
+	 */
+	public static function find(Presenter $presenter, string $attribute): ?ReflectionAttribute
+	{
+		$methodNames = [
+			Presenter::formatActionMethod($presenter->getAction()),
+			Presenter::formatRenderMethod($presenter->getAction()),
+		];
+		foreach ($methodNames as $methodName) {
+			try {
+				$method = new ReflectionMethod($presenter, $methodName);
+			} catch (ReflectionException) {
+				continue;
+			}
+			$attributes = $method->getAttributes($attribute);
+			if ($attributes !== []) {
+				return $attributes[0];
+			}
+		}
+		return null;
+	}
+
+}

--- a/app/src/Http/FetchMetadata/ResourceIsolationPolicy.php
+++ b/app/src/Http/FetchMetadata/ResourceIsolationPolicy.php
@@ -3,14 +3,13 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Http\FetchMetadata;
 
+use MichalSpacekCz\Application\ActionMethodAttributes;
 use Nette\Application\Application;
 use Nette\Application\IPresenter;
 use Nette\Application\Request as AppRequest;
 use Nette\Application\UI\Presenter;
 use Nette\Http\IRequest;
 use Nette\Utils\Arrays;
-use ReflectionException;
-use ReflectionMethod;
 use Tracy\Debugger;
 
 final readonly class ResourceIsolationPolicy
@@ -69,27 +68,12 @@ final readonly class ResourceIsolationPolicy
 
 		// [OPTIONAL] Exempt paths/endpoints meant to be served cross-origin
 		// In this app, presenter's action or render methods with the ResourceIsolationPolicyCrossSite attribute are allowed to be called cross-site
-		if (
-			$this->isCallableCrossSite($presenter, Presenter::formatActionMethod($presenter->action))
-			|| $this->isCallableCrossSite($presenter, Presenter::formatRenderMethod($presenter->action))
-		) {
+		if (ActionMethodAttributes::find($presenter, ResourceIsolationPolicyCrossSite::class) !== null) {
 			return true;
 		}
 
 		// Reject all other requests that are cross-site and not navigational
 		return false;
-	}
-
-
-	private function isCallableCrossSite(Presenter $presenter, string $method): bool
-	{
-		try {
-			$method = new ReflectionMethod($presenter, $method);
-		} catch (ReflectionException) {
-			return false;
-		}
-		$attributes = $method->getAttributes(ResourceIsolationPolicyCrossSite::class);
-		return $attributes !== [];
 	}
 
 

--- a/app/src/Http/SameOrigin/CrossOriginRedirectsTo.php
+++ b/app/src/Http/SameOrigin/CrossOriginRedirectsTo.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\SameOrigin;
+
+use Attribute;
+use Nette\Application\Attributes\Requires;
+
+/**
+ * Requires same origin and sends a cross-origin request to the given destination instead of running the action.
+ *
+ * Extends Requires with a preset sameOrigin: true, like Nette's own CrossOrigin presets false, so Nette
+ * enforces the check itself. A failed check normally redirects back to the same action, a recovery for
+ * same-site requests that don't have the `_nss` cookie yet, but a loop for a genuinely cross-origin
+ * request, so Www\BasePresenter::detectedCsrf() sends those to the destination instead.
+ *
+ * The destination must be an absolute action, like ':Admin:Homepage:', and must not require same origin
+ * itself, or the loop would only move there.
+ */
+#[Attribute(Attribute::TARGET_METHOD)]
+final class CrossOriginRedirectsTo extends Requires
+{
+
+	public function __construct(
+		public readonly string $destination,
+	) {
+		parent::__construct(sameOrigin: true);
+	}
+
+}

--- a/app/src/Presentation/Admin/Sign/SignPresenter.php
+++ b/app/src/Presentation/Admin/Sign/SignPresenter.php
@@ -8,6 +8,7 @@ use MichalSpacekCz\Form\User\PasskeyAuthenticateFormFactory;
 use MichalSpacekCz\Form\User\PasskeyRegistrationFormFactory;
 use MichalSpacekCz\Form\User\SignInHoneypotFormFactory;
 use MichalSpacekCz\Http\HttpInput;
+use MichalSpacekCz\Http\SameOrigin\CrossOriginRedirectsTo;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Presentation\Www\BasePresenter;
@@ -123,6 +124,10 @@ final class SignPresenter extends BasePresenter
 	}
 
 
+	/**
+	 * Logout changes state on a GET, so require same-origin: a cross-site request must not be able to force it
+	 */
+	#[CrossOriginRedirectsTo(':Admin:Homepage:')]
 	public function actionOut(): never
 	{
 		$this->permanentLogin->clear();

--- a/app/src/Presentation/Www/BasePresenter.php
+++ b/app/src/Presentation/Www/BasePresenter.php
@@ -4,16 +4,19 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Presentation\Www;
 
 use DateTimeInterface;
+use MichalSpacekCz\Application\ActionMethodAttributes;
 use MichalSpacekCz\Application\Locale\LocaleLink;
 use MichalSpacekCz\Application\Locale\LocaleLinkGenerator;
 use MichalSpacekCz\Css\CriticalCss;
 use MichalSpacekCz\Css\CriticalCssFactory;
 use MichalSpacekCz\EasterEgg\FourOhFourButFound\FourOhFourButFound;
 use MichalSpacekCz\Form\ThemeFormFactory;
+use MichalSpacekCz\Http\SameOrigin\CrossOriginRedirectsTo;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyDirective;
 use MichalSpacekCz\Http\SecurityHeaders\PermissionsPolicy\PermissionsPolicyOrigin;
 use MichalSpacekCz\Templating\DefaultTemplate;
 use MichalSpacekCz\User\Manager;
+use Nette\Application\BadRequestException;
 use Nette\Application\Request;
 use Nette\Application\Responses\TextResponse;
 use Nette\Application\UI\InvalidLinkException;
@@ -175,6 +178,26 @@ abstract class BasePresenter extends Presenter
 		parent::lastModified($lastModified, $etag, $expire);
 		// If the response was HTTP 304 then the following line won't be reached and 304s won't be compressed
 		ini_set('zlib.output_compression', $compression);
+	}
+
+
+	/**
+	 * An action with #[CrossOriginRedirectsTo] sends a blocked cross-origin request to the attribute's
+	 * destination, all other actions keep Nette's redirect back to the same action, see the attribute for why.
+	 */
+	#[Override]
+	public function detectedCsrf(): void
+	{
+		$redirect = ActionMethodAttributes::find($this, CrossOriginRedirectsTo::class);
+		if ($redirect === null) {
+			parent::detectedCsrf();
+			return;
+		}
+		try {
+			$this->redirect($redirect->newInstance()->destination);
+		} catch (InvalidLinkException $e) {
+			throw new BadRequestException($e->getMessage(), previous: $e);
+		}
 	}
 
 

--- a/app/src/Test/Http/Request.php
+++ b/app/src/Test/Http/Request.php
@@ -152,6 +152,22 @@ final class Request implements IRequest
 	}
 
 
+	/**
+	 * IRequest declares isSameSite() only via a @method annotation, not as a real method, so there is no #[Override];
+	 * Nette's AccessPolicy calls it dynamically at runtime, which the dead-code detector can't see.
+	 *
+	 * Upgrade caveat: nette/http 3.4+ changes isSameSite() (deprecated toward isFrom(), and the same-origin check
+	 * moves to the Sec-Fetch-Site header, with the `_nss` cookie kept as a fallback). When bumping the package,
+	 * recheck what AccessPolicy actually calls and update or drop this shim to match.
+	 *
+	 * @phpstan-ignore shipmonk.deadMethod
+	 */
+	public function isSameSite(): bool
+	{
+		return isset($this->cookies['_nss']); // Nette\Http\Helpers::StrictCookieName, the SameSite=Strict marker cookie
+	}
+
+
 	#[Override]
 	public function getRemoteAddress(): ?string
 	{

--- a/app/tests/Http/SameOrigin/CrossOriginRedirectsToTest.phpt
+++ b/app/tests/Http/SameOrigin/CrossOriginRedirectsToTest.phpt
@@ -1,0 +1,161 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\SameOrigin;
+
+use MichalSpacekCz\Presentation\Admin\Sign\SignPresenter;
+use MichalSpacekCz\Presentation\Www\BasePresenter;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Application\Attributes\Requires;
+use Nette\Application\IPresenterFactory;
+use Nette\Application\UI\Presenter;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionAttribute;
+use ReflectionClass;
+use ReflectionMethod;
+use RuntimeException;
+use SplFileInfo;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class CrossOriginRedirectsToTest extends TestCase
+{
+
+	public function __construct(
+		private readonly IPresenterFactory $presenterFactory,
+	) {
+	}
+
+
+	/**
+	 * The redirect happens in Www\BasePresenter::detectedCsrf(), so outside that presenter tree the attribute
+	 * would arm Nette's check but a blocked request would loop like there was no attribute at all. And Nette
+	 * checks a method's attributes right before invoking that method, so on a render method the check would
+	 * fire only after the action body, the thing being guarded, has already run.
+	 */
+	public function testEveryUseIsOnAnActionMethodOfAPresenterWithTheOverride(): void
+	{
+		$uses = $this->findAttributeUses();
+		Assert::contains(SignPresenter::class . '::actionOut()', array_keys($uses)); // the scan must find at least the known usage
+		foreach ($uses as $name => [$method]) {
+			Assert::true(is_subclass_of($method->getDeclaringClass()->getName(), BasePresenter::class), "{$name} is outside the Www\\BasePresenter tree, its detectedCsrf() override would never run and a blocked request would loop");
+			Assert::true(str_starts_with($method->getName(), 'action'), "{$name} must carry the attribute on the action method, on a render method the check would fire only after the action body has run");
+		}
+	}
+
+
+	/**
+	 * A destination that requires same origin itself would just move the redirect loop there, so every use
+	 * of the attribute must point to an unguarded absolute action. The attribute extends Requires and presets
+	 * sameOrigin: true, so the pairing that arms the check cannot be missing and is not tested here.
+	 */
+	public function testEveryDestinationIsAnUnguardedAbsoluteAction(): void
+	{
+		$uses = $this->findAttributeUses();
+		Assert::contains(SignPresenter::class . '::actionOut()', array_keys($uses)); // the scan must find at least the known usage
+		foreach ($uses as $name => [, $attribute]) {
+			$destination = $attribute->destination;
+			Assert::true(str_starts_with($destination, ':'), "{$name} must use an absolute destination like ':Admin:Homepage:', not '{$destination}'");
+			[$presenterName, $action] = $this->splitDestination($destination);
+			$targetClass = $this->presenterFactory->getPresenterClass($presenterName); // throws when the presenter doesn't exist
+			if (!class_exists($targetClass)) {
+				throw new RuntimeException("The {$targetClass} class should exist, getPresenterClass() checks that"); // here just to narrow the type for ReflectionClass
+			}
+			$target = new ReflectionClass($targetClass);
+			Assert::false($this->requiresSameOrigin($target), "{$name} redirects to {$destination} whose presenter requires same origin, the loop would just move there");
+			foreach ([Presenter::formatActionMethod($action), Presenter::formatRenderMethod($action)] as $targetMethodName) {
+				if (!$target->hasMethod($targetMethodName)) {
+					continue;
+				}
+				$targetMethod = $target->getMethod($targetMethodName);
+				// This also catches redirect chains, a #[CrossOriginRedirectsTo] destination is a Requires(sameOrigin: true) by inheritance
+				Assert::false($this->requiresSameOrigin($targetMethod), "{$name} redirects to {$destination} which requires same origin, the loop would just move there");
+			}
+		}
+	}
+
+
+	/**
+	 * @return array<string, array{ReflectionMethod, CrossOriginRedirectsTo}> indexed by "Class::method()"
+	 */
+	private function findAttributeUses(): array
+	{
+		$uses = [];
+		foreach ($this->findPresenterClasses() as $class) {
+			foreach (new ReflectionClass($class)->getMethods() as $method) {
+				$attributes = $method->getAttributes(CrossOriginRedirectsTo::class);
+				if ($attributes === [] || $method->getDeclaringClass()->getName() !== $class) {
+					continue;
+				}
+				$uses["{$class}::{$method->getName()}()"] = [$method, $attributes[0]->newInstance()];
+			}
+		}
+		return $uses;
+	}
+
+
+	/**
+	 * @param ReflectionClass<object>|ReflectionMethod $element
+	 */
+	private function requiresSameOrigin(ReflectionClass|ReflectionMethod $element): bool
+	{
+		foreach ($element->getAttributes(Requires::class, ReflectionAttribute::IS_INSTANCEOF) as $attribute) {
+			if ($attribute->newInstance()->sameOrigin === true) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+
+	/**
+	 * Splits ':Admin:Homepage:' into the presenter name 'Admin:Homepage' and the action 'default'.
+	 *
+	 * @return array{string, string}
+	 */
+	private function splitDestination(string $destination): array
+	{
+		$parts = explode(':', substr($destination, 1));
+		$action = array_pop($parts);
+		if ($action === '') {
+			$action = 'default'; // Same as in Nette\Application\UI\Presenter::DefaultAction, which is internal
+		}
+		return [implode(':', $parts), $action];
+	}
+
+
+	/**
+	 * @return list<class-string>
+	 */
+	private function findPresenterClasses(): array
+	{
+		$dir = realpath(__DIR__ . '/../../../src/Presentation');
+		if ($dir === false) {
+			throw new RuntimeException('Could not resolve app/src/Presentation/ directory');
+		}
+		$found = [];
+		foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($dir)) as $file) {
+			if (!$file instanceof SplFileInfo || !$file->isFile() || !str_ends_with($file->getFilename(), 'Presenter.php')) {
+				continue;
+			}
+			$realPath = realpath($file->getPathname());
+			if ($realPath === false) {
+				continue;
+			}
+			$relative = substr($realPath, strlen($dir) + 1, -strlen('.php'));
+			$class = 'MichalSpacekCz\\Presentation\\' . str_replace(DIRECTORY_SEPARATOR, '\\', $relative);
+			if (class_exists($class)) {
+				$found[] = $class;
+			}
+		}
+		return $found;
+	}
+
+}
+
+TestCaseRunner::run(CrossOriginRedirectsToTest::class);

--- a/app/tests/Presentation/Admin/Sign/SignPresenterTest.phpt
+++ b/app/tests/Presentation/Admin/Sign/SignPresenterTest.phpt
@@ -13,6 +13,8 @@ use MichalSpacekCz\User\SecurityActivity\SecurityEventType;
 use Nette\Application\Request;
 use Nette\Application\Responses\RedirectResponse;
 use Nette\Http\IRequest;
+use Nette\Http\IResponse;
+use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Override;
 use Tester\Assert;
@@ -37,6 +39,12 @@ final class SignPresenterTest extends TestCase
 		private readonly HttpRequestMock $httpRequest,
 		private readonly User $user,
 	) {
+	}
+
+
+	#[Override]
+	protected function setUp(): void
+	{
 		$this->httpRequest->setMethod(IRequest::Get);
 	}
 
@@ -44,6 +52,7 @@ final class SignPresenterTest extends TestCase
 	#[Override]
 	protected function tearDown(): void
 	{
+		$this->httpRequest->reset();
 		$this->database->reset();
 		$this->user->logout();
 	}
@@ -81,6 +90,36 @@ final class SignPresenterTest extends TestCase
 		$presenter->run(new Request('Admin:Sign', IRequest::Get, ['action' => 'in']));
 
 		Assert::count(0, $this->database->getParamsArrayForQuery('INSERT INTO security_events'));
+	}
+
+
+	public function testCrossSiteLogoutIsBlocked(): void
+	{
+		$this->user->login(new SimpleIdentity(42));
+		// No _nss cookie, so the request looks cross-site to the same-origin guard
+		$presenter = $this->applicationPresenter->createUiPresenter('Admin:Sign', 'Sign', 'out');
+		$presenter->autoCanonicalize = false;
+		$response = $presenter->run(new Request('Admin:Sign', IRequest::Get, ['action' => 'out']));
+
+		Assert::true($this->user->isLoggedIn()); // the logout body never ran
+		Assert::type(RedirectResponse::class, $response);
+		assert($response instanceof RedirectResponse);
+		// The CrossOriginRedirectsTo destination; sign/out here would mean the loop is back
+		Assert::same('https://admin.rizek.test/', $response->getUrl());
+		Assert::same(IResponse::S302_Found, $response->getCode()); // a permanent redirect would teach the browser to skip the logout for good
+	}
+
+
+	public function testSameSiteLogoutSignsUserOut(): void
+	{
+		$this->user->login(new SimpleIdentity(42));
+		$this->httpRequest->setCookie('_nss', '1'); // Nette's SameSite=Strict marker cookie, the request now looks same-site
+		$presenter = $this->applicationPresenter->createUiPresenter('Admin:Sign', 'Sign', 'out');
+		$presenter->autoCanonicalize = false;
+		$response = $presenter->run(new Request('Admin:Sign', IRequest::Get, ['action' => 'out']));
+
+		Assert::false($this->user->isLoggedIn()); // the logout body ran
+		Assert::type(RedirectResponse::class, $response);
 	}
 
 }


### PR DESCRIPTION
Logging out clears the permanent-login token and the session, but it runs on a GET, so on its own nothing stops another site from pointing the signed-in admin's browser at the logout URL and forcing them out. The admin session cookie is `SameSite=Strict` so a forged request already arrives without a session, but that is one outside layer and the guard belongs in the code too.

Nette adds the same-origin check to signals automatically but not to actions, so `actionOut` states it with `#[Requires(sameOrigin: true)]`. A request that arrives without the `_nss` strict cookie is now refused before the logout body runs, while a same-site logout still goes through. Newer version of the Nette package even uses Fetch Metadata for cross-origin request detection.

The test double gains `isSameSite()`, which `IRequest` only documents through a `@method` annotation, so a test can present a same-site or cross-site request and check the guard blocks or allows the logout.