### PR TITLE
Stop crawls for Pulse passwords URLs that do not exist

### DIFF
--- a/app/public/pulse/robots.txt
+++ b/app/public/pulse/robots.txt
@@ -4,3 +4,5 @@ Disallow: /*/result/
 Disallow: /*/request/
 Disallow: /*/search/
 Disallow: /*/searches/
+Disallow: /passwords/storages/site/*/
+Disallow: /passwords/storages/site/*?


### PR DESCRIPTION
Trying to stop the adult/porn spam traffic again.

Spiritual follow-up to fe95eae0f4d56b263932505ef3ddd3eced616223 and 6c1823b0d755a65be63aa0c7b6b0e2f4f240c802 and eafa3218fb702dbd632a7bfcfc6b36e62b5ed068.