### PR TITLE
Restrict training file uploads to a configured extension allow-list

### DIFF
--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -39,6 +39,10 @@ parameters:
 		reportingApi: https://plz.report-uri.com/a/d/g
 	vatRate: 0.21
 	loadCompanyDataVisible: true
+	trainingFiles:
+		# The file's real type is not verified, only the extension. Images are saved under the extension
+		# detected from their content, so list them as jpeg (not jpg), png, gif, webp
+		allowedExtensions: [7z, docx, gif, gz, jpeg, odp, ods, odt, pdf, png, pptx, tar, tgz, txt, webp, xlsx, zip]
 	permanentLogin:
 		interval: 14 days
 	session:

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -181,7 +181,7 @@ services:
 	- MichalSpacekCz\Training\Dates\UpcomingTrainingDates
 	- MichalSpacekCz\Training\Discontinued\DiscontinuedTrainings
 	- MichalSpacekCz\Training\Files\TrainingFileFactory
-	- MichalSpacekCz\Training\Files\TrainingFiles
+	- MichalSpacekCz\Training\Files\TrainingFiles(allowedExtensions: %trainingFiles.allowedExtensions%)
 	- MichalSpacekCz\Training\Files\TrainingFilesDownload
 	trainingFilesStorage: MichalSpacekCz\Training\Files\TrainingFilesStorage
 	- MichalSpacekCz\Training\FreeSeats

--- a/app/src/Form/Training/TrainingFileFormFactory.php
+++ b/app/src/Form/Training/TrainingFileFormFactory.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Form\Training;
 use DateTimeInterface;
 use MichalSpacekCz\Form\FormFactory;
 use MichalSpacekCz\Training\Files\TrainingFiles;
+use MichalSpacekCz\Utils\MimeType;
 use Nette\Forms\Form;
 use Nette\Http\FileUpload;
 use Nette\Utils\Html;
@@ -27,8 +28,32 @@ final readonly class TrainingFileFormFactory
 	public function create(callable $onSuccess, DateTimeInterface $trainingStart, array $applicationIdsAllowedFiles): Form
 	{
 		$form = $this->factory->create();
-		$form->addUpload('file', 'Soubor:');
+		$allowedExtensions = $this->trainingFiles->getAllowedExtensions();
+		$accept = [];
+		foreach ($allowedExtensions as $extension) {
+			$accept[] = ".{$extension}";
+			// Images also get MIME type in the list, because some (mobile) pickers match images by type rather than by extension
+			$mimeType = MimeType::getMimeTypeByExtension($extension);
+			if ($mimeType !== null) {
+				$accept[] = $mimeType;
+			}
+		}
+		$upload = $form->addUpload('file', 'Soubor:')
+			->setHtmlAttribute('accept', implode(',', $accept));
 		$form->addSubmit('submit', 'Přidat');
+		$form->onValidate[] = function () use ($upload, $allowedExtensions): void {
+			$file = $upload->getValue();
+			if (!$file instanceof FileUpload || !$file->hasFile()) {
+				return;
+			}
+			$extension = pathinfo($file->getSanitizedName(), PATHINFO_EXTENSION);
+			if (!$this->trainingFiles->isAllowedExtension($extension)) {
+				// For an image the extension is rewritten by the detected MIME type and may differ from the uploaded filename ext
+				$mime = $file->getContentType() ?? 'neznámý';
+				$allowed = implode(', ', $allowedExtensions);
+				$upload->addError("Nepodporovaný soubor (přípona {$extension}, typ {$mime}), povolené přípony: {$allowed}");
+			}
+		};
 		$form->onSuccess[] = function (Form $form) use ($onSuccess, $trainingStart, $applicationIdsAllowedFiles): void {
 			$values = $form->getValues();
 			assert($values->file instanceof FileUpload);

--- a/app/src/Presentation/Admin/Trainings/files.latte
+++ b/app/src/Presentation/Admin/Trainings/files.latte
@@ -15,7 +15,8 @@
 </ol>
 <hr>
 {form file}
-<p class="separated"><strong>{label file /}</strong> {input file}</p>
+<p class="separated"><strong>{label file /}</strong> {input file} <small>kontroluje se jen přípona souboru, ne jeho obsah</small></p>
+<p class="inputError" n:if="$form['file']->hasErrors()"><strong>{inputError file}</strong></p>
 <p>{input submit}</p>
 {/form file}
 {/define}

--- a/app/src/Training/Exceptions/TrainingFileUnsupportedExtensionException.php
+++ b/app/src/Training/Exceptions/TrainingFileUnsupportedExtensionException.php
@@ -1,0 +1,26 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Training\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class TrainingFileUnsupportedExtensionException extends RuntimeException
+{
+
+	/**
+	 * @param list<string> $allowedExtensions
+	 */
+	public function __construct(string $name, array $allowedExtensions, ?string $mimeType, ?Throwable $previous = null)
+	{
+		$message = sprintf(
+			"Unsupported training file extension of '%s' (%s), allowed extensions: %s",
+			$name,
+			$mimeType ?? 'unknown type',
+			implode(', ', $allowedExtensions),
+		);
+		parent::__construct($message, previous: $previous);
+	}
+
+}

--- a/app/src/Training/Files/TrainingFiles.php
+++ b/app/src/Training/Files/TrainingFiles.php
@@ -3,9 +3,9 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\Files;
 
-use DateTime;
 use DateTimeInterface;
 use MichalSpacekCz\Database\TypedDatabase;
+use MichalSpacekCz\DateTime\DateTimeFactory;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\ApplicationStatuses\TrainingApplicationStatuses;
 use MichalSpacekCz\Training\Exceptions\TrainingFileUnsupportedExtensionException;
@@ -29,6 +29,7 @@ final readonly class TrainingFiles
 		private TrainingApplicationStatuses $trainingApplicationStatuses,
 		private TrainingFileFactory $trainingFileFactory,
 		private TrainingFilesStorage $trainingFilesStorage,
+		private DateTimeFactory $dateTimeFactory,
 		private array $allowedExtensions,
 	) {
 	}
@@ -123,7 +124,7 @@ final readonly class TrainingFiles
 		}
 		$file->move($this->trainingFilesStorage->getFilesDir($start) . $name);
 
