### PR TITLE
Send HSTS on every response, and serve static CORS as a fixed `*`

### DIFF
--- a/app/psalm.xml
+++ b/app/psalm.xml
@@ -107,12 +107,14 @@
 		</UnusedClass>
 		<MoreSpecificReturnType>
 			<errorLevel type="suppress">
+				<file name="src/Http/Client/HttpClientRequest.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 				<file name="src/Http/SecurityHeaders/SecurityHeaders.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 				<file name="src/Formatter/TexyFormatter.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 			</errorLevel>
 		</MoreSpecificReturnType>
 		<LessSpecificReturnStatement>
 			<errorLevel type="suppress">
+				<file name="src/Http/Client/HttpClientRequest.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 				<file name="src/Http/SecurityHeaders/SecurityHeaders.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 				<file name="src/Formatter/TexyFormatter.php"/> <!-- clone(...) is a PHP 8.5 feature supported only in Psalm 7 currently in beta -->
 			</errorLevel>

--- a/app/src/Http/Client/HttpClient.php
+++ b/app/src/Http/Client/HttpClient.php
@@ -39,10 +39,14 @@ class HttpClient
 				'http' => $httpOptions,
 			],
 			[
-				'notification' => function (int $notificationCode, int $severity, ?string $message, int $messageCode): void {
-					if ($severity === STREAM_NOTIFY_SEVERITY_ERR) {
-						throw new HttpStreamException($notificationCode, $message, $messageCode);
+				'notification' => function (int $notificationCode, int $severity, ?string $message, int $messageCode) use ($request): void {
+					if ($severity !== STREAM_NOTIFY_SEVERITY_ERR) {
+						return;
 					}
+					if ($request->getIgnoreHttpErrors() && $messageCode >= 400 && $messageCode <= 599) {
+						return; // a real HTTP 4xx/5xx, the opt-in caller wants the response, not an exception
+					}
+					throw new HttpStreamException($notificationCode, $message, $messageCode);
 				},
 			],
 		);
@@ -100,6 +104,7 @@ class HttpClient
 				throw new HttpClientRequestException($request->getUrl());
 			}
 			$result = stream_get_contents($fp);
+			$wrapperData = stream_get_meta_data($fp)['wrapper_data'];
 			$options = stream_context_get_options($fp);
 			fclose($fp);
 		} catch (HttpStreamException $e) {
@@ -115,7 +120,8 @@ class HttpClient
 		} else {
 			$certificate = null;
 		}
-		return new HttpClientResponse($request, $result, $certificate);
+		$headers = is_array($wrapperData) ? array_values(array_filter($wrapperData, is_string(...))) : [];
+		return new HttpClientResponse($request, $result, $certificate, $headers);
 	}
 
 }

--- a/app/src/Http/Client/HttpClientRequest.php
+++ b/app/src/Http/Client/HttpClientRequest.php
@@ -112,4 +112,10 @@ final class HttpClientRequest
 		return $this;
 	}
 
+
+	public function withUrl(string $url): self
+	{
+		return clone($this, ['url' => $url]);
+	}
+
 }

--- a/app/src/Http/Client/HttpClientRequest.php
+++ b/app/src/Http/Client/HttpClientRequest.php
@@ -17,6 +17,8 @@ final class HttpClientRequest
 
 	private ?bool $tlsCaptureCertificate = null;
 
