### PR TITLE
Keep encryption keys and unencrypted emails out of the exception log

### DIFF
--- a/app/composer-dependency-analyser.php
+++ b/app/composer-dependency-analyser.php
@@ -24,12 +24,14 @@ return (new Configuration())
 	->ignoreErrorsOnPackage('async-aws/lambda', [ErrorType::UNUSED_DEPENDENCY])
 	->ignoreErrorsOnPackage('mlocati/ip-lib', [ErrorType::UNUSED_DEPENDENCY])
 
-	// These are in vendor-dev/composer.json, not in the main composer.json
-	// Remove once https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/258 is implemented
+	// These are in vendor-dev/composer.json or come with a dependency, not in the main composer.json
+	// Remove the vendor-dev ones once https://github.com/shipmonk-rnd/composer-dependency-analyser/issues/258 is implemented
 	->ignoreErrorsOnPackages([
 		'jetbrains/phpstorm-attributes',
 		'nette/component-model',
 		'nette/tester',
+		'paragonie/halite',
+		'paragonie/hidden-string',
 		'spomky-labs/cbor-php',
 	], [ErrorType::SHADOW_DEPENDENCY])
 	->ignoreErrorsOnExtensions([

--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -11,6 +11,10 @@ http:
 
 tracy:
 	netteMailer: false
+	keysToHide:
+		- keyMaterial # Halite's Key copies the encryption key out of its HiddenString into this
+		- ParagonIE\HiddenString\HiddenString::$internalStringValue # spaze/encryption wraps every value in one of these before handing it to Halite
+		- SensitiveParameterValue::$value # .md dump #[SensitiveParameter] handling, remove once https://github.com/nette/tracy/pull/618 is released
 
 session:
 	name: __Host-yourluckynumbers

--- a/app/tests/Application/ExceptionLogSecretsTest.phpt
+++ b/app/tests/Application/ExceptionLogSecretsTest.phpt
@@ -1,0 +1,154 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
+use ParagonIE\Halite\Symmetric\Crypto;
+use ParagonIE\Halite\Symmetric\EncryptionKey;
+use ParagonIE\HiddenString\HiddenString;
+use Spaze\Encryption\SymmetricKeyEncryption;
+use Tester\Assert;
+use Tester\FileMock;
+use Tester\TestCase;
+use Throwable;
+use Tracy\BlueScreen;
+use Tracy\Dumper;
+
+require __DIR__ . '/../bootstrap.php';
+
+/**
+ * Tracy writes every stack frame's arguments into the exception log, and the encryption library hands both the key
+ * and the not-yet-encrypted value around as objects, so anything that throws mid-encryption puts them in the log.
+ * The `tracy: keysToHide` setting in common.neon is what stops it.
+ *
+ * @testCase
+ */
+final class ExceptionLogSecretsTest extends TestCase
+{
+
+	private const string HTML_LOG = 'mock://bluescreen.html';
+	private const string MD_LOG = 'mock://bluescreen.md'; // Tracy writes this one alongside, with the .html suffix replaced
+
+
+	/**
+	 * The service is the same object Debugger::getBlueScreen() returns, but asking for it is what makes
+	 * TestCaseRunner build a container at all, and it's the container that applies the `tracy:` config; without
+	 * one these tests would run against Tracy's defaults and pass without the setting they exist to check
+	 */
+	public function __construct(
+		private readonly BlueScreen $blueScreen,
+	) {
+		FileMock::register(); // can't use FileMock::create(), it creates the file and Tracy's fopen(..., 'x') would fail
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		FileMock::$files = [];
+	}
+
+
+	public function testKeyIsNotLoggedWhenDecryptionFails(): void
+	{
+		$keyMaterial = self::keyMaterial();
+		$key = new EncryptionKey(new HiddenString($keyMaterial));
+		$cipherText = Crypto::encrypt(new HiddenString('whatever'), $key);
+
+		$thrown = null;
+		try {
+			Crypto::decrypt(substr($cipherText, 0, -4) . 'AAAA', $key); // a stored value that no longer authenticates
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+
+		foreach ($this->logAndReadBack($thrown, 'Decrypting a corrupted value should have failed') as $extension => $contents) {
+			Assert::notContains($keyMaterial, $contents, "the encryption key leaked into the {$extension} log");
+		}
+	}
+
+
+	public function testKeyAndPlaintextAreNotLoggedWhenEncryptionFails(): void
+	{
+		$keyMaterial = self::keyMaterial();
+		$key = new EncryptionKey(new HiddenString($keyMaterial));
+		$email = bin2hex(random_bytes(8)) . '@example.com';
+
+		$thrown = null;
+		try {
+			// Any failure inside encryption will do, this one is just easy to trigger; the plaintext is on the stack either way
+			Crypto::encrypt(new HiddenString($email), $key, 'not-a-real-encoding');
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+
+		foreach ($this->logAndReadBack($thrown, 'Encrypting with an unknown encoding should have failed') as $extension => $contents) {
+			Assert::notContains($email, $contents, "the plaintext leaked into the {$extension} log");
+			Assert::notContains($keyMaterial, $contents, "the encryption key leaked into the {$extension} log");
+		}
+	}
+
+
+	/**
+	 * The keys reach the encryption service as one `#[SensitiveParameter]` array, and it rejects a malformed one by
+	 * throwing, so a single bad key in local.neon would otherwise log every good key next to it
+	 */
+	public function testKeysAreNotLoggedWhenTheEncryptionServiceRejectsOne(): void
+	{
+		$goodKey = bin2hex(random_bytes(32));
+
+		$thrown = null;
+		try {
+			new SymmetricKeyEncryption(['live' => 'mstest_' . $goodKey, 'broken' => 'nope_' . bin2hex(random_bytes(32))], 'live', 'mstest');
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+
+		foreach ($this->logAndReadBack($thrown, 'A key with the wrong prefix should have been rejected') as $extension => $contents) {
+			Assert::notContains($goodKey, $contents, "a valid key leaked into the {$extension} log because another one was malformed");
+		}
+	}
+
+
+	/**
+	 * Printable key bytes, because Tracy renders binary as \xNN escapes and searching a log for the raw bytes of a
+	 * random key would find nothing whether it leaked or not. Hex of half the bytes is the 32 characters Halite wants
+	 */
+	private static function keyMaterial(): string
+	{
+		return bin2hex(random_bytes(16));
+	}
+
+
+	/**
+	 * @param Throwable|null $thrown Null when the call unexpectedly succeeded. Checked here because inside the
+	 *     caller's try block Assert's own exception would be caught, and the test would pass on its own failure
+	 * @return array<string, string> Log file contents, keyed by extension. Tracy writes an .html blue screen plus an
+	 *     .md rendering of the same exception, and the two hide values differently, so both are checked
+	 */
+	private function logAndReadBack(?Throwable $thrown, string $shouldHaveFailed): array
+	{
+		Assert::notNull($thrown, $shouldHaveFailed);
+		assert($thrown !== null); // Assert::notNull() doesn't narrow the type for phpstan and psalm
+		unset(FileMock::$files[self::HTML_LOG], FileMock::$files[self::MD_LOG]); // Tracy won't write over a file that exists
+		Assert::true($this->blueScreen->renderToFile($thrown, self::HTML_LOG));
+		Assert::hasKey(self::MD_LOG, FileMock::$files, 'Tracy no longer writes the .md log, drop it here rather than silently checking less');
+		$logged = [
+			'html' => FileMock::$files[self::HTML_LOG],
+			'md' => FileMock::$files[self::MD_LOG],
+		];
+		foreach ($logged as $extension => $contents) {
+			// Absence of a secret proves nothing if the arguments weren't dumped at all, which is what stops these
+			// tests from passing for the wrong reason if Tracy or the library ever stops putting them in the trace.
+			// Backslashes go because the .md escapes the asterisks Tracy marks a hidden value with
+			Assert::contains(Dumper::HIDDEN_VALUE, str_replace('\\', '', $contents), "nothing was hidden in the {$extension} log, so it can't show these secrets are being redacted");
+		}
+		return $logged;
+	}
+
+}
+
+TestCaseRunner::run(ExceptionLogSecretsTest::class);


### PR DESCRIPTION
Tracy writes every stack frame's arguments into the exception log, and both the key and the value being encrypted travel as objects, so anything that throws mid-encryption puts them in `app/log` in cleartext. I hit this while building the re-encryption sweep, whose whole job is to decrypt every stored value: one row that can't be decrypted logs the key that decrypts all the others.

Neither of the two things that look like they should prevent this does. `#[SensitiveParameter]` is on `encrypt()` and on the key array in the constructor, not on `decrypt()`, and Halite's `Crypto::decrypt()` doesn't mark its key argument either. The `HiddenString` doesn't help because `Halite\Key` copies the key out of it into a plain `keyMaterial` property, and while `Key::__debugInfo()` exists to hide exactly that, Tracy reflects real properties rather than calling it.

Each of the three entries covers a different carrier, and dropping any one of them fails exactly one of the new tests.

`keyMaterial` is the key itself. `internalStringValue` is the `HiddenString` that every encryption method wraps the plaintext in before handing it to Halite, which means an email sits in a frame argument for the whole of `Crypto::encryptWithAD()`; the throws that would expose it are rare, a failing CSPRNG or libsodium being the honest examples, but the frame is there on every single call and PHP records a frame's arguments regardless of where in the function it throws. `SensitiveParameterValue::$value` is needed because the `.md` log Tracy writes next to the blue screen dumps stack arguments without their parameter name, and the name is the only thing that makes it apply its own `#[SensitiveParameter]` handling; without that entry a single malformed key in `local.neon` gets the constructor to throw and logs every valid key beside it, which is exactly what the upcoming `spaze/encryption` upgrade makes likely. Hiding it by class and property rather than by the bare name `value` keeps ordinary properties visible.

The tests assert on real log files from real failing library calls rather than on the config, because the two files hide values differently and only the real thing shows that. Alongside each secret being absent they check that something in the log was hidden at all, so they can't pass by the arguments quietly no longer being dumped. Building the exception outside the try and checking it after is deliberate: `Tester\AssertException` is an `Exception`, so an `Assert::fail()` inside the try would be caught by the very `catch` it sits above and the test would pass on its own failure. Key material is printable because Tracy renders binary as escape sequences, so searching the log for a random key's raw bytes would find nothing whether it leaked or not.

The tests call Halite directly, to make encryption fail with a key or a plaintext still on the stack, so the dependency analyser is told to allow it rather than the packages being required anywhere. Requiring them would mean choosing a version that `spaze/encryption` already chooses for us, and putting them in `vendor-dev` would install a second copy that wins the autoloader, so the tests would assert about property names in a Halite the application never loads. Going through our own encryption service instead won't do: Halite marks its key constructors sensitive, so the key arrives there already wrapped and exercises a different entry, and the one path that does hand over a bare `HiddenString`, a wrong-length key blowing up when it's first used, disappears once the library validates keys in its constructor.

This covers values that reach the log through the encryption library. An email handed to a method as a plain `string` parameter is still dumped in full if something further down throws, a database error on the write being the realistic case; marking those parameters is a separate change.