### PR TITLE
Don't follow HTTP redirects by default in `HttpClient`

### DIFF
--- a/app/src/Http/Client/HttpClient.php
+++ b/app/src/Http/Client/HttpClient.php
@@ -24,9 +24,8 @@ class HttpClient
 		if ($request->getUserAgent() !== null) {
 			$httpOptions = ['user_agent' => str_replace('\\', '/', $request->getUserAgent())] + $httpOptions;
 		}
-		if ($request->getFollowLocation() !== null) {
-			$httpOptions = ['follow_location' => (int)$request->getFollowLocation()] + $httpOptions;
-		}
+		// Don't follow redirects unless a request opts in, so an unset value can't silently follow to a redirect target
+		$httpOptions = ['follow_location' => (int)($request->getFollowLocation() ?? false)] + $httpOptions;
 		if ($request->getTlsCaptureCertificate() !== null) {
 			$tlsOptions = ['capture_peer_cert' => $request->getTlsCaptureCertificate()] + $tlsOptions;
 		}

--- a/app/src/Tls/CertificateGatherer.php
+++ b/app/src/Tls/CertificateGatherer.php
@@ -69,7 +69,7 @@ final readonly class CertificateGatherer
 	{
 		$request = new HttpClientRequest("https://{$ipAddress}/");
 		$request->setUserAgent(__METHOD__);
-		$request->setFollowLocation(false);
+		$request->setFollowLocation(false); // capture this host's certificate, never a redirect target's, regardless of the client default
 		$request->addHeader('Host', $hostname);
 		$request->setTlsCaptureCertificate(true);
 		$request->setTlsServerName($hostname);

--- a/app/tests/Http/Client/HttpClientTest.phpt
+++ b/app/tests/Http/Client/HttpClientTest.phpt
@@ -82,6 +82,26 @@ final class HttpClientTest extends TestCase
 	}
 
 
+	public function testCreateStreamContextDoesNotFollowRedirectsUnlessRequested(): void
+	{
+		$method = new ReflectionMethod($this->httpClient, 'createStreamContext');
+		$requests = [
+			'unset' => new HttpClientRequest('https://example.com/'),
+			'off' => new HttpClientRequest('https://example.com/')->setFollowLocation(false),
+			'on' => new HttpClientRequest('https://example.com/')->setFollowLocation(true),
+		];
+		$actual = [];
+		foreach ($requests as $label => $request) {
+			$context = $method->invoke($this->httpClient, $request);
+			assert(is_resource($context));
+			$options = stream_context_get_params($context)['options'];
+			assert(is_array($options['http']));
+			$actual[$label] = $options['http']['follow_location'];
+		}
+		Assert::same(['unset' => 0, 'off' => 0, 'on' => 1], $actual);
+	}
+
+
 	public function testCreateStreamContextNotificationIgnoresHttpErrors(): void
 	{
 		$errorAt = function (callable $notification, int $status): callable {


### PR DESCRIPTION
`follow_location` was only set on the stream context when a request called `setFollowLocation()` explicitly; left unset, the context fell through to PHP's default of following redirects. Following an attacker-influenced redirect is the risky direction for an HTTP client, so the safe default is not to follow: a request now has to opt in with `setFollowLocation(true)` to follow, and an unset value means don't follow rather than silently chasing a redirect target.

No current caller relies on the old follow-by-default behavior. The four callers that set nothing (`CertificatesApiClient`, `Technicolor`, `CompanyRegisterAres`, `CompanyRegisterRegisterUz`) all fetch JSON from fixed https endpoints that answer directly, so dropping the follow changes nothing for them.

`CertificateGatherer` already passes `setFollowLocation(false)`, which now equals the default in value but stays because its reason is stronger and local: it must capture the certificate of the exact host it connects to, never a redirect target's, whatever the client default happens to be. That's now spelled out in a comment so the call isn't later deleted as redundant, which would make the cert gathering correct only by accident.