+	private bool $ignoreHttpErrors = false;
+
 
 	public function __construct(
 		private readonly string $url,
@@ -94,6 +96,19 @@ final class HttpClientRequest
 	public function setTlsCaptureCertificate(bool $tlsCaptureCertificate): self
 	{
 		$this->tlsCaptureCertificate = $tlsCaptureCertificate;
+		return $this;
+	}
+
+
+	public function getIgnoreHttpErrors(): bool
+	{
+		return $this->ignoreHttpErrors;
+	}
+
+
+	public function setIgnoreHttpErrors(bool $ignoreHttpErrors): self
+	{
+		$this->ignoreHttpErrors = $ignoreHttpErrors;
 		return $this;
 	}
 

--- a/app/src/Http/Client/HttpClientResponse.php
+++ b/app/src/Http/Client/HttpClientResponse.php
@@ -8,13 +8,23 @@ use MichalSpacekCz\Http\Exceptions\HttpClientTlsCertificateNotCapturedException;
 use OpenSSLCertificate;
 use Uri\WhatWg\Url;
 
-final readonly class HttpClientResponse
+final class HttpClientResponse
 {
 
+	/**
+	 * @var array<lowercase-string, list<string>>|null
+	 */
+	private ?array $normalizedHeaders = null;
+
+
+	/**
+	 * @param list<string> $headers Raw response header lines like "Foo: bar"
+	 */
 	public function __construct(
-		private HttpClientRequest $request,
-		private string $body,
-		private ?OpenSSLCertificate $tlsCertificate,
+		private readonly HttpClientRequest $request,
+		private readonly string $body,
+		private readonly ?OpenSSLCertificate $tlsCertificate,
+		private readonly array $headers,
 	) {
 	}
 
@@ -22,6 +32,24 @@ final readonly class HttpClientResponse
 	public function getBody(): string
 	{
 		return $this->body;
+	}
+
+
+	public function getHeader(string $name): ?string
+	{
+		$this->normalizeHeaders();
+		$name = strtolower($name);
+		return $this->normalizedHeaders[$name][0] ?? null;
+	}
+
+
+	/**
+	 * @return list<string>|null
+	 */
+	public function getAllHeaders(string $name): ?array
+	{
+		$this->normalizeHeaders();
+		return $this->normalizedHeaders[strtolower($name)] ?? null;
 	}
 
 
@@ -39,6 +67,28 @@ final readonly class HttpClientResponse
 			throw new HttpClientTlsCertificateNotCapturedException();
 		}
 		return $this->tlsCertificate;
+	}
+
+
+	private function normalizeHeaders(): void
+	{
+		if ($this->normalizedHeaders === null) {
+			$this->normalizedHeaders = [];
+			foreach ($this->headers as $header) {
+				if (str_starts_with($header, 'HTTP/')) {
+					$this->normalizedHeaders = []; // a status line starts a new response; when redirects are followed keep only the last one's headers
+					continue;
+				}
+				$parts = explode(':', $header, 2);
+				if (isset($parts[1])) {
+					$name = strtolower($parts[0]);
+					if (!isset($this->normalizedHeaders[$name])) {
+						$this->normalizedHeaders[$name] = [];
+					}
+					$this->normalizedHeaders[$name][] = trim($parts[1]);
+				}
+			}
+		}
 	}
 
 }

--- a/app/src/Test/Http/Client/HttpClientMock.php
+++ b/app/src/Test/Http/Client/HttpClientMock.php
@@ -23,7 +23,7 @@ final class HttpClientMock extends HttpClient
 	#[Override]
 	public function get(HttpClientRequest $request): HttpClientResponse
 	{
-		return new HttpClientResponse($request, $this->response, null);
+		return new HttpClientResponse($request, $this->response, null, []);
 	}
 
 }

--- a/app/tests/Http/Client/HttpClientResponseTest.phpt
+++ b/app/tests/Http/Client/HttpClientResponseTest.phpt
@@ -24,29 +24,64 @@ final class HttpClientResponseTest extends TestCase
 		assert($certificate instanceof OpenSSLCertificate);
 
 		Assert::exception(function () use (&$certificate): void {
-			new HttpClientResponse(new HttpClientRequest(':-/'), 'body', $certificate)->getTlsCertificate();
+			new HttpClientResponse(new HttpClientRequest(':-/'), 'body', $certificate, [])->getTlsCertificate();
 		}, HttpClientTlsCertificateNotAvailableException::class);
 
 		Assert::exception(function () use (&$certificate): void {
-			new HttpClientResponse(new HttpClientRequest('http://not.secure.example'), 'body', $certificate)->getTlsCertificate();
+			new HttpClientResponse(new HttpClientRequest('http://not.secure.example'), 'body', $certificate, [])->getTlsCertificate();
 		}, HttpClientTlsCertificateNotAvailableException::class);
 
 		Assert::exception(function () use (&$certificate): void {
-			new HttpClientResponse(new HttpClientRequest('https://www.example'), 'body', $certificate)->getTlsCertificate();
+			new HttpClientResponse(new HttpClientRequest('https://www.example'), 'body', $certificate, [])->getTlsCertificate();
 		}, HttpClientTlsCertificateNotCapturedException::class);
 
 		Assert::exception(function (): void {
-			new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', null)->getTlsCertificate();
+			new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', null, [])->getTlsCertificate();
 		}, HttpClientTlsCertificateNotCapturedException::class);
 
