### PR TITLE
Send `Vary: Origin` whenever CORS check is attempted (and only then)

### DIFF
--- a/app/src/Http/SecurityHeaders/CrossOriginResourceSharing.php
+++ b/app/src/Http/SecurityHeaders/CrossOriginResourceSharing.php
@@ -34,6 +34,7 @@ final readonly class CrossOriginResourceSharing
 	 */
 	public function accessControlAllowOrigin(string $source): void
 	{
+		$this->httpResponse->addHeader('Vary', 'Origin');
 		$origin = $this->httpRequest->getHeader('Origin');
 		if ($origin === null) {
 			return;

--- a/app/src/Presentation/Api/BasePresenter.php
+++ b/app/src/Presentation/Api/BasePresenter.php
@@ -7,6 +7,7 @@ use MichalSpacekCz\Api\Endpoint\EndpointAccess;
 use MichalSpacekCz\Api\Endpoint\EndpointAccessAttribute;
 use MichalSpacekCz\Http\Robots\Robots;
 use MichalSpacekCz\Http\Robots\RobotsRule;
+use MichalSpacekCz\Http\SecurityHeaders\CrossOriginResourceSharing;
 use MichalSpacekCz\Presentation\Www\BasePresenter as WwwBasePresenter;
 use Nette\Application\BadRequestException;
 use Nette\Http\IResponse;
@@ -16,6 +17,7 @@ abstract class BasePresenter extends WwwBasePresenter
 {
 
 	private Robots $robots;
+	private CrossOriginResourceSharing $crossOriginResourceSharing;
 
 
 	/**
@@ -27,11 +29,21 @@ abstract class BasePresenter extends WwwBasePresenter
 	}
 
 
+	/**
+	 * @internal
+	 */
+	public function injectCrossOriginResourceSharing(CrossOriginResourceSharing $crossOriginResourceSharing): void
+	{
+		$this->crossOriginResourceSharing = $crossOriginResourceSharing;
+	}
+
+
 	#[Override]
 	final protected function startup(): void
 	{
 		parent::startup();
 		$this->robots->setHeader([RobotsRule::NoIndex, RobotsRule::NoFollow]);
+		$this->crossOriginResourceSharing->accessControlAllowOrigin('Www:Homepage:');
 		$this->checkAccessAttribute();
 		$this->startupApi();
 	}

--- a/app/src/Presentation/Api/Company/CompanyPresenter.php
+++ b/app/src/Presentation/Api/Company/CompanyPresenter.php
@@ -6,7 +6,6 @@ namespace MichalSpacekCz\Presentation\Api\Company;
 use MichalSpacekCz\Api\Endpoint\EndpointAllowsPublicAccess;
 use MichalSpacekCz\CompanyInfo\CompanyInfo;
 use MichalSpacekCz\Http\FetchMetadata\ResourceIsolationPolicyCrossSite;
-use MichalSpacekCz\Http\SecurityHeaders\CrossOriginResourceSharing;
 use MichalSpacekCz\Presentation\Api\BasePresenter;
 use Nette\Application\BadRequestException;
 
@@ -16,7 +15,6 @@ final class CompanyPresenter extends BasePresenter
 
 	public function __construct(
 		private readonly CompanyInfo $companyInfo,
-		private readonly CrossOriginResourceSharing $crossOriginResourceSharing,
 	) {
 		parent::__construct();
 	}
@@ -28,8 +26,6 @@ final class CompanyPresenter extends BasePresenter
 		if ($country === null || $companyId === null) {
 			throw new BadRequestException('No country or companyId specified');
 		}
-
-		$this->crossOriginResourceSharing->accessControlAllowOrigin('Www:Homepage:');
 		$this->sendJson($this->companyInfo->getDetails($country, $companyId));
 	}
 

--- a/conf/nginx/common-api.michalspacek.cz.conf
+++ b/conf/nginx/common-api.michalspacek.cz.conf
@@ -1,3 +1,2 @@
 root /srv/www/michalspacek.cz/app/public/api;
-add_header Vary Origin always;
 include /srv/www/michalspacek.cz/conf/nginx/common-_.michalspacek.cz.conf;


### PR DESCRIPTION
… and attempt the check for all presenters in the whole Api module.

`Vary: Origin` on all API responses is required for dynamic `Access-Control-Allow-Origin` to prevent CDN cache poisoning. It ensures caches don't accidentally serve an origin-specific response (or a response without CORS headers generated by curl) to the wrong client. Moving it from nginx config closer to where they're needed, nginx would also send the header for a favicon, robots.txt etc, where the header is not needed.

Applying it early in the lifecycle in `startup()` ensures CORS headers are attached globally to all API responses, including 4xx and 5xx errors. If applied in the action, early failures (like 404s) would lack CORS headers, causing the frontend browser to block the response and blinding the JS application from reading the actual error payload.