### PR TITLE
Reject non-http(s) URLs in HttpClientRequest

### DIFF
--- a/app/src/Http/Client/HttpClientRequest.php
+++ b/app/src/Http/Client/HttpClientRequest.php
@@ -3,6 +3,9 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Http\Client;
 
+use MichalSpacekCz\Http\Exceptions\HttpClientRequestUnsupportedSchemeException;
+use Uri\WhatWg\Url;
+
 final class HttpClientRequest
 {
 
@@ -20,9 +23,16 @@ final class HttpClientRequest
 	private bool $ignoreHttpErrors = false;
 
 
+	/**
+	 * @throws HttpClientRequestUnsupportedSchemeException
+	 */
 	public function __construct(
 		private readonly string $url,
 	) {
+		$scheme = Url::parse($url)?->getScheme();
+		if ($scheme !== 'http' && $scheme !== 'https') {
+			throw new HttpClientRequestUnsupportedSchemeException($url, $scheme);
+		}
 	}
 
 

--- a/app/src/Http/Exceptions/HttpClientRequestUnsupportedSchemeException.php
+++ b/app/src/Http/Exceptions/HttpClientRequestUnsupportedSchemeException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\Exceptions;
+
+use RuntimeException;
+use Throwable;
+
+final class HttpClientRequestUnsupportedSchemeException extends RuntimeException
+{
+
+	public function __construct(string $url, ?string $scheme, ?Throwable $previous = null)
+	{
+		$message = $scheme === null
+			? "Only http(s) URLs are allowed, '{$url}' has no scheme"
+			: "Only http(s) URLs are allowed, '{$url}' has scheme '{$scheme}'";
+		parent::__construct($message, previous: $previous);
+	}
+
+}

--- a/app/tests/Http/Client/HttpClientRequestTest.phpt
+++ b/app/tests/Http/Client/HttpClientRequestTest.phpt
@@ -1,0 +1,47 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Http\Client;
+
+use MichalSpacekCz\Http\Exceptions\HttpClientRequestUnsupportedSchemeException;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/** @testCase */
+final class HttpClientRequestTest extends TestCase
+{
+
+	public function testOnlyHttpSchemesAllowed(): void
+	{
+		$expected = [
+			'https://example.com/' => true,
+			'http://example.com/' => true,
+			'HTTPS://example.net/' => true, // WHATWG lower-cases the scheme
+			'HTTP://example.net/' => true, // same here
+			'file:///etc/passwd' => false,
+			'php://filter/convert.base64-encode/resource=/etc/passwd' => false,
+			'ftp://example.com/' => false,
+			'gopher://example.com/' => false,
+			'data:text/plain,hello' => false,
+			'ws://example.com/' => false,
+			'/etc/passwd' => false, // no scheme, fopen() would read it as a local path
+			'' => false,
+		];
+		$allowed = [];
+		foreach (array_keys($expected) as $url) {
+			try {
+				new HttpClientRequest($url);
+				$allowed[$url] = true;
+			} catch (HttpClientRequestUnsupportedSchemeException) {
+				$allowed[$url] = false;
+			}
+		}
+		Assert::same($expected, $allowed);
+	}
+
+}
+
+TestCaseRunner::run(HttpClientRequestTest::class);

--- a/app/tests/Http/Client/HttpClientResponseTest.phpt
+++ b/app/tests/Http/Client/HttpClientResponseTest.phpt
@@ -24,10 +24,6 @@ final class HttpClientResponseTest extends TestCase
 		assert($certificate instanceof OpenSSLCertificate);
 
 		Assert::exception(function () use (&$certificate): void {
-			new HttpClientResponse(new HttpClientRequest(':-/'), 'body', $certificate, [])->getTlsCertificate();
-		}, HttpClientTlsCertificateNotAvailableException::class);
-
-		Assert::exception(function () use (&$certificate): void {
 			new HttpClientResponse(new HttpClientRequest('http://not.secure.example'), 'body', $certificate, [])->getTlsCertificate();
 		}, HttpClientTlsCertificateNotAvailableException::class);
 


### PR DESCRIPTION
HttpClient fetches with `fopen($url, ...)`, which picks the stream wrapper from the scheme, so a `file://` or `php://filter/...` URL would read a local file instead of making an HTTP request. Every caller today passes an `https` literal, config value or internal link, so it is not reachable now.

The constructor now parses the URL with `Uri\WhatWg\Url` (the WHATWG parser browsers use, which normalizes the scheme) and throws unless it is `http` or `https`, so `file`, `php`, `ftp`, `data`, scheme-less paths and the rest can never reach `fopen`. One existing test built a request from a scheme-less dummy URL to exercise a branch that is now unreachable, so it is dropped.