-		Assert::type(OpenSSLCertificate::class, new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', $certificate)->getTlsCertificate());
+		Assert::type(OpenSSLCertificate::class, new HttpClientResponse(new HttpClientRequest('https://www.example')->setTlsCaptureCertificate(true), 'body', $certificate, [])->getTlsCertificate());
 	}
 
 
 	public function testGetBody(): void
 	{
 		$body = 'a response body';
-		Assert::same($body, new HttpClientResponse(new HttpClientRequest('https://www.example'), $body, null)->getBody());
+		Assert::same($body, new HttpClientResponse(new HttpClientRequest('https://www.example'), $body, null, [])->getBody());
+	}
+
+
+	public function testGetHeaderAllHeaders(): void
+	{
+		$headers = [
+			'Single-Header:foo',
+			'Single-Header2:    foo   ',
+			'Multiple-Header: bar',
+			'Multiple-Header: baz',
+		];
+		$response = new HttpClientResponse(new HttpClientRequest('https://www.example'), '', null, $headers);
+		Assert::same('foo', $response->getHeader('single-header'));
+		Assert::same(['foo'], $response->getAllHeaders('single-header'));
+		Assert::same('foo', $response->getHeader('SiNgLe-HeAdEr2'));
+		Assert::same(['foo'], $response->getAllHeaders('SiNgLe-HeAdEr2'));
+		Assert::same('bar', $response->getHeader('multiple-header'));
+		Assert::same(['bar', 'baz'], $response->getAllHeaders('multiple-header'));
+	}
+
+
+	public function testKeepsOnlyTheLastResponseAfterRedirects(): void
+	{
+		$headers = [
+			'HTTP/1.1 301 Moved Permanently',
+			'Location: https://www.example/final',
+			'X-Hop: first',
+			'HTTP/1.1 200 OK',
+			'X-Hop: second',
+		];
+		$response = new HttpClientResponse(new HttpClientRequest('https://www.example'), '', null, $headers);
+		Assert::same('second', $response->getHeader('x-hop')); // the final response, not the redirect
+		Assert::same(['second'], $response->getAllHeaders('x-hop'));
+		Assert::null($response->getHeader('location')); // the redirect hop's header is discarded
+		Assert::null($response->getAllHeaders('location'));
 	}
 
 }

--- a/app/tests/Http/Client/HttpClientTest.phpt
+++ b/app/tests/Http/Client/HttpClientTest.phpt
@@ -2,17 +2,15 @@
 /** @noinspection PhpUnhandledExceptionInspection */
 declare(strict_types = 1);
 
-namespace MichalSpacekCz\Http;
+namespace MichalSpacekCz\Http\Client;
 
-use MichalSpacekCz\Http\Client\HttpClient;
-use MichalSpacekCz\Http\Client\HttpClientRequest;
 use MichalSpacekCz\Http\Exceptions\HttpStreamException;
 use MichalSpacekCz\Test\TestCaseRunner;
 use ReflectionMethod;
 use Tester\Assert;
 use Tester\TestCase;
 
-require __DIR__ . '/../bootstrap.php';
+require __DIR__ . '/../../bootstrap.php';
 
 /** @testCase */
 final class HttpClientTest extends TestCase
@@ -81,6 +79,39 @@ final class HttpClientTest extends TestCase
 		Assert::exception(function () use ($params): void {
 			call_user_func($params['notification'], 418, STREAM_NOTIFY_SEVERITY_ERR, null, 808);
 		}, HttpStreamException::class, '¯\_(ツ)_/¯ (418)', 808);
+	}
+
+
+	public function testCreateStreamContextNotificationIgnoresHttpErrors(): void
+	{
+		$errorAt = function (callable $notification, int $status): callable {
+			return function () use ($notification, $status): void {
+				$notification(STREAM_NOTIFY_FAILURE, STREAM_NOTIFY_SEVERITY_ERR, 'err', $status);
+			};
+		};
+
+		// off by default: an HTTP error severity throws, even for a 4xx
+		$default = $this->notificationCallback(new HttpClientRequest('https://example.com/'));
+		Assert::exception($errorAt($default, 404), HttpStreamException::class);
+
+		// on: a 4xx/5xx (400 to 599) is swallowed so the response comes back; anything outside that range still throws
+		$ignoring = $this->notificationCallback(new HttpClientRequest('https://example.com/')->setIgnoreHttpErrors(true));
+		Assert::noError($errorAt($ignoring, 400));
+		Assert::noError($errorAt($ignoring, 404));
+		Assert::noError($errorAt($ignoring, 599));
+		Assert::exception($errorAt($ignoring, 399), HttpStreamException::class);
+		Assert::exception($errorAt($ignoring, 600), HttpStreamException::class);
+	}
+
+
+	private function notificationCallback(HttpClientRequest $request): callable
+	{
+		$method = new ReflectionMethod($this->httpClient, 'createStreamContext');
+		$context = $method->invoke($this->httpClient, $request);
+		assert(is_resource($context));
+		$notification = stream_context_get_params($context)['notification'];
+		assert(is_callable($notification));
+		return $notification;
 	}
 
 }

