### PR TITLE
Rename `redirectToSecure` to `redirectToCanonicalHost`, make it testable

### DIFF
--- a/app/src/Application/WebApplication.php
+++ b/app/src/Application/WebApplication.php
@@ -33,7 +33,10 @@ final readonly class WebApplication
 	public function run(): void
 	{
 		$this->detectCrLfUrlInjectionAttempt();
-		$this->redirectToSecure();
+		if (ServerEnv::tryGetString('HTTP_HOST') !== $this->fqdn) {
+			$this->redirectToCanonicalHost();
+			return;
+		}
 		$this->resourceIsolationPolicy->install();
 		$this->application->onResponse[] = function (): void {
 			$this->securityHeaders->sendHeaders();
@@ -43,14 +46,11 @@ final readonly class WebApplication
 	}
 
 
-	private function redirectToSecure(): void
+	private function redirectToCanonicalHost(): void
 	{
-		if (ServerEnv::tryGetString('HTTP_HOST') !== $this->fqdn) {
-			$this->securityHeaders->sendHeaders(CspValues::Default);
-			$url = $this->httpRequest->getUrl()->withScheme('https')->withHost($this->fqdn);
-			$this->httpResponse->redirect($url->getAbsoluteUrl(), IResponse::S301_MovedPermanently);
-			exit();
-		}
+		$this->securityHeaders->sendHeaders(CspValues::Default);
+		$url = $this->httpRequest->getUrl()->withScheme('https')->withHost($this->fqdn);
+		$this->httpResponse->redirect($url->getAbsoluteUrl(), IResponse::S301_MovedPermanently);
 	}
 
 

--- a/app/src/Test/Application/SpyApplication.php
+++ b/app/src/Test/Application/SpyApplication.php
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Test\Application;
+
+use Nette\Application\Application;
+use Override;
+
+/**
+ * Stands in for the real application so `WebApplication::run()` can be driven in a test
+ * without dispatching a presenter; `$ran` records whether the run was reached.
+ */
+final class SpyApplication extends Application
+{
+
+	private(set) bool $ran = false;
+
+
+	/**
+	 * @noinspection PhpMissingParentConstructorInspection
+	 * @phpstan-ignore constructor.missingParentCall
+	 */
+	public function __construct()
+	{
+	}
+
+
+	#[Override]
+	public function run(): void
+	{
+		$this->ran = true;
+	}
+
+}

--- a/app/src/Test/Http/Response.php
+++ b/app/src/Test/Http/Response.php
@@ -14,6 +14,10 @@ final class Response implements IResponse
 
 	private ?string $reason = null;
 
+	private ?string $redirectUrl = null;
+
+	private ?int $redirectCode = null;
+
 	/** @var array<string, string> */
 	private array $headers = [];
 
@@ -82,6 +86,20 @@ final class Response implements IResponse
 	#[Override]
 	public function redirect(string $url, int $code = self::S302_Found): void
 	{
+		$this->redirectUrl = $url;
+		$this->redirectCode = $code;
+	}
+
+
+	public function getRedirectUrl(): ?string
+	{
+		return $this->redirectUrl;
+	}
+
+
+	public function getRedirectCode(): ?int
+	{
+		return $this->redirectCode;
 	}
 
 
@@ -181,6 +199,8 @@ final class Response implements IResponse
 		$this->cookies = [];
 		$this->cookieDomain = '';
 		$this->cookiePath = '/';
+		$this->redirectUrl = null;
+		$this->redirectCode = null;
 	}
 
 }

--- a/app/tests/Application/WebApplicationTest.phpt
+++ b/app/tests/Application/WebApplicationTest.phpt
@@ -1,0 +1,91 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use MichalSpacekCz\EasterEgg\CrLfUrlInjections;
+use MichalSpacekCz\Http\FetchMetadata\ResourceIsolationPolicy;
+use MichalSpacekCz\Http\SecurityHeaders\SecurityHeaders;
+use MichalSpacekCz\Test\Application\SpyApplication;
+use MichalSpacekCz\Test\Http\Request;
+use MichalSpacekCz\Test\Http\Response;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\UserSessionAdditionalData;
+use Nette\Http\IResponse;
+use Nette\Http\UrlScript;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class WebApplicationTest extends TestCase
+{
+
+	public function __construct(
+		private readonly WebApplication $webApplication,
+		private readonly Request $httpRequest,
+		private readonly Response $httpResponse,
+		private readonly SecurityHeaders $securityHeaders,
+		private readonly CrLfUrlInjections $crLfUrlInjections,
+		private readonly ResourceIsolationPolicy $resourceIsolationPolicy,
+		private readonly UserSessionAdditionalData $userSessionAdditionalData,
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->httpResponse->reset();
+		ServerEnv::unset('HTTP_HOST');
+	}
+
+
+	public function testRedirectsToCanonicalHostOverHttps(): void
+	{
+		$application = new SpyApplication();
+		$this->httpRequest->setUrl(new UrlScript('http://totally.not.fqdn.example/path/here?query=1'));
+		ServerEnv::setString('HTTP_HOST', 'totally.not.fqdn.example');
+
+		$this->createWebApplication($application)->run();
+
+		Assert::false($application->ran); // a wrong host redirects and returns before Application::run()
+		Assert::same(IResponse::S301_MovedPermanently, $this->httpResponse->getRedirectCode());
+		Assert::same(sprintf('https://%s/path/here?query=1', $this->webApplication->getFqdn()), $this->httpResponse->getRedirectUrl());
+	}
+
+
+	public function testDoesNotRedirectWhenAlreadyOnCanonicalHost(): void
+	{
+		$application = new SpyApplication();
+		$this->httpRequest->setUrl(new UrlScript(sprintf('https://%s/path/here', $this->webApplication->getFqdn())));
+		ServerEnv::setString('HTTP_HOST', $this->webApplication->getFqdn());
+
+		$this->createWebApplication($application)->run();
+
+		Assert::true($application->ran); // a canonical host proceeds to Application::run()
+		Assert::null($this->httpResponse->getRedirectCode());
+		Assert::null($this->httpResponse->getRedirectUrl());
+	}
+
+
+	private function createWebApplication(SpyApplication $application): WebApplication
+	{
+		return new WebApplication(
+			$this->httpRequest,
+			$this->httpResponse,
+			$this->securityHeaders,
+			$application,
+			$this->crLfUrlInjections,
+			$this->resourceIsolationPolicy,
+			$this->userSessionAdditionalData,
+			$this->webApplication->getFqdn(),
+		);
+	}
+
+}
+
+TestCaseRunner::run(WebApplicationTest::class);


### PR DESCRIPTION
This redirects a request that arrived on a host other than the configured `fqdn` to `https://fqdn`. The `Secure` in the name is a 2014 relic from when it also forced the scheme and picked a host that had a certificate; what it is for now is the canonical host, since the scheme is already handled upstream by nginx redirecting `http` to `https` at the edge. It stays as an app-level backstop for the wrong-host case, which Nette's canonicalization cannot cover because a wrong host matches no fixed-host route. Name it for what it does.

The host check moves up into `run()` so the method just performs the redirect and `run()` returns, which drops the `exit()` that was the only one left in `src/`. A spy standing in for `Nette\Application\Application` then makes both branches of the dispatch fork observable through the real `run()`: a request on the wrong host comes back as a 301 to `https://fqdn` and never reaches the application, while a request already on the canonical host is left alone and proceeds to it. The response test double now records the `redirect()` target for the assertion.