### PR TITLE
Remove the dead password encryption config

### DIFF
--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -58,8 +58,6 @@ parameters:
 
 	encryption:
 		keys:
-			password:
-				dev1: "mspe_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafef00d" # [0-9a-fA-F]{64}
 			email:
 				dev1: "msee_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafebabe" # [0-9a-fA-F]{64}
 			session:
@@ -67,12 +65,10 @@ parameters:
 			securityEvent:
 				dev1: "msle_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe1337" # [0-9a-fA-F]{64}
 		activeKeyIds:
-			password: dev1
 			email: dev1
 			session: dev1
 			securityEvent: dev1
 		keyPrefixes:
-			password: mspe
 			email: msee
 			session: msse
 			securityEvent: msle

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -77,17 +77,14 @@ parameters:
 		trainingFrom: "Bar <bar@qux.example>"
 	encryption:
 		keys:
-			password: []
 			email: []
 			session: []
 			securityEvent: []
 		activeKeyIds:
-			password: ""
 			email: ""
 			session: ""
 			securityEvent: ""
 		keyPrefixes:
-			password: ""
 			email: ""
 			session: ""
 			securityEvent: ""

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -9,8 +9,6 @@ parameters:
 			com: burger.test
 	encryption:
 		keys:
-			password!:
-				test: "mspetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafea570"
 			email!:
 				test: "mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafeb053"
 			session!:
@@ -18,12 +16,10 @@ parameters:
 			securityEvent!:
 				test: "msletest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe7100"
 		activeKeyIds:
-			password: test
 			email: test
 			session: test
 			securityEvent: test
 		keyPrefixes:
-			password: mspetest
 			email: mseetest
 			session: mssetest
 			securityEvent: msletest


### PR DESCRIPTION
The `passwordEncryption` service registration went away in #848 but the parameters it read stayed: the empty defaults in `parameters.neon`, the dev key in `local.template.neon`, and the test key in `tests.neon`. Nothing reads `encryption.keys.password` and friends anymore, so a fresh dev or test setup would mint a key that nothing can ever use. The `mspe` prefix stays in the Gitleaks rules on purpose: the old keys are still secrets wherever they survive, in production config comments or in backups, and leaking them should still be caught.

Ref #731