### PR TITLE
Drop the legacy `bright` theme cookie value

### DIFF
--- a/app/src/Application/Theme/Theme.php
+++ b/app/src/Application/Theme/Theme.php
@@ -31,10 +31,6 @@ final readonly class Theme
 	public function isDarkMode(): ?bool
 	{
 		$cookie = $this->cookies->getString(CookieName::Theme) ?? '';
-		if ($cookie === 'bright') {
-			// Support legacy cookie value, can be removed in August 2025 because then all legacy cookies will expire
-			$cookie = ThemeMode::Light->value;
-		}
 		try {
 			return ThemeMode::from($cookie) === ThemeMode::Dark;
 		} catch (ValueError) {

--- a/app/tests/Application/Theme/ThemeTest.phpt
+++ b/app/tests/Application/Theme/ThemeTest.phpt
@@ -75,13 +75,6 @@ final class ThemeTest extends TestCase
 	}
 
 
-	public function testIsDarkModeValueLegacy(): void
-	{
-		$this->request->setCookie(self::COOKIE, 'bright');
-		Assert::false($this->theme->isDarkMode());
-	}
-
-
 	public function testIsDarkModeValueLight(): void
 	{
 		$this->request->setCookie(self::COOKIE, 'light');


### PR DESCRIPTION
The mapping supported cookies from before the value was renamed to `light` (in #381 in Aug 2024), and its comment said it can be removed in August 2025, when all cookies with the old value will have expired, the cookie lives for 365 days. That was almost a year ago. A `bright` cookie now means the auto theme, like any other unknown value.