### PR TITLE
Enforce the `CrossOriginRedirectsTo` placement with PHPStan, not only with a test

### DIFF
--- a/app/disallowed-calls.neon
+++ b/app/disallowed-calls.neon
@@ -125,6 +125,12 @@ parameters:
 				- src/Application/ServerEnv.php
 				- tests/Application/ServerEnvTest.phpt
 				- tests/EasterEgg/FourOhFourButFound/FourOhFourButFoundTest.phpt
+	disallowedAttributes:
+		-
+			attribute: 'MichalSpacekCz\Http\SameOrigin\CrossOriginRedirectsTo'
+			message: 'put it on a presenter action method, elsewhere Nette checks it only after the action body, when the thing being guarded, has already run'
+			allowInMethods:
+				- '*Presenter::action*()'
 	disallowedClasses:
 		-
 			class:

--- a/app/tests/Http/SameOrigin/CrossOriginRedirectsToTest.phpt
+++ b/app/tests/Http/SameOrigin/CrossOriginRedirectsToTest.phpt
@@ -32,19 +32,12 @@ final class CrossOriginRedirectsToTest extends TestCase
 	}
 
 
-	/**
-	 * The redirect happens in Www\BasePresenter::detectedCsrf(), so outside that presenter tree the attribute
-	 * would arm Nette's check but a blocked request would loop like there was no attribute at all. And Nette
-	 * checks a method's attributes right before invoking that method, so on a render method the check would
-	 * fire only after the action body, the thing being guarded, has already run.
-	 */
-	public function testEveryUseIsOnAnActionMethodOfAPresenterWithTheOverride(): void
+	public function testEveryUseIsInAPresenterWithTheOverride(): void
 	{
 		$uses = $this->findAttributeUses();
 		Assert::contains(SignPresenter::class . '::actionOut()', array_keys($uses)); // the scan must find at least the known usage
 		foreach ($uses as $name => [$method]) {
 			Assert::true(is_subclass_of($method->getDeclaringClass()->getName(), BasePresenter::class), "{$name} is outside the Www\\BasePresenter tree, its detectedCsrf() override would never run and a blocked request would loop");
-			Assert::true(str_starts_with($method->getName(), 'action'), "{$name} must carry the attribute on the action method, on a render method the check would fire only after the action body has run");
 		}
 	}
 


### PR DESCRIPTION
The attribute belongs on a presenter action method. Elsewhere, Nette checks it only after the action body has already run, so a cross-site request runs the guarded action and only then gets redirected, a bypass that a same-origin click while testing never reveals.

Catching that while typing, provided your IDE is configured to run PHPStan, beats catching it only when the test suite runs, so the placement rule moves to `disallowed-calls.neon`. The spaze/phpstan-disallowed-calls v4.13 update (#817) is what makes allowInMethods see an attribute sitting on a method.

The test keeps the other rule, that the attribute lives in a presenter with the `detectedCsrf()` override. Both rules can't live in the config, disallowed-calls keys attributes by name so two entries for one attribute collapse into one, and a single entry with both `allowInMethods` and `allowInInstanceOf` allows either of them, not both.