### PR TITLE
Add a `data-submit-once` attribute that guards a form against double submits

### DIFF
--- a/app/public/www.michalspacek.cz/i/js/app.js
+++ b/app/public/www.michalspacek.cz/i/js/app.js
@@ -30,6 +30,14 @@ App.onChange = function (selector, listener) {
 App.onLoad = function (selector, listener) {
 	App.on('load', selector, listener);
 }
+App.onDelegated = function (type, selector, listener) {
+	document.addEventListener(type, function (event) {
+		const element = event.target.closest?.(selector);
+		if (element) {
+			listener.call(element, event);
+		}
+	});
+}
 App.clone = function (element) {
 	const cloned = element.cloneNode(true);
 	const sourceElements = element.getElementsByTagName('*');
@@ -72,3 +80,25 @@ App.bufferToBase64url = function (buffer) {
 	}
 	return btoa(binary).replaceAll('+', '-').replaceAll('/', '_').replaceAll('=', '');
 }
+
+// A form marked with data-submit-once has its submit buttons disabled after the first submit for
+// data-submit-once-timeout seconds (default 5), showing their data-submit-once-disabled-label while disabled
+App.onDelegated('submit', 'form[data-submit-once]', function (event) {
+	if (event.defaultPrevented) {
+		return;
+	}
+	const buttons = this.querySelectorAll('[type="submit"]');
+	const labels = new Map();
+	for (const button of buttons) {
+		labels.set(button, button.value);
+		button.disabled = true;
+		button.value = button.dataset.submitOnceDisabledLabel ?? button.value;
+	}
+	const reenableAfter = (parseInt(this.dataset.submitOnceTimeout, 10) || 5) * 1000;
+	setTimeout(function () {
+		for (const button of buttons) {
+			button.disabled = false;
+			button.value = labels.get(button);
+		}
+	}, reenableAfter);
+});

--- a/app/public/www.michalspacek.cz/i/js/upckeys.js
+++ b/app/public/www.michalspacek.cz/i/js/upckeys.js
@@ -1,25 +1,6 @@
 App.ready(document, function () {
-	let submitted = false;
 	let timer = null;
 	let orig = null;
-	App.on('submit', '#frm-ssid', function () {
-		if (submitted) {
-			return false;
-		}
-		submitted = true;
-		const s = document.querySelector('#submit');
-		const alt = s.dataset.alt;
-		s.dataset.alt = s.value;
-		s.value = alt;
-		s.disabled = true;
-		setTimeout(function () {
-			const alt = s.value;
-			s.value = s.dataset.alt;
-			s.disabled = false;
-			s.dataset.alt = alt;
-			submitted = false;
-		}, 5000);
-	});
 	const listener = function () {
 		const filterType = document.querySelector('#filterType').value;
 		const filterPrefix = document.querySelector('#filterPrefix').value;

--- a/app/src/Form/UpcKeysSsidFormFactory.php
+++ b/app/src/Form/UpcKeysSsidFormFactory.php
@@ -29,8 +29,7 @@ final readonly class UpcKeysSsidFormFactory
 			->setRequired('Please enter an SSID')
 			->addRule(Form::Pattern, 'Wi-Fi network name has to be "UPC" and 7 digits (UPC1234567)', '\s*' . $this->upcKeys->getValidSsidPattern() . '\s*');
 		$form->addSubmit('submit', 'Get keys')
-			->setHtmlId('submit')
-			->setHtmlAttribute('data-alt', 'Wait…');
+			->setHtmlId('submit');
 		$form->onSuccess[] = function (Form $form) use ($onSuccess): void {
 			$values = $form->getValues();
 			assert(is_string($values->ssid));

--- a/app/src/Presentation/Admin/Trainings/files.latte
+++ b/app/src/Presentation/Admin/Trainings/files.latte
@@ -14,7 +14,7 @@
 	<li>{$file->getFileInfo()->getPathInfo()->getBasename()}/{$file->getFilename()} {if $file->getFileInfo()->isReadable()}({$file->getFileInfo()->getSize()|bytes}, přidáno {$file->getAdded()|localeDay}){else}<strong>does not exist</strong>{/if}</li>
 </ol>
 <hr>
-{form file}
+{form file, data-submit-once => true}
 <p class="separated"><strong>{label file /}</strong> {input file} <small>kontroluje se jen přípona souboru, ne jeho obsah</small></p>
 <p class="inputError" n:if="$form['file']->hasErrors()"><strong>{inputError file}</strong></p>
 <p>{input submit}</p>

--- a/app/src/Presentation/UpcKeys/Homepage/default.latte
+++ b/app/src/Presentation/UpcKeys/Homepage/default.latte
@@ -42,7 +42,7 @@
 	<div id="result">
 		<div n:ifset="$error" class="error"><strong>{$error}</strong></div>
 		<div>
-		{form ssid}
+		{form ssid, data-submit-once => true, data-submit-once-disabled-label => Wait…}
 		{label ssid /} {input ssid} {input submit}
 		{/form}
 		</div>


### PR DESCRIPTION
Double-clicking a submit button posts the form twice. A form marked `data-submit-once` now has its submit buttons disabled on the first submit, so the second click hits a dead button; the first still goes through, because submission is detected from the posted data, not the (now-dropped) button.

Possible customization: the buttons re-enable after **`data-submit-once-timeout`** seconds (default 5), so a request that fails or times out without navigating away doesn't leave them stuck, and each shows its **`data-submit-once-disabled-label`** while disabled.

Disabling is skipped when client-side validation cancels the submit: the handler is delegated on `document`, so it runs after netteForms' form-level validation and reads `event.defaultPrevented` rather than re-validating.

Use `data-submit-once` on the file upload and also UPC keys forms where it was previously hand-rolled.

Follow-up:
- #836