-		$datetime = new DateTime();
+		$datetime = $this->dateTimeFactory->create();
 		$this->database->beginTransaction();
 
 		$timeZone = $datetime->getTimezone()->getName();

--- a/app/src/Training/Files/TrainingFiles.php
+++ b/app/src/Training/Files/TrainingFiles.php
@@ -8,6 +8,8 @@ use DateTimeInterface;
 use MichalSpacekCz\Database\TypedDatabase;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\ApplicationStatuses\TrainingApplicationStatuses;
+use MichalSpacekCz\Training\Exceptions\TrainingFileUnsupportedExtensionException;
+use MichalSpacekCz\Utils\MimeType;
 use Nette\Database\Explorer;
 use Nette\Http\FileUpload;
 use Nette\Utils\FileSystem;
@@ -15,13 +17,40 @@ use Nette\Utils\FileSystem;
 final readonly class TrainingFiles
 {
 
+	/**
+	 * Extensions must be lowercase: isAllowedExtension() lowercases the uploaded name's extension but
+	 * not this list, so a non-lowercase entry like PDF would silently never match.
+	 *
+	 * @param list<lowercase-string> $allowedExtensions
+	 */
 	public function __construct(
 		private Explorer $database,
 		private TypedDatabase $typedDatabase,
 		private TrainingApplicationStatuses $trainingApplicationStatuses,
 		private TrainingFileFactory $trainingFileFactory,
 		private TrainingFilesStorage $trainingFilesStorage,
+		private array $allowedExtensions,
 	) {
+	}
+
+
+	/**
+	 * @return list<lowercase-string>
+	 */
+	public function getAllowedExtensions(): array
+	{
+		return $this->allowedExtensions;
+	}
+
+
+	/**
+	 * Matched on the extension only; the file's real type is not verified, so e.g. a binary named .txt
+	 * is accepted. Harmless: these files are only ever downloaded as content-typed attachments served by
+	 * TrainingFilesDownload from outside the web root, never executed or rendered inline.
+	 */
+	public function isAllowedExtension(string $extension): bool
+	{
+		return in_array(strtolower($extension), $this->allowedExtensions, true);
 	}
 
 
@@ -87,7 +116,11 @@ final readonly class TrainingFiles
 	 */
 	public function addFile(DateTimeInterface $start, FileUpload $file, array $applicationIds): string
 	{
-		$name = basename($file->getSanitizedName());
+		$name = $file->getSanitizedName();
+		if (!$this->isAllowedExtension(pathinfo($name, PATHINFO_EXTENSION))) {
+			$mimeType = MimeType::detectMimeType($file->getTemporaryFile());
+			throw new TrainingFileUnsupportedExtensionException($name, $this->allowedExtensions, $mimeType);
+		}
 		$file->move($this->trainingFilesStorage->getFilesDir($start) . $name);
 
 		$datetime = new DateTime();

--- a/app/src/Training/Files/TrainingFilesDownload.php
+++ b/app/src/Training/Files/TrainingFilesDownload.php
@@ -3,11 +3,11 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\Files;
 
-use finfo;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Training\Applications\TrainingApplication;
 use MichalSpacekCz\Training\Applications\TrainingApplications;
 use MichalSpacekCz\Training\Exceptions\TrainingApplicationDoesNotExistException;
+use MichalSpacekCz\Utils\MimeType;
 use Nette\Application\Application;
 use Nette\Application\BadRequestException;
 use Nette\Application\Responses\FileResponse;
@@ -71,8 +71,7 @@ final readonly class TrainingFilesDownload
 			throw new BadRequestException(sprintf('No file %s for application id %s', $filename, $applicationId));
 		}
 		$pathname = $file->getFileInfo()->getPathname();
-		$mimeType = (new finfo(FILEINFO_MIME_TYPE))->file($pathname);
-		return new FileResponse($pathname, null, $mimeType !== false ? $mimeType : null);
+		return new FileResponse($pathname, null, MimeType::detectMimeType($pathname));
 	}
 
 

