### PR TITLE
basename the stored image filename so it can't traverse the image directory

### DIFF
--- a/app/src/Media/Resources/MediaResources.php
+++ b/app/src/Media/Resources/MediaResources.php
@@ -24,7 +24,7 @@ abstract class MediaResources
 
 	public function getImageFilename(int $id, string $fileName): string
 	{
-		return "{$this->locationRoot}/{$this->imagesRoot}/{$this->getSubDir()}/{$id}/{$fileName}";
+		return "{$this->locationRoot}/{$this->imagesRoot}/{$this->getSubDir()}/{$id}/" . basename($fileName);
 	}
 
 

--- a/app/tests/Media/Resources/MediaResourcesTest.phpt
+++ b/app/tests/Media/Resources/MediaResourcesTest.phpt
@@ -1,0 +1,34 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Media\Resources;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class MediaResourcesTest extends TestCase
+{
+
+	public function testGetImageFilenameStripsPathTraversal(): void
+	{
+		$mediaResources = new class ('images', 'https://static.example', '/var/www') extends MediaResources {
+
+			#[Override]
+			protected function getSubDir(): string
+			{
+				return 'slides';
+			}
+
+		};
+		Assert::same('/var/www/images/slides/42/hash.png', $mediaResources->getImageFilename(42, 'hash.png'));
+		Assert::same('/var/www/images/slides/42/passwd', $mediaResources->getImageFilename(42, '../../../etc/passwd'));
+	}
+
+}
+
+TestCaseRunner::run(MediaResourcesTest::class);


### PR DESCRIPTION
A slide's `filename` is an admin-editable free-text field stored in `talk_slides.filename`. On a slide replace with removal it comes back as `$originalFile` and flows raw into `MediaResources::getImageFilename()`, which built the path by concatenation, and on into `rename()` and `unlink()`, so a value like `../../../some/file` would traverse out of the image directory - an arbitrary-file rename-then-delete for the web user.

It is admin-only, behind CSRF, and a normal upload names the file after a content hash with no separator, so this is defense in depth for a multi-admin bar rather than a live hole - the slide counterpart to the training-upload allow-list in #834. `basename()` at the sink covers every caller and is a no-op for the content-hash names.

Follow-ups:
- #838