### PR TITLE
Make the sri-macros concatenation check check something again

### DIFF
--- a/app/bin/check-sri-macros-concat.sh
+++ b/app/bin/check-sri-macros-concat.sh
@@ -2,11 +2,17 @@
 
 echo "Wrong spaze/sri-macros concatenations (without spaces, e.g. {script foo+bar}):"
 
-BAD_LINES=$(grep --recursive --perl-regexp --ignore-case --line-number "{(script|stylesheet)" app/ | grep --perl-regexp "[^\s]\+|\+[^\s]")
+LINES=$(grep --recursive --perl-regexp --ignore-case --line-number "{(script|stylesheet)" src/)
+if [ -z "$LINES" ]; then
+	echo "The check has found no lines with the macros, did you run it from the app/ directory which has src/ in it?"
+	exit 2
+fi
+
+BAD_LINES=$(echo "$LINES" | grep --perl-regexp "[^\s]\+|\+[^\s]")
 if [ "$BAD_LINES" ]; then
 	echo "$BAD_LINES" | grep --color ".+."
 	exit 1
 else
-	echo "None, all have spaces around the plus sign (foo + bar, not foo+bar)"
+	echo "None, all $(echo "$LINES" | wc -l) lines have spaces around the plus sign (foo + bar, not foo+bar)"
 	exit 0
 fi


### PR DESCRIPTION
The check greps a path relative to the current directory, and it kept the `app/` path from before the rename in which the application moved from `site/` to `app/` (#402). It always runs with the current directory already inside `app/`, where no `app/` directory exists, so ever since the rename it has been grepping nothing and passing.

A check that finds no files to check now fails instead of passing, so this can't happen silently again, and the success message reports how many lines were checked. The grep scans `src/`, where all the templates are, which also stops the check from matching the example in its own output when run from the wrong directory.