### PR TITLE
Reload a restored page when the theme changed while it was cached in the bfcache

### DIFF
--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -80,6 +80,7 @@ subresourceIntegrity:
 		remove-fbclid: /i/js/remove-fbclid.js
 		passkey-authenticate: /i/js/passkey-authenticate.js
 		passkey-register: /i/js/passkey-register.js
+		theme: /i/js/theme.js
 		rating: /i/css/rating.css
 		screen-main: /i/css/screen.css
 		screen-main-dark: /i/css/screen-dark.css

--- a/app/public/www.michalspacek.cz/i/js/theme.js
+++ b/app/public/www.michalspacek.cz/i/js/theme.js
@@ -1,0 +1,20 @@
+(function () {
+	// Reload if a page restored from the back/forward cache uses an old theme
+	const theme = document.documentElement.dataset.theme;
+	if (theme === undefined) {
+		return;
+	}
+	try {
+		localStorage.setItem('theme', theme);
+	} catch (e) {
+		return; // Prevent reloads on every restore when localStorage is read-only
+	}
+	window.addEventListener('pageshow', function (event) {
+		try {
+			if (event.persisted && localStorage.getItem('theme') !== theme) {
+				location.reload();
+			}
+		} catch (e) {
+		}
+	});
+})();

--- a/app/src/Presentation/Admin/@layout.latte
+++ b/app/src/Presentation/Admin/@layout.latte
@@ -3,5 +3,5 @@
 {var $headerLinks = false}
 {define #feeds}{/define}
 {define #scriptsReplace}
-{script app + admin + passkey-authenticate + netteForms async, defer}
+{script app + admin + theme + passkey-authenticate + netteForms async, defer}
 {/define}

--- a/app/src/Presentation/Admin/Passkeys/add.latte
+++ b/app/src/Presentation/Admin/Passkeys/add.latte
@@ -4,7 +4,7 @@
 	&raquo; <a n:href="Passkeys:">{_messages.passkeys.manage.managePasskeys}</a>
 {/define}
 {define #scriptsReplace}
-	{script app + admin + passkey-register + netteForms async, defer}
+	{script app + admin + theme + passkey-register + netteForms async, defer}
 {/define}
 {define #content}
 <p id="passkeyReopenMessage" class="hidden">{_messages.passkeys.add.reopenLink}</p>

--- a/app/src/Presentation/Admin/Sign/passkeyReset.latte
+++ b/app/src/Presentation/Admin/Sign/passkeyReset.latte
@@ -1,5 +1,5 @@
 {define #scriptsReplace}
-	{script app + admin + passkey-register + netteForms async, defer}
+	{script app + admin + theme + passkey-register + netteForms async, defer}
 {/define}
 {define #content}
 <div n:foreach="$flashes as $flash" class="flash {$flash->type}"><strong>{$flash->message}</strong></div>

--- a/app/src/Presentation/Www/@layout.latte
+++ b/app/src/Presentation/Www/@layout.latte
@@ -5,7 +5,7 @@
 {/define}
 {block|strip}
 <!DOCTYPE html>
-<html lang="{_html.attribute.lang}">
+<html lang="{_html.attribute.lang}" data-theme="{$darkMode === null ? 'auto' : ($darkMode ? 'dark' : 'light')}">
 <head>
 	<meta charset="utf-8">
 	<meta name="robots" content="{$robots}" n:ifset="$robots">
@@ -23,7 +23,7 @@
 	{ifset #scriptsReplace}
 		{include #scriptsReplace}
 	{else}
-		{script app + scripts async, defer}
+		{script app + scripts + theme async, defer}
 		{script netteForms async, defer}
 		{script remove-fbclid async, defer}
 	{/ifset}
@@ -35,7 +35,14 @@
 	{else}
 		<link rel="canonical" n:href="//this">
 	{/ifset}
-	<meta name="theme-color" content="#EEE">
+	{if $darkMode === null}
+		<meta name="theme-color" media="(prefers-color-scheme: light)" content="#EEE">
+		<meta name="theme-color" media="(prefers-color-scheme: dark)" content="#15202B">
+	{elseif $darkMode}
+		<meta name="theme-color" content="#15202B">
+	{else}
+		<meta name="theme-color" content="#EEE">
+	{/if}
 	<link rel="apple-touch-icon" href="{='michal-spacek.jpg'|staticImageUrl}">
 	<meta property="article:author" content="https://www.facebook.com/spaze">
 	<link rel="icon" href="{='/favicon.ico'|staticUrl}">


### PR DESCRIPTION
A page restored from the back/forward cache is shown exactly as it was rendered, no HTTP request is made, so `Vary: Cookie` or `Cache-Control` don't apply. Only `no-store` would, by making the page ineligible for the back/forward cache in most browsers, and current Chrome caches even such pages and evicts them when cookies change. So after switching the theme, going Back shows the previous page in the old theme until it's reloaded.

The new `theme.js` reloads a restored page when its theme, read from the new `data-theme` attribute, differs from the current one. The theme cookie is HttpOnly, so the script tracks the current theme in `localStorage`. Only a page with a different theme is reloaded, a Back navigation with no theme change stays instant. There's no form submit hook, the theme switch redirects and the freshly loaded page syncs the new theme to `localStorage`. That also covers an expired theme cookie: the next load re-syncs to auto and an old restored page reloads just once.

The script is concatenated into the existing bundles, so no extra request is made, and it loads only on pages that use themes, so not on Pulse or UPC keys pages.