### PR TITLE
Short keys they are invalid in spaze/encryption v3, make them longer aka valid

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -23,5 +23,5 @@ paths = [
 ]
 regexTarget = "match"
 regexes = [
-  '''^ms[a-z]{2}_(cafe){15}[0-9a-f]{4}$''',
+  '''^ms[a-z]{2}(test)?_(cafe){15}[0-9a-f]{4}$''',
 ]

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -21,3 +21,7 @@ paths = [
   '''i/build/''',
   '''app/temp/cache/''',
 ]
+regexTarget = "match"
+regexes = [
+  '''^ms[a-z]{2}_(cafe){15}[0-9a-f]{4}$''',
+]

--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -59,13 +59,13 @@ parameters:
 	encryption:
 		keys:
 			password:
-				dev1: "mspe_abadcafec15c0d06f00dcafed00dbeef" # [0-9A-F]{64}
+				dev1: "mspe_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafef00d" # [0-9a-fA-F]{64}
 			email:
-				dev1: "msee_cafebabe25da1768d69ee80717cc2f30" # [0-9A-F]{64}
+				dev1: "msee_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafebabe" # [0-9a-fA-F]{64}
 			session:
-				dev1: "msse_25da1768d69ee80717cc2f30cafebabe" # [0-9A-F]{64}
+				dev1: "msse_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafed00d" # [0-9a-fA-F]{64}
 			securityEvent:
-				dev1: "msle_deadbeef" # [0-9A-F]{64}
+				dev1: "msle_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe1337" # [0-9a-fA-F]{64}
 		activeKeyIds:
 			password: dev1
 			email: dev1

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -10,13 +10,13 @@ parameters:
 	encryption:
 		keys:
 			password!:
-				test: "mspetest_f015033d6b0b24e77bc9cbd86ec52ed5bc94ca4901c9f1378768423ec0278d66"
+				test: "mspetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafea570"
 			email!:
-				test: "mseetest_17fa3225effc107a689eb72fd8c20983bbc690bf9ea42a2f0306e0c226720845"
+				test: "mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafeb053"
 			session!:
-				test: "mssetest_0d89ba7b95bce3a1f5092faf7aa038bffcaca2a98d264ab18c81aec8f74b90ab"
+				test: "mssetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe5a08"
 			securityEvent!:
-				test: "msletest_3f36cd84abba407803aba4ce26d1becdeb94a64b2afdd893789d8da59cee18ee"
+				test: "msletest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe7100"
 		activeKeyIds:
 			password: test
 			email: test


### PR DESCRIPTION
Even though these are just example keys (and full of `cafe` or `beef`) - real ones are set in `local.neon` - they are still in the repo and should be handled accordingly.

Short keys were always invalid, but spaze/encryption v3 validates the keys in constructor, not when used. v3 is not installed yet, but let's be ready. See https://github.com/spaze/encryption/releases/tag/v3.0.0
