### PR TITLE
Make the `nette.micro` and `security.txt` routes enforce HTTPS

### DIFF
--- a/app/src/EasterEgg/NetteCve202015227.php
+++ b/app/src/EasterEgg/NetteCve202015227.php
@@ -148,7 +148,7 @@ final readonly class NetteCve202015227
 
 	public function addRoute(RouteList $router): void
 	{
-		$router->withModule('EasterEgg')->addRoute('/nette.micro', ['presenter' => 'Nette', 'action' => 'micro']);
+		$router->withModule('EasterEgg')->addRoute('https://%host%/nette.micro', ['presenter' => 'Nette', 'action' => 'micro']);
 	}
 
 }

--- a/app/src/SecurityTxt/SecurityTxtResponse.php
+++ b/app/src/SecurityTxt/SecurityTxtResponse.php
@@ -39,7 +39,7 @@ final readonly class SecurityTxtResponse
 
 	public function addRoute(RouteList $router): void
 	{
-		$router->withModule('WellKnown')->addRoute('/.well-known/security.txt', ['presenter' => 'WellKnown', 'action' => 'securityTxt']);
+		$router->withModule('WellKnown')->addRoute('https://%host%/.well-known/security.txt', ['presenter' => 'WellKnown', 'action' => 'securityTxt']);
 	}
 
 }

--- a/app/tests/Application/Routing/RouterFactoryTest.phpt
+++ b/app/tests/Application/Routing/RouterFactoryTest.phpt
@@ -4,7 +4,9 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Application\Routing;
 
 use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Application\Routers\RouteList;
 use Nette\Http\UrlScript;
+use Nette\Routing\Route;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -39,6 +41,42 @@ final class RouterFactoryTest extends TestCase
 			'presenter' => 'Api:Certificates',
 			'action' => 'logIssued',
 		], $refUrl));
+	}
+
+
+	public function testEveryRouteEnforcesHttps(): void
+	{
+		$localeRouter = $this->routerFactory->createRouter();
+		$masks = [];
+		foreach ([$localeRouter->getRouteList(), ...array_values($localeRouter->getLocaleRouters())] as $routeList) {
+			$masks = [...$masks, ...$this->collectMasks($routeList)];
+		}
+
+		Assert::notSame([], $masks);
+		$notHttps = [];
+		foreach ($masks as $mask) {
+			if (!str_starts_with($mask, 'https://')) {
+				$notHttps[] = $mask;
+			}
+		}
+		Assert::same([], $notHttps);
+	}
+
+
+	/**
+	 * @return list<string>
+	 */
+	private function collectMasks(RouteList $routeList): array
+	{
+		$masks = [];
+		foreach ($routeList->getRouters() as $router) {
+			if ($router instanceof RouteList) {
+				$masks = [...$masks, ...$this->collectMasks($router)];
+			} elseif ($router instanceof Route) {
+				$masks[] = $router->getMask();
+			}
+		}
+		return $masks;
 	}
 
 }


### PR DESCRIPTION
Every module route is built by `RouterFactory` as `https://host/...`, so it enforces HTTPS by construction, but two routes are registered directly and bypass that: `nette.micro` (the CVE bot trap) and `.well-known/security.txt`. Their relative masks (`/nette.micro`) only inherited HTTPS from the incoming request's scheme rather than pinning it, so they were the one place a route did not force the scheme in the canonical URL it generates.

This is nowhere near the first thing that gets a visitor onto HTTPS: nginx redirects every request at the edge and the domain is HSTS-preloaded, so as a scheme guarantee this is more like the 75th layer, Defense in Depth FTW.

It is here for consistency, so every route pins the scheme the same way instead of one quietly depending on the request. Prefixing the masks with `https://%host%/` does that, and the `%host%` foaming parameter still matches any host so both keep serving on every domain (see https://doc.nette.org/en/application/routing#toc-https).

The new test builds the router and walks every route list, asserting each mask is scheme-prefixed, so a route added directly with a relative mask fails the suite instead of silently depending on the request scheme.