--- a/app/tests/Http/HstsHeaderPresentTest.phpt
+++ b/app/tests/Http/HstsHeaderPresentTest.phpt
@@ -9,6 +9,7 @@ use MichalSpacekCz\Http\Client\HttpClientRequest;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Tester\Assert;
 use Tester\TestCase;
+use Uri\WhatWg\Url;
 
 require __DIR__ . '/../bootstrap.php';
 
@@ -16,27 +17,32 @@ require __DIR__ . '/../bootstrap.php';
 final class HstsHeaderPresentTest extends TestCase
 {
 
-	private const string EXPECTED_HSTS = 'max-age=31536000; includeSubDomains; preload';
+	private const string HTTPS_EXPECTED_HSTS = 'max-age=31536000; includeSubDomains; preload';
+	private const null HTTP_EXPECTED_HSTS = null;
 
 
-	public function testHstsSentOnEveryResponseClass(): void
+	public function testHstsSentOnEveryResponseClassButNotOnHttp(): void
 	{
 		TestCaseRunner::needsInternet();
-		$urls = [
+		$httpsUrls = [
 			'https://www.michalspacek.cz/', // app page, inherits the server-level header
 			'https://www.michalspacek.cz/robots.txt', // static file, common-headers-static.conf
 			'https://www.michalspacek.cz/security.txt', // 301 redirect, common-headers-redir&notfound.conf
 			'https://www.michalspacek.cz/there-is-no.php', // nginx 404, common-headers-redir&notfound.conf
 		];
 		$client = new HttpClient();
-		$actual = [];
-		foreach ($urls as $url) {
-			$request = new HttpClientRequest($url)
+		$httpsActual = $httpActual = $httpUrls = [];
+		foreach ($httpsUrls as $httpsUrl) {
+			$request = new HttpClientRequest($httpsUrl)
 				->setFollowLocation(false) // need a redirect's own headers, not the target's
 				->setIgnoreHttpErrors(true); // the 404 is a response to inspect, not an error to throw on
-			$actual[$url] = $client->get($request)->getHeader('Strict-Transport-Security');
+			$httpUrl = new Url($httpsUrl)->withScheme('http')->toUnicodeString();
+			$httpUrls[] = $httpUrl;
+			$httpsActual[$httpsUrl] = $client->get($request)->getHeader('Strict-Transport-Security');
+			$httpActual[$httpUrl] = $client->get($request->withUrl($httpUrl))->getHeader('Strict-Transport-Security');
 		}
-		Assert::same(array_fill_keys($urls, self::EXPECTED_HSTS), $actual);
+		Assert::same(array_fill_keys($httpsUrls, self::HTTPS_EXPECTED_HSTS), $httpsActual);
+		Assert::same(array_fill_keys($httpUrls, self::HTTP_EXPECTED_HSTS), $httpActual);
 	}
 
 }

--- a/app/tests/Http/HstsHeaderPresentTest.phpt
+++ b/app/tests/Http/HstsHeaderPresentTest.phpt
@@ -1,0 +1,44 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http;
+
+use MichalSpacekCz\Http\Client\HttpClient;
+use MichalSpacekCz\Http\Client\HttpClientRequest;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class HstsHeaderPresentTest extends TestCase
+{
+
+	private const string EXPECTED_HSTS = 'max-age=31536000; includeSubDomains; preload';
+
+
+	public function testHstsSentOnEveryResponseClass(): void
+	{
+		TestCaseRunner::needsInternet();
+		$urls = [
+			'https://www.michalspacek.cz/', // app page, inherits the server-level header
+			'https://www.michalspacek.cz/robots.txt', // static file, common-headers-static.conf
+			'https://www.michalspacek.cz/security.txt', // 301 redirect, common-headers-redir&notfound.conf
+			'https://www.michalspacek.cz/there-is-no.php', // nginx 404, common-headers-redir&notfound.conf
+		];
+		$client = new HttpClient();
+		$actual = [];
+		foreach ($urls as $url) {
+			$request = new HttpClientRequest($url)
+				->setFollowLocation(false) // need a redirect's own headers, not the target's
+				->setIgnoreHttpErrors(true); // the 404 is a response to inspect, not an error to throw on
+			$actual[$url] = $client->get($request)->getHeader('Strict-Transport-Security');
+		}
+		Assert::same(array_fill_keys($urls, self::EXPECTED_HSTS), $actual);
+	}
+
+}
+
+TestCaseRunner::run(HstsHeaderPresentTest::class);

--- a/conf/nginx/common-headers-hsts.conf
+++ b/conf/nginx/common-headers-hsts.conf
@@ -1,0 +1,1 @@
+add_header Strict-Transport-Security $hsts_header always;

--- a/conf/nginx/common-headers-static.conf
+++ b/conf/nginx/common-headers-static.conf
@@ -1,4 +1,3 @@
 include /srv/www/michalspacek.cz/conf/nginx/common-headers.conf;
 add_header Content-Security-Policy "script-src 'none'; report-uri https://plz.report-uri.com/r/default/csp/enforce; report-to default" always;
-add_header Access-Control-Allow-Origin $http_origin;
-add_header Vary Origin;
+add_header Access-Control-Allow-Origin *;

--- a/conf/nginx/common-headers.conf
+++ b/conf/nginx/common-headers.conf
@@ -7,3 +7,4 @@ add_header X-Frame-Options DENY always;
 add_header Integrity-Policy "blocked-destinations=(script), endpoints=(default)" always;
 add_header Report-To '{"group": "default", "max_age": 31536000, "endpoints": [{"url": "https://plz.report-uri.com/a/d/g"}], "include_subdomains": true}' always;
 add_header NEL '{"report_to": "default", "max_age": 31536000, "include_subdomains": true}' always;
+include /srv/www/michalspacek.cz/conf/nginx/common-headers-hsts.conf;

--- a/conf/nginx/common-https.conf
+++ b/conf/nginx/common-https.conf
@@ -2,4 +2,4 @@ include /etc/common-config/nginx/https.conf;
 
 server_tokens off;
 
-add_header Strict-Transport-Security "max-age=31536000; includeSubDomains; preload" always;
+include /srv/www/michalspacek.cz/conf/nginx/common-headers-hsts.conf;

--- a/conf/nginx/common-map.conf
+++ b/conf/nginx/common-map.conf
@@ -1,0 +1,4 @@
+map $scheme $hsts_header {
+    https "max-age=31536000; includeSubDomains; preload";
+    default "";
+}

--- a/conf/nginx/dev-michalspacek.cz.conf
+++ b/conf/nginx/dev-michalspacek.cz.conf
@@ -1,3 +1,5 @@
+include /srv/www/michalspacek.cz/conf/nginx/common-map.conf;
+
 server {
     listen 127.0.0.1:80;
     server_name michalspacek.cz.test;

--- a/conf/nginx/prod-michalspacek.cz.conf
+++ b/conf/nginx/prod-michalspacek.cz.conf
@@ -1,3 +1,5 @@
+include /srv/www/michalspacek.cz/conf/nginx/common-map.conf;
+
 server {
     listen 80 default_server;
     listen [::]:80 default_server;


### PR DESCRIPTION
### HSTS everywhere
HSTS has been served since 2014, but the 2017 move into nginx dropped it from any response whose location sets its own `add_header`, because nginx does not inherit a server level `add_header` into a location that defines one of its own. Only app pages, which take their headers from PHP and inherit the server level HSTS, kept sending it. The value now lives in one `common-headers-hsts.conf`, included both at server level and from `common-headers.conf` that the static, redirect and 404 blocks pull in, so every response sends the same HSTS from a single source.

To keep HSTS covered, a `needsInternet` test hits the live site on a static file, a redirect, a 404 and an app page. The test asserts deployed behavior, so it stays red until this ships and is skipped in a normal `make test` run.

### Fixed `*` for static CORS
The `/i/` assets are public and loaded `crossorigin=anonymous`, so `Access-Control-Allow-Origin: *` says exactly what is true. Unlike a reflected `$http_origin` it fails safe, since `*` is rejected by the browser if `Access-Control-Allow-Credentials` is ever added next to it, so it cannot quietly become a credentialed allow-any leak, and a constant value needs no `Vary: Origin`. This settles the note in `896904a78` (2016) the other way: for public, credential-less assets `*` beats an allowlist that would need updating for every new domain and could not be unit tested.