### PR TITLE
Stop sending the theme cookie where nothing reads it

### DIFF
--- a/app/src/Application/Theme/Theme.php
+++ b/app/src/Application/Theme/Theme.php
@@ -45,7 +45,7 @@ final readonly class Theme
 
 	private function setCookie(ThemeMode $mode): void
 	{
-		$this->cookies->set(CookieName::Theme, $mode->value, $this->getCookieLifetime(), sameSite: 'None');
+		$this->cookies->set(CookieName::Theme, $mode->value, $this->getCookieLifetime(), sameSite: 'Lax');
 	}
 
 

--- a/app/tests/Application/Theme/ThemeTest.phpt
+++ b/app/tests/Application/Theme/ThemeTest.phpt
@@ -51,7 +51,7 @@ final class ThemeTest extends TestCase
 		Assert::true($cookie->isSecure());
 		Assert::same('/foo', $cookie->getPath());
 		Assert::same('example.org', $cookie->getDomain());
-		Assert::same('None', $cookie->getSameSite());
+		Assert::same('Lax', $cookie->getSameSite());
 	}
 
 


### PR DESCRIPTION
The theme cookie was `SameSite=None` since dark mode was introduced in 2020 (#1, yeah, really), most likely because it appeared to fix pages showing the old theme after a Back navigation. That is caused by the back/forward cache restoring the page exactly as it was rendered, no request is made, so no cookie attribute can affect it, and it reproduces the same with `None` and with `Lax`. The restored pages get a real fix separately.

The cookie is only read when the server renders a page, and `Lax` still sends it with every request that can do that, including a link followed from another site landing on a page in the chosen theme, which `Strict` would break. What `Lax` stops is the cookie accompanying requests made by other sites for content embedded there, where nothing reads it. It was also the only `None` cookie in the app.