### PR TITLE
`gitleaks dir` flags `generic-api-key` in `phpstan.phar`, stop it

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -20,6 +20,7 @@ paths = [
   # Paths otherwise .gitignored should be listed here if you want to use `gitleaks directory`
   '''i/build/''',
   '''app/temp/cache/''',
+  '''app/vendor-dev/''',
 ]
 regexTarget = "match"
 regexes = [


### PR DESCRIPTION
Residual from the `vendor-dev` move #726.