--- a/app/src/Utils/Exceptions/EmptyFilenameException.php
+++ b/app/src/Utils/Exceptions/EmptyFilenameException.php
@@ -1,0 +1,17 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Utils\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class EmptyFilenameException extends RuntimeException
+{
+
+	public function __construct(?Throwable $previous = null)
+	{
+		parent::__construct('The filename is an empty string', previous: $previous);
+	}
+
+}

--- a/app/src/Utils/MimeType.php
+++ b/app/src/Utils/MimeType.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Utils;
+
+use finfo;
+use MichalSpacekCz\Utils\Exceptions\EmptyFilenameException;
+
+final readonly class MimeType
+{
+
+	private const array IMAGE_MIME_TYPES_BY_EXTENSION = [
+		'gif' => 'image/gif',
+		'jpeg' => 'image/jpeg',
+		'png' => 'image/png',
+		'webp' => 'image/webp',
+	];
+
+
+	/**
+	 * @throws EmptyFilenameException
+	 */
+	public static function detectMimeType(string $filename): ?string
+	{
+		if ($filename === '') {
+			throw new EmptyFilenameException();
+		}
+		$type = new finfo(FILEINFO_MIME_TYPE)->file($filename);
+		return $type !== false ? $type : null;
+	}
+
+
+	/**
+	 * @param lowercase-string $extension
+	 */
+	public static function getMimeTypeByExtension(string $extension): ?string
+	{
+		return self::IMAGE_MIME_TYPES_BY_EXTENSION[$extension] ?? null;
+	}
+
+}

--- a/app/tests/Training/Files/TrainingFilesTest.phpt
+++ b/app/tests/Training/Files/TrainingFilesTest.phpt
@@ -4,7 +4,16 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Training\Files;
 
+use DateTimeImmutable;
+use MichalSpacekCz\DateTime\DateTimeFormat;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\DateTime\DateTimeMachineFactory;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\Test\Training\TrainingFilesNullStorage;
+use MichalSpacekCz\Training\Exceptions\TrainingFileUnsupportedExtensionException;
+use Nette\Http\FileUpload;
+use Nette\Utils\FileSystem;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -16,7 +25,18 @@ final class TrainingFilesTest extends TestCase
 
 	public function __construct(
 		private readonly TrainingFiles $trainingFiles,
+		private readonly TrainingFilesNullStorage $storage,
+		private readonly Database $database,
+		private readonly DateTimeMachineFactory $dateTimeFactory,
 	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->dateTimeFactory->setDateTime(null);
 	}
 
 
@@ -29,6 +49,80 @@ final class TrainingFilesTest extends TestCase
 		Assert::false($this->trainingFiles->isAllowedExtension('jpg')); // nette/forms saves an uploaded JPEG as .jpeg, not .jpg
 		Assert::false($this->trainingFiles->isAllowedExtension('php'));
 		Assert::false($this->trainingFiles->isAllowedExtension('html'));
