### PR TITLE
Clear the training access token when purging personal data

### DIFF
--- a/app/db/default.sql
+++ b/app/db/default.sql
@@ -331,7 +331,7 @@ CREATE TABLE `training_applications` (
   `invoice_id` int unsigned DEFAULT NULL,
   `paid` datetime DEFAULT NULL,
   `paid_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
-  `access_token` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,
+  `access_token` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci DEFAULT NULL,
   `key_status` int unsigned NOT NULL,
   `status_time` datetime NOT NULL,
   `status_time_timezone` varchar(200) CHARACTER SET utf8mb3 COLLATE utf8mb3_czech_ci NOT NULL,

--- a/app/src/Training/Trainings/Trainings.php
+++ b/app/src/Training/Trainings/Trainings.php
@@ -270,6 +270,7 @@ final class Trainings
 				'company_id' => null,
 				'company_tax_id' => null,
 				'note' => null,
+				'access_token' => null,
 			],
 			$dateIds,
 		);

--- a/app/tests/Training/Trainings/TrainingsTest.phpt
+++ b/app/tests/Training/Trainings/TrainingsTest.phpt
@@ -5,6 +5,7 @@ namespace MichalSpacekCz\Training\Trainings;
 
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -21,10 +22,38 @@ final class TrainingsTest extends TestCase
 	}
 
 
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+	}
+
+
 	public function testGetActionById(): void
 	{
 		$this->database->setFetchFieldDefaultResult('pulled pork');
 		Assert::same('pulled pork', $this->trainings->getActionById(303));
+	}
+
+
+	public function testDeletePersonalData(): void
+	{
+		$this->trainings->deletePersonalData([123, 246]);
+		$params = $this->database->getParamsArrayForQuery('UPDATE training_applications SET ? WHERE key_date IN (?)');
+		Assert::same([
+			'name' => null,
+			'email' => null,
+			'company' => null,
+			'street' => null,
+			'city' => null,
+			'zip' => null,
+			'country' => null,
+			'company_id' => null,
+			'company_tax_id' => null,
+			'note' => null,
+			'access_token' => null,
+		], $params[0]);
+		Assert::same([123, 246], $params[1]);
 	}
 
 }


### PR DESCRIPTION
`deletePersonalData()` nulled the attendee's data but skipped `access_token`, so a purged application kept the access token that had been sent to the attendee. The related files are deleted by the same purge, so the token grants nothing useful afterwards, but a record whose personal data is gone should not retain an access credential that was in someone's inbox. Null it too, so a later leaked token also fails at validation.

`access_token` was `NOT NULL`, so the column is made nullable; the `UNIQUE` key is unaffected because MySQL allows multiple `NULL`s.