### PR TITLE
Validate the slide filename fields against the allowed image names

### DIFF
--- a/app/src/Form/Talk/TalkSlidesFormFactory.php
+++ b/app/src/Form/Talk/TalkSlidesFormFactory.php
@@ -15,6 +15,7 @@ use Nette\Application\Request;
 use Nette\Forms\Container;
 use Nette\Forms\Control;
 use Nette\Forms\Controls\BaseControl;
+use Nette\Forms\Controls\TextInput;
 use Nette\Forms\Form;
 use Nette\Http\FileUpload;
 use Nette\Utils\ArrayHash;
@@ -125,6 +126,19 @@ final readonly class TalkSlidesFormFactory
 	}
 
 
+	/**
+	 * @param non-empty-list<string> $extensions
+	 */
+	private function addSlideFilenameField(Container $container, string $name, array $extensions, bool $disabled): TextInput
+	{
+		$pattern = '[a-zA-Z0-9_-]+\.(' . implode('|', $extensions) . ')';
+		return $container->addText($name, 'Soubor:')
+			->setDisabled($disabled)
+			->setHtmlAttribute('class', 'slide-filename')
+			->addRule(Form::Pattern, 'Neplatný název souboru, povolené přípony: ' . implode(', ', $extensions), $pattern);
+	}
+
+
 	private function addSlideFields(Container $container, ?int $filenamesTalkId): void
 	{
 		$supportedImages = '*.' . implode(', *.', $this->supportedImageFileFormats->getMainExtensions());
@@ -147,9 +161,7 @@ final readonly class TalkSlidesFormFactory
 			->addRule(Form::MimeType, "Soubor musí být obrázek typu {$supportedImages}", $this->supportedImageFileFormats->getMainContentTypes())
 			->setHtmlAttribute('title', "Nahradit soubor ({$supportedImages})")
 			->setHtmlAttribute('accept', implode(',', $this->supportedImageFileFormats->getMainContentTypes()));
-		$container->addText('filename', 'Soubor:')
-			->setDisabled($disableSlideUploads)
-			->setHtmlAttribute('class', 'slide-filename')
+		$this->addSlideFilenameField($container, 'filename', $this->supportedImageFileFormats->getMainExtensions(), $disableSlideUploads)
 			->addConditionOn($upload, Form::Blank)
 				->setRequired('Zadejte prosím soubor');
 		$container->addUpload('replaceAlternative', 'Nahradit:')
@@ -157,9 +169,7 @@ final readonly class TalkSlidesFormFactory
 			->addRule(Form::MimeType, "Alternativní soubor musí být obrázek typu {$supportedAlternativeImages}", $this->supportedImageFileFormats->getAlternativeContentTypes())
 			->setHtmlAttribute('title', "Nahradit alternativní soubor ({$supportedAlternativeImages})")
 			->setHtmlAttribute('accept', implode(',', $this->supportedImageFileFormats->getAlternativeContentTypes()));
-		$container->addText('filenameAlternative', 'Soubor:')
-			->setDisabled($disableSlideUploads)
-			->setHtmlAttribute('class', 'slide-filename');
+		$this->addSlideFilenameField($container, 'filenameAlternative', $this->supportedImageFileFormats->getAlternativeExtensions(), $disableSlideUploads);
 		$ruleTexyTalkSlides = $this->talkSlidesTexyRuleFactory->create();
 		$container->addTextArea('speakerNotes', 'Poznámky:')
 			->addRule($ruleTexyTalkSlides->getRule())

--- a/app/tests/Form/Talk/TalkSlidesFormFactoryTest.phpt
+++ b/app/tests/Form/Talk/TalkSlidesFormFactoryTest.phpt
@@ -9,6 +9,8 @@ use MichalSpacekCz\Talks\Slides\TalkSlideCollection;
 use MichalSpacekCz\Test\Application\ApplicationPresenter;
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\Application\Request;
+use Nette\Forms\Container;
+use Nette\Forms\Controls\TextInput;
 use Nette\Http\FileUpload;
 use Nette\Utils\Arrays;
 use Nette\Utils\Html;
@@ -53,6 +55,33 @@ final class TalkSlidesFormFactoryTest extends TestCase
 		Assert::same('messages.talks.admin.slideadded', $onSuccessMessage);
 		Assert::same('info', $onSuccessType);
 		Assert::same($talkId, $onSuccessTalkId);
+	}
+
+
+	public function testFilenameFieldRejectsPathTraversal(): void
+	{
+		$talkId = 123;
+		$slides = new TalkSlideCollection($talkId);
+		$slides->add(new TalkSlide(1, 'slide1', 1, 'slide1.jpg', 'slide-alt.jpg', null, 'Title 1', Html::fromText('Notes 1'), 'Notes 1', null, null, null));
+		$form = $this->talkSlidesFormFactory->create(function (): void {
+		}, $talkId, $slides, 0, new Request('foo'));
+		$this->applicationPresenter->anchorForm($form);
+
+		$slidesContainer = $form->getComponent('slides');
+		assert($slidesContainer instanceof Container);
+		$slideContainer = $slidesContainer->getComponent('1');
+		assert($slideContainer instanceof Container);
+		$filename = $slideContainer->getComponent('filename');
+		assert($filename instanceof TextInput);
+
+		$filename->setDefaultValue('../../../etc/passwd');
+		$filename->validate();
+		Assert::true($filename->hasErrors());
+
+		$filename->cleanErrors();
+		$filename->setDefaultValue('abc-123_DEF.png');
+		$filename->validate();
+		Assert::false($filename->hasErrors());
 	}
 
 


### PR DESCRIPTION
The slide `filename`/`filenameAlternative` are admin-editable free-text fields. #837 stopped a `../` value from traversing the filesystem at the `getImageFilename` sink, but the value itself could still be stored in `talk_slides.filename`; this rejects it at the source with a `Form::Pattern` rule requiring `[A-Za-z0-9_-]+` plus a supported extension.

The allowed extensions come from `SupportedImageFileFormats` so the rule can't drift from the content-type allow-list, and every legitimate value already matches since filenames are the base64url content hash of an upload. Defense in depth on top of #837: no bad value reaches the DB for a future path-builder to trip over.