+	}
+
+
+	public function testAddFileRejectsDisallowedExtensionReportingDetectedType(): void
+	{
+		$content = "This is plain text, not an executable.\n";
+		$tmpName = $this->uniqueTempPath();
+		FileSystem::write($tmpName, $content);
+		$file = new FileUpload([
+			'name' => 'malware.exe',
+			'tmp_name' => $tmpName,
+			'size' => strlen($content),
+			'error' => UPLOAD_ERR_OK,
+		]);
+		try {
+			$e = Assert::exception(function () use ($file): void {
+				$this->trainingFiles->addFile(new DateTimeImmutable(), $file, [1]);
+			}, TrainingFileUnsupportedExtensionException::class);
+			assert($e instanceof TrainingFileUnsupportedExtensionException);
+			// The type is detected from the file content (text/plain), not derived from the .exe name
+			Assert::same(
+				"Unsupported training file extension of 'malware.exe' (text/plain), allowed extensions: 7z, docx, gif, gz, jpeg, odp, ods, odt, pdf, png, pptx, tar, tgz, txt, webp, xlsx, zip",
+				$e->getMessage(),
+			);
+		} finally {
+			FileSystem::delete($tmpName);
+		}
+	}
+
+
+	public function testAddFileStoresAllowedFileAndRecordsIt(): void
+	{
+		$now = new DateTimeImmutable('2020-10-20 12:34:56');
+		$this->dateTimeFactory->setDateTime($now);
+		$filesDir = $this->uniqueTempPath() . '/';
+		$this->storage->setFilesDir($filesDir);
+		$this->database->setDefaultInsertId('1337');
+
+		$content = "Course notes, plain text.\n";
+		$tmpName = $this->uniqueTempPath();
+		FileSystem::write($tmpName, $content);
+		$file = new FileUpload([
+			'name' => 'notes.txt',
+			'tmp_name' => $tmpName,
+			'size' => strlen($content),
+			'error' => UPLOAD_ERR_OK,
+		]);
+		try {
+			$name = $this->trainingFiles->addFile(new DateTimeImmutable(), $file, [42]);
+			Assert::same('notes.txt', $name);
+			Assert::same($content, FileSystem::read($filesDir . 'notes.txt'));
+
+			Assert::same(
+				[[
+					'filename' => 'notes.txt',
+					'added' => $now->format(DateTimeFormat::MYSQL),
+					'added_timezone' => $now->getTimezone()->getName(),
+				]],
+				$this->database->getParamsArrayForQuery('INSERT INTO files'),
+			);
+			Assert::same(
+				[['key_file' => '1337', 'key_application' => 42]],
+				$this->database->getParamsArrayForQuery('INSERT INTO training_materials'),
+			);
+		} finally {
+			FileSystem::delete($filesDir);
+			FileSystem::delete($tmpName);
+		}
+	}
+
+
+	private function uniqueTempPath(): string
+	{
+		return sys_get_temp_dir() . '/training-file-upload-test-' . bin2hex(random_bytes(8));
 	}
 
 }

--- a/app/tests/Training/Files/TrainingFilesTest.phpt
+++ b/app/tests/Training/Files/TrainingFilesTest.phpt
@@ -1,0 +1,36 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Training\Files;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class TrainingFilesTest extends TestCase
+{
+
+	public function __construct(
+		private readonly TrainingFiles $trainingFiles,
+	) {
+	}
+
+
+	public function testIsAllowedExtension(): void
+	{
+		Assert::true($this->trainingFiles->isAllowedExtension('pdf'));
+		Assert::true($this->trainingFiles->isAllowedExtension('PDF'));
+		Assert::true($this->trainingFiles->isAllowedExtension('png'));
+		Assert::true($this->trainingFiles->isAllowedExtension('jpeg'));
+		Assert::false($this->trainingFiles->isAllowedExtension('jpg')); // nette/forms saves an uploaded JPEG as .jpeg, not .jpg
+		Assert::false($this->trainingFiles->isAllowedExtension('php'));
+		Assert::false($this->trainingFiles->isAllowedExtension('html'));
+	}
+
+}
+
+TestCaseRunner::run(TrainingFilesTest::class);

--- a/app/tests/Utils/MimeTypeTest.phpt
+++ b/app/tests/Utils/MimeTypeTest.phpt
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Utils;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\Utils\Exceptions\EmptyFilenameException;
+use Tester\Assert;
+use Tester\FileMock;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class MimeTypeTest extends TestCase
+{
+
+	/**
+	 * @return list<array{0:string, 1:string}>
+	 */
+	public function getContents(): array
+	{
+		return [
+			['image/gif', "\x47\x49\x46\x38\x39\x61\x01\x00\x01\x00\x00\x00\x00\x2C\x00\x00\x00\x00\x01\x00\x01\x00\x00\x02\x01\x01\x00\x3B"],
+			['application/x-7z-compressed', "\x37\x7A\xBC\xAF\x27\x1C\x00\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00"],
+			['application/pdf', "\x25\x50\x44\x46\x2D\x31\x2E\x0A\x31\x20\x30\x20\x6F\x62\x6A\x3C\x3C\x2F\x50\x61\x67\x65\x73\x20\x32\x20\x30\x20\x52\x3E\x3E\x65\x6E\x64\x6F\x62\x6A\x0A\x32\x20\x30\x20\x6F\x62\x6A\x3C\x3C\x2F\x4B\x69\x64\x73\x5B\x33\x20\x30\x20\x52\x5D\x2F\x43\x6F\x75\x6E\x74\x20\x31\x3E\x3E\x65\x6E\x64\x6F\x62\x6A\x0A\x33\x20\x30\x20\x6F\x62\x6A\x3C\x3C\x2F\x50\x61\x72\x65\x6E\x74\x20\x32\x20\x30\x20\x52\x3E\x3E\x65\x6E\x64\x6F\x62\x6A\x0A\x74\x72\x61\x69\x6C\x65\x72\x20\x3C\x3C\x2F\x52\x6F\x6F\x74\x20\x31\x20\x30\x20\x52\x3E\x3E"],
+			['text/plain', 'pain text'],
+			['application/x-empty', ''],
+		];
+	}
+
+
+	/**
+	 * @dataProvider getContents
+	 */
+	public function testDetectMimeType(string $expectedType, string $contents): void
+	{
+		$file = FileMock::create($contents);
+		Assert::same($expectedType, MimeType::detectMimeType($file));
+	}
+
+
+	public function testDetectMimeTypeEmptyFilename(): void
+	{
+		Assert::throws(fn() => MimeType::detectMimeType(''), EmptyFilenameException::class);
+	}
+
+
+	/**
+	 * @return list<array{0:lowercase-string, 1:string}>
+	 */
+	public function getMimeTypes(): array
+	{
+		return [
+			['gif', 'image/gif'],
+			['jpeg', 'image/jpeg'],
+			['png', 'image/png'],
+			['webp', 'image/webp'],
+		];
+	}
+
+
+	/**
+	 * @param lowercase-string $extension
+	 * @dataProvider getMimeTypes
+	 */
+	public function testGetMimeTypeByExtension(string $extension, string $type): void
+	{
+		Assert::same($type, MimeType::getMimeTypeByExtension($extension));
+	}
+
+}
+
+TestCaseRunner::run(MimeTypeTest::class);

--- a/app/tests/php-unix.ini
+++ b/app/tests/php-unix.ini
@@ -2,6 +2,7 @@
 extension=ctype.so
 extension=dom.so
 extension=fileinfo.so
+extension=gd.so
 extension=iconv.so
 extension=intl.so
 extension=mbstring.so


### PR DESCRIPTION
Training file uploads accepted any type. It was never actually exploitable: the upload is admin-only, files land outside every web root (so a stored `.php` cannot execute), and every download forces `Content-Disposition: attachment` (so a stored `.html`/`.svg` cannot render inline). So this is defense in depth, not a patch. It holds the line if a future web-server change ever maps a document root near `app/files/`.

The list is config-driven (`trainingFiles.allowedExtensions`) and surfaced in the upload form through the `accept` attribute. It is enforced twice: the form rejects on submit, and a backstop throw in `addFile()` guards the service directly, because that is the real boundary, not the UI. A rejected upload names the extension and MIME type detected from the file next to the allowed extensions, so the admin sees both what they sent and what passes, which matters when an image's extension is rewritten to the one detected from its content.

The gate is by extension, not by detected MIME. The fileinfo extension (the finfo class) identifies these formats precisely (a `.docx` is not merely a zip), so detection is not the issue; the issue is that a content-type check does not control the stored name, and its extension is what a web server would key on. A genuine PDF uploaded as `evil.php` passes a MIME check yet still lands as `.php`. So the extension is the axis that matters here, and an extension list also stays readable and editable, unlike a wall of `application/vnd.openxmlformats-...` strings.

Images are the one type whose stored extension does come from the content: Nette rewrites an uploaded image's name to the extension it detects, so a JPEG is saved as `jpeg` (never `jpg`) whatever it was called, and that detected extension is what the list must hold. The `accept` attribute also carries the image MIME types, because some file pickers match images by MIME type rather than by extension.