### PR TITLE
Add a way to re-encrypt stored data, needed before `spaze/encryption` v3

### DIFF
--- a/app/bin/reencrypt.php
+++ b/app/bin/reencrypt.php
@@ -1,0 +1,26 @@
+#!/usr/bin/env php
+<?php
+declare(strict_types = 1);
+
+/*
+ * Re-encrypts stored values that the encryption library reports as needing it: encrypted with a key that is no
+ * longer the active one, or written in a storage format the library has since moved on from.
+ *
+ * - Run manually after a key rotation, or after an encryption library upgrade that changes the stored format
+ * - Use --dry-run to see what would be re-encrypted without writing anything, also useful to verify a previous real run left nothing behind
+ *
+ * Sessions are not swept: the session handler re-encrypts a session whenever its data changes, and rows expire
+ * anyway, so they migrate on their own. That means a rotated session key has to stay configured until the last
+ * pre-rotation session has expired, because the handler decrypts without catching anything and an old session
+ * whose key is gone is an error on every request that visitor makes.
+ */
+
+namespace MichalSpacekCz\Bin;
+
+use MichalSpacekCz\Application\Bootstrap;
+use MichalSpacekCz\Encryption\ReEncryption;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+$reEncryption = Bootstrap::bootCli(ReEncryption::class)->getByType(ReEncryption::class);
+exit($reEncryption->run());

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -42,6 +42,8 @@ services:
 	- MichalSpacekCz\EasterEgg\FourOhFourButFound\FourOhFourButFound
 	- MichalSpacekCz\EasterEgg\NetteCve202015227
 	- MichalSpacekCz\EasterEgg\WinterIsComing\WinterIsComing
+	- MichalSpacekCz\Encryption\ColumnReEncryptor(batchSize: 1000)
+	- MichalSpacekCz\Encryption\ReEncryption(storages: typed(MichalSpacekCz\Encryption\EncryptedStorage))
 	- MichalSpacekCz\Feed\Exports
 	- MichalSpacekCz\Form\BlogPostFormFactory
 	- MichalSpacekCz\Form\Controls\FormControlsFactory

--- a/app/src/Encryption/ColumnReEncryptionResult.php
+++ b/app/src/Encryption/ColumnReEncryptionResult.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+final readonly class ColumnReEncryptionResult
+{
+
+	/**
+	 * @param list<int> $failedIds
+	 */
+	public function __construct(
+		public int $reEncrypted,
+		public int $upToDate,
+		public array $failedIds,
+		public int $changedMeanwhile,
+	) {
+	}
+
+}

--- a/app/src/Encryption/ColumnReEncryptor.php
+++ b/app/src/Encryption/ColumnReEncryptor.php
@@ -1,0 +1,100 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+use InvalidArgumentException;
+use MichalSpacekCz\Database\TypedDatabase;
+use Nette\Database\Explorer;
+use Throwable;
+use Tracy\Debugger;
+
+/**
+ * Re-encrypts one encrypted database column, so a service storing encrypted values can implement
+ * EncryptedStorage by just saying which table, id column, and value column are its own.
+ *
+ * Rows are read in batches ordered by id, so a table that has grown large doesn't have to fit in memory at once.
+ */
+final readonly class ColumnReEncryptor
+{
+
+	public function __construct(
+		private Explorer $database,
+		private TypedDatabase $typedDatabase,
+		private int $batchSize,
+	) {
+		if ($batchSize < 1) {
+			throw new InvalidArgumentException("Batch size must be at least 1, {$batchSize} given");
+		}
+	}
+
+
+	public function reEncrypt(EncryptedColumn $column, bool $dryRun): ColumnReEncryptionResult
+	{
+		$reEncrypted = 0;
+		$upToDate = 0;
+		$failedIds = [];
+		$changedMeanwhile = 0;
+		$encryption = $column->encryption;
+		$table = $column->table;
+		$idColumn = $column->idColumn;
+		$valueColumn = $column->valueColumn;
+		$fromId = 0; // the next id to read, not the last one read, so a row with id 0 is included
+		do {
+			// An empty value holds nothing to re-encrypt, same as a null one, and trying would fail as a malformed
+			// ciphertext on every run without saying why
+			$rows = $this->typedDatabase->fetchPairsIntString(
+				'SELECT ?name, ?name FROM ?name WHERE ?name IS NOT NULL AND ?name != ? AND ?name >= ? ORDER BY ?name LIMIT ?',
+				$idColumn,
+				$valueColumn,
+				$table,
+				$valueColumn,
+				$valueColumn,
+				'',
+				$idColumn,
+				$fromId,
+				$idColumn,
+				$this->batchSize,
+			);
+			foreach ($rows as $id => $encrypted) {
+				// Advance even when the value below is skipped, otherwise the next batch would start at the same row again
+				$fromId = $id + 1;
+				try {
+					if (!$encryption->needsReEncrypt($encrypted)) {
+						$upToDate++;
+						continue;
+					}
+					$reEncryptedValue = $encryption->encrypt($encryption->decrypt($encrypted));
+				} catch (Throwable $e) {
+					// A value that can't be decrypted (a dropped key, corruption) is left unchanged, the rest of the run continues
+					Debugger::log($e);
+					$failedIds[] = $id;
+					continue;
+				}
+				if ($dryRun) {
+					$reEncrypted++;
+					continue;
+				}
+				// The value in the WHERE makes sure a row changed by someone else since the read above is left alone,
+				// that write encrypted with the active key anyway and updating would overwrite the newer value
+				$result = $this->database->query(
+					'UPDATE ?name SET ?name = ? WHERE ?name = ? AND ?name = ?',
+					$table,
+					$valueColumn,
+					$reEncryptedValue,
+					$idColumn,
+					$id,
+					$valueColumn,
+					$encrypted,
+				);
+				if ($result->getRowCount() === 1) {
+					$reEncrypted++;
+				} else {
+					$changedMeanwhile++;
+				}
+			}
+		} while (count($rows) === $this->batchSize);
+		return new ColumnReEncryptionResult($reEncrypted, $upToDate, $failedIds, $changedMeanwhile);
+	}
+
+}

--- a/app/src/Encryption/EncryptedColumn.php
+++ b/app/src/Encryption/EncryptedColumn.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+use Spaze\Encryption\SymmetricKeyEncryption;
+
+/**
+ * One encrypted database column, everything ColumnReEncryptor needs to sweep it and the report needs to name it.
+ */
+final readonly class EncryptedColumn
+{
+
+	public function __construct(
+		public SymmetricKeyEncryption $encryption,
+		public string $table,
+		public string $idColumn,
+		public string $valueColumn,
+	) {
+	}
+
+}

--- a/app/src/Encryption/EncryptedStorage.php
+++ b/app/src/Encryption/EncryptedStorage.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+/**
+ * Implement this when the class stores encrypted data in one or more table columns, so the data can be re-encrypted
+ * after the encryption key has been rotated or the stored format has changed.
+ */
+interface EncryptedStorage
+{
+
+	/**
+	 * What the storage keeps encrypted, e.g. 'training application emails', for the re-encryption report.
+	 *
+	 * @return non-empty-string
+	 */
+	public function getEncryptedDataLabel(): string;
+
+
+	/**
+	 * The columns this storage keeps encrypted. It only declares them, the re-encryption itself is driven from
+	 * one place, so nothing here can decide on its own whether a run writes or is a dry run.
+	 *
+	 * @return non-empty-list<EncryptedColumn> A storage with nothing encrypted has no business implementing this,
+	 *     and an empty list would silently leave it out of the report entirely
+	 */
+	public function getEncryptedColumns(): array;
+
+}

--- a/app/src/Encryption/ReEncryption.php
+++ b/app/src/Encryption/ReEncryption.php
@@ -1,0 +1,90 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+use MichalSpacekCz\Application\Cli\CliArgs;
+use MichalSpacekCz\Application\Cli\CliArgsProvider;
+use Nette\CommandLine\Parser;
+use Override;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+use Throwable;
+use Tracy\Debugger;
+
+final readonly class ReEncryption implements CliArgsProvider
+{
+
+	private const string DRY_RUN = '--dry-run';
+
+
+	/**
+	 * @param iterable<EncryptedStorage> $storages
+	 */
+	public function __construct(
+		private iterable $storages,
+		private ColumnReEncryptor $columnReEncryptor,
+		private CliArgs $cliArgs,
+		private ConsoleColor $color,
+	) {
+	}
+
+
+	public function run(): int
+	{
+		$cliArgsError = $this->cliArgs->getError();
+		if ($cliArgsError !== null) {
+			fprintf(STDERR, "%s\n", $this->color->apply('light_red', $cliArgsError));
+			return 3;
+		}
+		$dryRun = $this->cliArgs->getFlag(self::DRY_RUN);
+		$hasFailures = false;
+		foreach ($this->storages as $storage) {
+			$storageLabel = $storage->getEncryptedDataLabel();
+			$columns = $storage->getEncryptedColumns();
+			foreach ($columns as $column) {
+				// The column only when the storage has more than one, it says nothing extra when there is just one
+				$label = count($columns) > 1 ? sprintf('%s, %s', $storageLabel, $column->valueColumn) : $storageLabel;
+				try {
+					$result = $this->columnReEncryptor->reEncrypt($column, $dryRun);
+				} catch (Throwable $e) {
+					Debugger::log($e);
+					fprintf(STDERR, "%s: %s\n", $label, $this->color->apply('light_red', $e->getMessage()));
+					$hasFailures = true;
+					continue;
+				}
+				$failedCount = count($result->failedIds);
+				if ($failedCount > 0) {
+					$hasFailures = true;
+				}
+				// Written so it can go straight into a query, those rows have to be sorted out by hand before the old key can be dropped
+				$failed = $failedCount > 0
+					? sprintf(
+						$failedCount === 1 ? '%d failed (`%s.%s = %s`)' : '%d failed (`%s.%s IN (%s)`)',
+						$failedCount,
+						$column->table,
+						$column->idColumn,
+						implode(', ', $result->failedIds),
+					)
+					: '0 failed';
+				$parts = [
+					sprintf($dryRun ? '%d would be re-encrypted' : '%d re-encrypted', $result->reEncrypted),
+					sprintf('%d up to date', $result->upToDate),
+					$failedCount > 0 ? $this->color->apply('light_red', $failed) : $failed,
+				];
+				if (!$dryRun) {
+					$parts[] = sprintf('%d changed meanwhile', $result->changedMeanwhile);
+				}
+				printf("%s: %s\n", $label, implode(', ', $parts));
+			}
+		}
+		return $hasFailures ? 1 : 0;
+	}
+
+
+	#[Override]
+	public static function defineArgs(Parser $parser): void
+	{
+		$parser->addSwitch(self::DRY_RUN);
+	}
+
+}

--- a/app/src/Test/Database/Database.php
+++ b/app/src/Test/Database/Database.php
@@ -139,6 +139,16 @@ final class Database extends Explorer
 	public function query(string $sql, ...$params): ResultSet
 	{
 		$this->maybeThrow();
+		$this->recordParams($sql, $params);
+		return $this->resultSet ?? new ResultSet();
+	}
+
+
+	/**
+	 * @param array<array-key, mixed> $params
+	 */
+	private function recordParams(string $sql, array $params): void
+	{
 		foreach ($params as $param) {
 			if (is_array($param)) {
 				$arrayParams = [];
@@ -150,7 +160,6 @@ final class Database extends Explorer
 				$this->queriesScalarParams[$sql][] = $this->formatValue($param);
 			}
 		}
-		return $this->resultSet ?? new ResultSet();
 	}
 
 
@@ -209,6 +218,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetch(string $sql, ...$params): ?Row
 	{
+		$this->recordParams($sql, $params);
 		$row = $this->createRow($this->fetchResults[$this->fetchResultsPosition++] ?? $this->fetchDefaultResult);
 		return $row->count() > 0 ? $row : null;
 	}
@@ -233,6 +243,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchField(string $sql, ...$params): mixed
 	{
+		$this->recordParams($sql, $params);
 		return $this->fetchFieldResults[$this->fetchFieldResultsPosition++] ?? $this->fetchFieldDefaultResult;
 	}
 
@@ -263,6 +274,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchPairs(string $sql, ...$params): array
 	{
+		$this->recordParams($sql, $params);
 		return $this->fetchPairsResults[$this->fetchPairsResultsPosition++] ?? $this->fetchPairsDefaultResult;
 	}
 
@@ -315,6 +327,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchAll(string $sql, ...$params): array
 	{
+		$this->recordParams($sql, $params);
 		return $this->fetchAllResults[$this->fetchAllResultsPosition++] ?? $this->fetchAllDefaultResult;
 	}
 

--- a/app/src/Test/Encryption/EncryptedStorageMock.php
+++ b/app/src/Test/Encryption/EncryptedStorageMock.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Test\Encryption;
+
+use MichalSpacekCz\Encryption\EncryptedColumn;
+use MichalSpacekCz\Encryption\EncryptedStorage;
+use MichalSpacekCz\Test\WillThrow;
+use Override;
+
+final class EncryptedStorageMock implements EncryptedStorage
+{
+
+	use WillThrow;
+
+
+	/**
+	 * @param non-empty-string $label
+	 * @param non-empty-list<EncryptedColumn> $columns
+	 */
+	public function __construct(
+		private readonly string $label,
+		private readonly array $columns,
+	) {
+	}
+
+
+	#[Override]
+	public function getEncryptedDataLabel(): string
+	{
+		return $this->label;
+	}
+
+
+	/**
+	 * @return non-empty-list<EncryptedColumn>
+	 */
+	#[Override]
+	public function getEncryptedColumns(): array
+	{
+		$this->maybeThrow();
+		return $this->columns;
+	}
+
+}

--- a/app/src/Training/Applications/TrainingApplicationStorage.php
+++ b/app/src/Training/Applications/TrainingApplicationStorage.php
@@ -4,6 +4,8 @@ declare(strict_types = 1);
 namespace MichalSpacekCz\Training\Applications;
 
 use DateTime;
+use MichalSpacekCz\Encryption\EncryptedColumn;
+use MichalSpacekCz\Encryption\EncryptedStorage;
 use MichalSpacekCz\Training\ApplicationStatuses\TrainingApplicationStatus;
 use MichalSpacekCz\Training\ApplicationStatuses\TrainingApplicationStatuses;
 use MichalSpacekCz\Training\Dates\TrainingDate;
@@ -13,14 +15,20 @@ use MichalSpacekCz\Training\Prices;
 use Nette\Database\Explorer;
 use Nette\Database\UniqueConstraintViolationException;
 use Nette\Utils\Random;
+use Override;
 use ParagonIE\Halite\Alerts\HaliteAlert;
 use RuntimeException;
 use SodiumException;
 use Spaze\Encryption\SymmetricKeyEncryption;
 use Tracy\Debugger;
 
-final readonly class TrainingApplicationStorage
+final readonly class TrainingApplicationStorage implements EncryptedStorage
 {
+
+	private const string TABLE = 'training_applications';
+	private const string ID_COLUMN = 'id_application';
+	private const string EMAIL_COLUMN = 'email';
+
 
 	public function __construct(
 		private Explorer $database,
@@ -178,7 +186,7 @@ final readonly class TrainingApplicationStorage
 		$data = [
 			'key_date' => $dateId,
 			'name' => $name,
-			'email' => $this->emailEncryption->encrypt($email),
+			self::EMAIL_COLUMN => $this->emailEncryption->encrypt($email),
 			'company' => $company !== '' ? $company : null,
 			'street' => $street !== '' ? $street : null,
 			'city' => $city !== '' ? $city : null,
@@ -213,7 +221,7 @@ final readonly class TrainingApplicationStorage
 	{
 		$data['access_token'] = $this->generateAccessCode();
 		try {
-			$this->database->query('INSERT INTO training_applications', $data);
+			$this->database->query('INSERT INTO ?name', self::TABLE, $data);
 		} catch (UniqueConstraintViolationException) {
 			// regenerate the access code and try harder this time
 			Debugger::log("Regenerating access token, {$data['access_token']} already exists");
@@ -262,10 +270,11 @@ final readonly class TrainingApplicationStorage
 			): void {
 				$price = $this->prices->resolvePriceDiscountVat($date->getPrice(), $date->getStudentDiscount(), TrainingApplicationStatus::SignedUp, $note);
 				$this->database->query(
-					'UPDATE training_applications SET ? WHERE id_application = ?',
+					'UPDATE ?name SET ? WHERE ?name = ?',
+					self::TABLE,
 					[
 						'name' => $name,
-						'email' => $this->emailEncryption->encrypt($email),
+						self::EMAIL_COLUMN => $this->emailEncryption->encrypt($email),
 						'company' => $company,
 						'street' => $street,
 						'city' => $city,
@@ -279,6 +288,7 @@ final readonly class TrainingApplicationStorage
 						'price_vat' => $price->getPriceVat(),
 						'discount' => $price->getDiscount(),
 					],
+					self::ID_COLUMN,
 					$applicationId,
 				);
 			},
@@ -319,7 +329,7 @@ final readonly class TrainingApplicationStorage
 		}
 		$data = [
 			'name' => $name,
-			'email' => $email !== null ? $this->emailEncryption->encrypt($email) : null,
+			self::EMAIL_COLUMN => $email !== null ? $this->emailEncryption->encrypt($email) : null,
 			'company' => $company,
 			'familiar' => $familiar,
 			'street' => $street,
@@ -341,19 +351,38 @@ final readonly class TrainingApplicationStorage
 		if ($dateId !== null) {
 			$data['key_date'] = $dateId;
 		}
-		$this->database->query('UPDATE training_applications SET ? WHERE id_application = ?', $data, $applicationId);
+		$this->database->query('UPDATE ?name SET ? WHERE ?name = ?', self::TABLE, $data, self::ID_COLUMN, $applicationId);
 	}
 
 
 	public function updateApplicationInvoiceData(int $applicationId, string $invoiceId): void
 	{
 		$this->database->query(
-			'UPDATE training_applications SET ? WHERE id_application = ?',
+			'UPDATE ?name SET ? WHERE ?name = ?',
+			self::TABLE,
 			[
 				'invoice_id' => $invoiceId !== '' ? (int)$invoiceId : null,
 			],
+			self::ID_COLUMN,
 			$applicationId,
 		);
+	}
+
+
+	#[Override]
+	public function getEncryptedDataLabel(): string
+	{
+		return 'training application emails';
+	}
+
+
+	/**
+	 * @return non-empty-list<EncryptedColumn>
+	 */
+	#[Override]
+	public function getEncryptedColumns(): array
+	{
+		return [new EncryptedColumn($this->emailEncryption, self::TABLE, self::ID_COLUMN, self::EMAIL_COLUMN)];
 	}
 
 }

--- a/app/src/User/SecurityActivity/SecurityActivity.php
+++ b/app/src/User/SecurityActivity/SecurityActivity.php
@@ -5,26 +5,24 @@ namespace MichalSpacekCz\User\SecurityActivity;
 
 use DateTimeInterface;
 use MichalSpacekCz\DateTime\DateTimeFactory;
+use MichalSpacekCz\Encryption\EncryptedColumn;
+use MichalSpacekCz\Encryption\EncryptedStorage;
 use MichalSpacekCz\User\Exceptions\IdentityIdNotIntException;
 use MichalSpacekCz\User\Manager;
 use Nette\Database\Explorer;
 use Nette\Security\User;
 use Nette\Utils\Json;
+use Override;
 use Spaze\Encryption\SymmetricKeyEncryption;
 use Throwable;
 use Tracy\Debugger;
 
-final readonly class SecurityActivity
+final readonly class SecurityActivity implements EncryptedStorage
 {
 
-	private const string SELECT = 'SELECT
-			action,
-			created,
-			created_timezone AS createdTimezone,
-			ip,
-			user_agent AS userAgent,
-			details
-		FROM security_events';
+	private const string TABLE = 'security_events';
+	private const string ID_COLUMN = 'id_security_event';
+	private const string DETAILS_COLUMN = 'details';
 
 
 	public function __construct(
@@ -44,8 +42,14 @@ final readonly class SecurityActivity
 	public function getEventsForCurrentUser(): array
 	{
 		return $this->buildEvents($this->database->fetchAll(
-			self::SELECT . ' WHERE key_user = ? ORDER BY created DESC, id_security_event DESC',
+			'SELECT action, created, created_timezone AS createdTimezone, ip, user_agent AS userAgent, ?name
+				FROM ?name
+				WHERE key_user = ?
+				ORDER BY created DESC, ?name DESC',
+			self::DETAILS_COLUMN,
+			self::TABLE,
 			$this->manager->getUserId($this->user),
+			self::ID_COLUMN,
 		));
 	}
 
@@ -98,6 +102,23 @@ final readonly class SecurityActivity
 			Debugger::log($e, 'auth');
 			return [];
 		}
+	}
+
+
+	#[Override]
+	public function getEncryptedDataLabel(): string
+	{
+		return 'security event details';
+	}
+
+
+	/**
+	 * @return non-empty-list<EncryptedColumn>
+	 */
+	#[Override]
+	public function getEncryptedColumns(): array
+	{
+		return [new EncryptedColumn($this->securityEventEncryption, self::TABLE, self::ID_COLUMN, self::DETAILS_COLUMN)];
 	}
 
 }

--- a/app/src/User/UserAccounts.php
+++ b/app/src/User/UserAccounts.php
@@ -5,14 +5,21 @@ namespace MichalSpacekCz\User;
 
 use Exception;
 use MichalSpacekCz\Database\TypedDatabase;
+use MichalSpacekCz\Encryption\EncryptedColumn;
+use MichalSpacekCz\Encryption\EncryptedStorage;
 use Nette\Database\Explorer;
+use Override;
 use Spaze\Encryption\SymmetricKeyEncryption;
 
 /**
  * A user's own account settings, with the notification email encrypted at rest like other emails in the app.
  */
-final readonly class UserAccounts
+final readonly class UserAccounts implements EncryptedStorage
 {
+
+	private const string ID_COLUMN = 'id_user';
+	private const string NOTIFICATION_EMAIL_COLUMN = 'notification_email';
+
 
 	public function __construct(
 		private Explorer $database,
@@ -26,8 +33,10 @@ final readonly class UserAccounts
 	public function getNotificationEmail(int $userId): ?string
 	{
 		$encrypted = $this->typedDatabase->fetchFieldStringNullable(
-			'SELECT notification_email FROM ?name WHERE id_user = ?',
+			'SELECT ?name FROM ?name WHERE ?name = ?',
+			self::NOTIFICATION_EMAIL_COLUMN,
 			$this->usersTableName,
+			self::ID_COLUMN,
 			$userId,
 		);
 		return $encrypted !== null ? $this->emailEncryption->decrypt($encrypted) : null;
@@ -37,9 +46,10 @@ final readonly class UserAccounts
 	public function setNotificationEmail(int $userId, string $email): void
 	{
 		$this->database->query(
-			'UPDATE ?name SET ? WHERE id_user = ?',
+			'UPDATE ?name SET ? WHERE ?name = ?',
 			$this->usersTableName,
-			['notification_email' => $this->emailEncryption->encrypt($email)],
+			[self::NOTIFICATION_EMAIL_COLUMN => $this->emailEncryption->encrypt($email)],
+			self::ID_COLUMN,
 			$userId,
 		);
 	}
@@ -54,8 +64,10 @@ final readonly class UserAccounts
 		try {
 			// lock the row so the old notification email can't change between this read and the write below
 			$encryptedOld = $this->typedDatabase->fetchFieldStringNullable(
-				'SELECT notification_email FROM ?name WHERE id_user = ? FOR UPDATE',
+				'SELECT ?name FROM ?name WHERE ?name = ? FOR UPDATE',
+				self::NOTIFICATION_EMAIL_COLUMN,
 				$this->usersTableName,
+				self::ID_COLUMN,
 				$userId,
 			);
 			// decrypt before the write so an undecryptable old value rolls back rather than committing then throwing
@@ -67,6 +79,23 @@ final readonly class UserAccounts
 			throw $e;
 		}
 		return $oldEmail;
+	}
+
+
+	#[Override]
+	public function getEncryptedDataLabel(): string
+	{
+		return 'user notification emails';
+	}
+
+
+	/**
+	 * @return non-empty-list<EncryptedColumn>
+	 */
+	#[Override]
+	public function getEncryptedColumns(): array
+	{
+		return [new EncryptedColumn($this->emailEncryption, $this->usersTableName, self::ID_COLUMN, self::NOTIFICATION_EMAIL_COLUMN)];
 	}
 
 }

--- a/app/tests/Encryption/ColumnReEncryptorTest.phpt
+++ b/app/tests/Encryption/ColumnReEncryptorTest.phpt
@@ -1,0 +1,210 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+use InvalidArgumentException;
+use MichalSpacekCz\Database\TypedDatabase;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\ResultSet;
+use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
+use Spaze\Encryption\SymmetricKeyEncryption;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class ColumnReEncryptorTest extends TestCase
+{
+
+	private const string SELECT_SQL = 'SELECT ?name, ?name FROM ?name WHERE ?name IS NOT NULL AND ?name != ? AND ?name >= ? ORDER BY ?name LIMIT ?';
+	private const string UPDATE_SQL = 'UPDATE ?name SET ?name = ? WHERE ?name = ? AND ?name = ?';
+	private const int BATCH_SIZE = 1000;
+
+	private readonly SymmetricKeyEncryption $encryption;
+	private readonly SymmetricKeyEncryption $oldKeyEncryption;
+	private readonly ColumnReEncryptor $reEncryptor;
+
+
+	public function __construct(
+		private readonly Database $database,
+		private readonly TypedDatabase $typedDatabase,
+		private readonly NullLogger $logger,
+	) {
+		// Both instances know both keys, so values written with the old key still decrypt; only the active key differs
+		$keys = [
+			'old' => 'mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafeb9a3',
+			'new' => 'mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafef158',
+		];
+		$this->encryption = new SymmetricKeyEncryption($keys, 'new', 'mseetest');
+		$this->oldKeyEncryption = new SymmetricKeyEncryption($keys, 'old', 'mseetest');
+		$this->reEncryptor = new ColumnReEncryptor($this->database, $this->typedDatabase, self::BATCH_SIZE);
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->logger->reset();
+	}
+
+
+	private static function column(SymmetricKeyEncryption $encryption): EncryptedColumn
+	{
+		return new EncryptedColumn($encryption, 'stuff', 'id_stuff', 'secret');
+	}
+
+
+	public function testReEncryptsValuesUsingAnOldKey(): void
+	{
+		$oldCiphertext1 = $this->oldKeyEncryption->encrypt('one@example.com');
+		$currentCiphertext = $this->encryption->encrypt('two@example.com');
+		$oldCiphertext2 = $this->oldKeyEncryption->encrypt('three@example.com');
+		$this->database->setFetchPairsDefaultResult([
+			5 => $oldCiphertext1,
+			6 => $currentCiphertext,
+			7 => $oldCiphertext2,
+		]);
+		$this->database->setResultSet(new ResultSet(1));
+
+		$result = $this->reEncryptor->reEncrypt(self::column($this->encryption), false);
+
+		Assert::same(2, $result->reEncrypted);
+		Assert::same(1, $result->upToDate);
+		Assert::same([], $result->failedIds);
+		Assert::same(0, $result->changedMeanwhile);
+		Assert::same(['id_stuff', 'secret', 'stuff', 'secret', 'secret', '', 'id_stuff', 0, 'id_stuff', self::BATCH_SIZE], $this->database->getParamsForQuery(self::SELECT_SQL));
+
+		$params = $this->database->getParamsForQuery(self::UPDATE_SQL);
+		Assert::count(14, $params); // 7 params per update, one update per old-key row, the current row is left alone
+
+		$first = array_slice($params, 0, 7);
+		Assert::same(['stuff', 'secret'], array_slice($first, 0, 2));
+		assert(is_string($first[2]));
+		Assert::false($this->encryption->needsReEncrypt($first[2])); // written back under the active key
+		Assert::same('one@example.com', $this->encryption->decrypt($first[2])); // same plaintext, new ciphertext
+		Assert::same(['id_stuff', 5, 'secret', $oldCiphertext1], array_slice($first, 3)); // the WHERE pins the exact value that was read
+
+		$second = array_slice($params, 7, 7);
+		assert(is_string($second[2]));
+		Assert::same('three@example.com', $this->encryption->decrypt($second[2]));
+		Assert::same(['id_stuff', 7, 'secret', $oldCiphertext2], array_slice($second, 3));
+	}
+
+
+	public function testDryRunDecryptsAndCountsButWritesNothing(): void
+	{
+		$this->database->setFetchPairsDefaultResult([
+			5 => $this->oldKeyEncryption->encrypt('one@example.com'),
+			6 => $this->encryption->encrypt('two@example.com'),
+		]);
+
+		$result = $this->reEncryptor->reEncrypt(self::column($this->encryption), true);
+
+		Assert::same(1, $result->reEncrypted);
+		Assert::same(1, $result->upToDate);
+		Assert::same([], $result->failedIds);
+		Assert::same(0, $result->changedMeanwhile);
+		Assert::same([], $this->database->getParamsForQuery(self::UPDATE_SQL));
+	}
+
+
+	public function testDryRunReportsValuesItCouldNotDecrypt(): void
+	{
+		$this->database->setFetchPairsDefaultResult([
+			1 => '$dropped$deadbeef', // the key id isn't the active one but can't be decrypted
+			2 => $this->oldKeyEncryption->encrypt('one@example.com'),
+		]);
+
+		$result = $this->reEncryptor->reEncrypt(self::column($this->encryption), true);
+
+		Assert::same(1, $result->reEncrypted);
+		Assert::same(0, $result->upToDate);
+		Assert::same([1], $result->failedIds);
+		Assert::same(0, $result->changedMeanwhile);
+		Assert::count(1, $this->logger->getLogged());
+		Assert::same([], $this->database->getParamsForQuery(self::UPDATE_SQL)); // still writes nothing
+	}
+
+
+	public function testUndecryptableValuesAreSkippedAndTheRunContinues(): void
+	{
+		$oldCiphertext = $this->oldKeyEncryption->encrypt('still@example.com');
+		$this->database->setFetchPairsDefaultResult([
+			1 => 'not-a-valid-ciphertext',
+			2 => '$dropped$deadbeef', // a key id no longer in the configuration
+			3 => $oldCiphertext,
+		]);
+		$this->database->setResultSet(new ResultSet(1));
+
+		$result = $this->reEncryptor->reEncrypt(self::column($this->encryption), false);
+
+		Assert::same(1, $result->reEncrypted); // the value after the broken ones is still processed
+		Assert::same(0, $result->upToDate);
+		Assert::same([1, 2], $result->failedIds);
+		Assert::same(0, $result->changedMeanwhile);
+		Assert::count(2, $this->logger->getLogged()); // both broken values are logged for the operator
+		Assert::count(7, $this->database->getParamsForQuery(self::UPDATE_SQL));
+	}
+
+
+	public function testRowChangedBetweenReadAndWriteIsLeftAlone(): void
+	{
+		$this->database->setFetchPairsDefaultResult([
+			5 => $this->oldKeyEncryption->encrypt('one@example.com'),
+		]);
+		$this->database->setResultSet(new ResultSet(0)); // the UPDATE matched nothing, someone changed the row meanwhile
+
+		$result = $this->reEncryptor->reEncrypt(self::column($this->encryption), false);
+
+		Assert::same(0, $result->reEncrypted);
+		Assert::same(0, $result->upToDate);
+		Assert::same([], $result->failedIds);
+		Assert::same(1, $result->changedMeanwhile);
+	}
+
+
+	public function testBatchSizeBelowOneIsRejected(): void
+	{
+		Assert::exception(function (): void {
+			new ColumnReEncryptor($this->database, $this->typedDatabase, 0);
+		}, InvalidArgumentException::class, 'Batch size must be at least 1, 0 given');
+		Assert::exception(function (): void {
+			new ColumnReEncryptor($this->database, $this->typedDatabase, -1);
+		}, InvalidArgumentException::class, 'Batch size must be at least 1, -1 given');
+	}
+
+
+	public function testReadsFurtherBatchesUntilOneIsNotFull(): void
+	{
+		$reEncryptor = new ColumnReEncryptor($this->database, $this->typedDatabase, 2);
+		$this->database->addFetchPairsResult([ // a full batch, so another one is read
+			5 => $this->oldKeyEncryption->encrypt('one@example.com'),
+			6 => 'not-a-valid-ciphertext', // a skipped value still moves the next batch past it
+		]);
+		$this->database->addFetchPairsResult([
+			9 => $this->oldKeyEncryption->encrypt('three@example.com'),
+		]);
+		$this->database->setResultSet(new ResultSet(1));
+
+		$result = $reEncryptor->reEncrypt(self::column($this->encryption), false);
+
+		Assert::same(2, $result->reEncrypted); // rows from both batches
+		Assert::same(0, $result->upToDate);
+		Assert::same([6], $result->failedIds); // the skipped row is reported by its own id, not by its position
+		Assert::same(0, $result->changedMeanwhile);
+
+		$params = $this->database->getParamsForQuery(self::SELECT_SQL);
+		Assert::count(20, $params); // 10 params per select, two selects
+		Assert::same(0, $params[7]); // the first batch starts at the beginning, id 0 included
+		Assert::same(7, $params[17]); // the second one starts just past the last row of the first, skipped or not
+	}
+
+}
+
+TestCaseRunner::run(ColumnReEncryptorTest::class);

--- a/app/tests/Encryption/ReEncryptionTest.phpt
+++ b/app/tests/Encryption/ReEncryptionTest.phpt
@@ -1,0 +1,197 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Encryption;
+
+use MichalSpacekCz\Application\Cli\CliArgs;
+use MichalSpacekCz\Database\TypedDatabase;
+use MichalSpacekCz\Test\Database\Database;
+use MichalSpacekCz\Test\Database\ResultSet;
+use MichalSpacekCz\Test\Encryption\EncryptedStorageMock;
+use MichalSpacekCz\Test\NullLogger;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Database\DriverException;
+use Override;
+use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+use Spaze\Encryption\SymmetricKeyEncryption;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/** @testCase */
+final class ReEncryptionTest extends TestCase
+{
+
+	private const string SELECT_SQL = 'SELECT ?name, ?name FROM ?name WHERE ?name IS NOT NULL AND ?name != ? AND ?name >= ? ORDER BY ?name LIMIT ?';
+	private const string UPDATE_SQL = 'UPDATE ?name SET ?name = ? WHERE ?name = ? AND ?name = ?';
+
+	private readonly SymmetricKeyEncryption $encryption;
+	private readonly SymmetricKeyEncryption $oldKeyEncryption;
+	private readonly ColumnReEncryptor $columnReEncryptor;
+
+
+	public function __construct(
+		private readonly Database $database,
+		TypedDatabase $typedDatabase,
+		private readonly NullLogger $logger,
+	) {
+		$keys = [
+			'old' => 'mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafeb9a3',
+			'new' => 'mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafef158',
+		];
+		$this->encryption = new SymmetricKeyEncryption($keys, 'new', 'mseetest');
+		$this->oldKeyEncryption = new SymmetricKeyEncryption($keys, 'old', 'mseetest');
+		$this->columnReEncryptor = new ColumnReEncryptor($this->database, $typedDatabase, 1000);
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+		$this->logger->reset();
+	}
+
+
+	/**
+	 * @param list<EncryptedStorage> $storages
+	 * @return array{0: int, 1: string} The return code and the printed report
+	 */
+	private function runReEncryption(array $storages, ?CliArgs $cliArgs = null): array
+	{
+		$reEncryption = new ReEncryption($storages, $this->columnReEncryptor, $cliArgs ?? new CliArgs([], null), new ConsoleColor());
+		ob_start();
+		$code = $reEncryption->run();
+		$output = ob_get_clean();
+		assert(is_string($output));
+		return [$code, $output];
+	}
+
+
+	/**
+	 * @param non-empty-string $label
+	 */
+	private function storage(string $label, string $table, string $idColumn, string $valueColumn, string ...$moreValueColumns): EncryptedStorageMock
+	{
+		$columns = [new EncryptedColumn($this->encryption, $table, $idColumn, $valueColumn)];
+		foreach ($moreValueColumns as $moreValueColumn) {
+			$columns[] = new EncryptedColumn($this->encryption, $table, $idColumn, $moreValueColumn);
+		}
+		return new EncryptedStorageMock($label, $columns);
+	}
+
+
+	public function testReportsEveryStorageAndReturnsZeroWhenNothingFailed(): void
+	{
+		$this->database->addFetchPairsResult([1 => $this->oldKeyEncryption->encrypt('one@example.com')]);
+		$this->database->addFetchPairsResult([2 => $this->encryption->encrypt('two@example.com')]);
+		$this->database->setResultSet(new ResultSet(1));
+
+		[$code, $output] = $this->runReEncryption([
+			$this->storage('first storage', 'first_table', 'id_first', 'secret'),
+			$this->storage('second storage', 'second_table', 'id_second', 'secret'),
+		]);
+
+		Assert::same(0, $code);
+		Assert::same(
+			"first storage: 1 re-encrypted, 0 up to date, 0 failed, 0 changed meanwhile\n"
+			. "second storage: 0 re-encrypted, 1 up to date, 0 failed, 0 changed meanwhile\n",
+			$output,
+		);
+	}
+
+
+	public function testDryRunSaysWhatItWouldDoAndWritesNothing(): void
+	{
+		$this->database->setFetchPairsDefaultResult([1 => $this->oldKeyEncryption->encrypt('one@example.com')]);
+
+		[$code, $output] = $this->runReEncryption(
+			[$this->storage('some storage', 'some_table', 'id_some', 'secret')],
+			new CliArgs(['--dry-run' => true], null),
+		);
+
+		Assert::same(0, $code);
+		Assert::same("some storage: 1 would be re-encrypted, 0 up to date, 0 failed\n", $output);
+		Assert::same([], $this->database->getParamsForQuery(self::UPDATE_SQL));
+	}
+
+
+	public function testValuesThatCannotBeDecryptedFailTheRunAndSayWhereTheyAre(): void
+	{
+		$this->database->setFetchPairsDefaultResult([41 => 'not-a-valid-ciphertext', 88 => '$dropped$deadbeef']);
+
+		[$code, $output] = $this->runReEncryption([$this->storage('some storage', 'some_table', 'id_some', 'secret')]);
+
+		Assert::same(1, $code);
+		Assert::contains('2 failed (`some_table.id_some IN (41, 88)`)', $output); // ready to paste into a query
+		Assert::count(2, $this->logger->getLogged());
+	}
+
+
+	public function testSingleFailureIsWrittenAsOneEquality(): void
+	{
+		$this->database->setFetchPairsDefaultResult([12 => 'not-a-valid-ciphertext']);
+
+		[, $output] = $this->runReEncryption([$this->storage('some storage', 'some_table', 'id_some', 'secret')]);
+
+		Assert::contains('1 failed (`some_table.id_some = 12`)', $output);
+	}
+
+
+	public function testStorageWithSeveralColumnsGetsALinePerColumn(): void
+	{
+		$this->database->addFetchPairsResult([7 => 'not-a-valid-ciphertext']);
+		$this->database->addFetchPairsResult([8 => $this->encryption->encrypt('a note')]);
+
+		[$code, $output] = $this->runReEncryption([$this->storage('some storage', 'some_table', 'id_some', 'email', 'note')]);
+
+		Assert::same(1, $code);
+		// Named per column, or the counts and the failed rows couldn't be told apart
+		Assert::same(
+			"some storage, email: 0 re-encrypted, 0 up to date, 1 failed (`some_table.id_some = 7`), 0 changed meanwhile\n"
+			. "some storage, note: 0 re-encrypted, 1 up to date, 0 failed, 0 changed meanwhile\n",
+			$output,
+		);
+		// Both columns were really read: the labels above come from the loop, so they'd look the same if one of them was swept twice
+		$params = $this->database->getParamsForQuery(self::SELECT_SQL);
+		Assert::contains('email', $params);
+		Assert::contains('note', $params);
+	}
+
+
+	public function testColumnThatCannotBeWrittenIsReportedAndTheRestStillRuns(): void
+	{
+		$this->database->addFetchPairsResult([1 => $this->oldKeyEncryption->encrypt('one@example.com')]); // needs a write, which fails
+		$this->database->addFetchPairsResult([2 => $this->encryption->encrypt('two@example.com')]); // needs nothing
+		$exception = new DriverException('The database fell over');
+		$this->database->willThrowOnce($exception);
+
+		[$code, $output] = $this->runReEncryption([
+			$this->storage('broken storage', 'broken_table', 'id_broken', 'secret'),
+			$this->storage('working storage', 'working_table', 'id_working', 'secret'),
+		]);
+
+		Assert::same(1, $code);
+		Assert::contains('working storage: 0 re-encrypted, 1 up to date, 0 failed, 0 changed meanwhile', $output);
+		Assert::notContains('broken storage', $output); // failures go to the error output, so they survive `> report.txt`
+		Assert::same([$exception], $this->logger->getLogged()); // the whole exception, a flattened message would lose the trace and the cause
+	}
+
+
+	public function testBadArgsAreReportedWithoutSweepingAnything(): void
+	{
+		[$code, $output] = $this->runReEncryption(
+			[$this->storage('some storage', 'some_table', 'id_some', 'secret')],
+			new CliArgs([], 'Unknown option --frobnicate'),
+		);
+
+		Assert::same(3, $code);
+		Assert::notContains('Unknown option --frobnicate', $output); // the error output again, not the report
+		Assert::same([], $this->database->getParamsForQuery(self::SELECT_SQL)); // nothing was even read
+	}
+
+}
+
+TestCaseRunner::run(ReEncryptionTest::class);

--- a/app/tests/Form/TrainingApplication/TrainingApplicationAdminFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingApplicationAdminFormFactoryTest.phpt
@@ -96,7 +96,7 @@ final class TrainingApplicationAdminFormFactoryTest extends TestCase
 		]);
 		Arrays::invoke($form->onSuccess, $form);
 		Assert::same(self::TRAINING_DATE_ID, $this->result);
-		$params = $this->database->getParamsArrayForQuery('UPDATE training_applications SET ? WHERE id_application = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		Assert::true($params[0]['familiar']);
 		Assert::same(self::TRAINING_DATE_ID, $params[0]['key_date']);
 	}

--- a/app/tests/Form/TrainingApplication/TrainingMultipleApplicationsFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingMultipleApplicationsFormFactoryTest.phpt
@@ -74,7 +74,7 @@ final class TrainingMultipleApplicationsFormFactoryTest extends TestCase
 		$this->applicationPresenter->anchorForm($form);
 		Arrays::invoke($form->onSuccess, $form);
 		Assert::same(self::TRAINING_DATE_ID, $this->result);
-		$params = $this->database->getParamsArrayForQuery('INSERT INTO training_applications');
+		$params = $this->database->getParamsArrayForQuery('INSERT INTO ?name');
 		Assert::same(self::TRAINING_DATE_ID, $params[0]['key_date']);
 		Assert::same(self::NEW_STATUS_ID, $params[0]['key_status']);
 	}

--- a/app/tests/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactoryTest.phpt
@@ -75,7 +75,7 @@ final class TrainingPreliminaryApplicationFormFactoryTest extends TestCase
 		Arrays::invoke($this->form->onSuccess, $this->form);
 		Assert::same('action', $this->action);
 		Assert::null($this->message);
-		$params = $this->database->getParamsArrayForQuery('INSERT INTO training_applications');
+		$params = $this->database->getParamsArrayForQuery('INSERT INTO ?name');
 		Assert::same(self::TRAINING_ID, $params[0]['key_training']);
 	}
 

--- a/app/tests/Form/User/AccountNotificationEmailFormFactoryTest.phpt
+++ b/app/tests/Form/User/AccountNotificationEmailFormFactoryTest.phpt
@@ -75,7 +75,7 @@ final class AccountNotificationEmailFormFactoryTest extends TestCase
 		Arrays::invoke($form->onSuccess, $form);
 
 		Assert::true($this->onSuccessCalled);
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		Assert::notSame('me@example.com', $stored); // stored encrypted, never plaintext
@@ -113,7 +113,7 @@ final class AccountNotificationEmailFormFactoryTest extends TestCase
 
 		Assert::true($form->hasErrors());
 		Assert::false($this->onSuccessCalled);
-		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')); // not saved
+		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?')); // not saved
 	}
 
 
@@ -165,7 +165,7 @@ final class AccountNotificationEmailFormFactoryTest extends TestCase
 	private function seedCurrentNotificationEmail(string $address): void
 	{
 		$this->userAccounts->setNotificationEmail(42, $address);
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->setFetchFieldDefaultResult($stored); // every getNotificationEmail() returns the seeded address until overwritten

--- a/app/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
+++ b/app/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
@@ -141,7 +141,7 @@ final class TrainingApplicationFormSuccessTest extends TestCase
 		Assert::same(self::TRAINING_ACTION, $this->onSuccessAction);
 		Assert::null($this->onErrorMessage);
 
-		$params = $this->database->getParamsArrayForQuery('INSERT INTO training_applications');
+		$params = $this->database->getParamsArrayForQuery('INSERT INTO ?name');
 		Assert::same(self::DATE_ID, $params[0]['key_date']);
 
 		$this->assertSessionSection();
@@ -161,11 +161,10 @@ final class TrainingApplicationFormSuccessTest extends TestCase
 		Assert::same(self::TRAINING_ACTION, $this->onSuccessAction);
 		Assert::null($this->onErrorMessage);
 
-		$query = 'UPDATE training_applications SET ? WHERE id_application = ?';
+		$query = 'UPDATE ?name SET ? WHERE ?name = ?';
 		$params = $this->database->getParamsArrayForQuery($query);
 		Assert::same(self::NAME, $params[0]['name']);
-		$whereParams = $this->database->getParamsForQuery($query);
-		Assert::same(self::APPLICATION_ID, $whereParams[0]);
+		Assert::same(['training_applications', 'id_application', self::APPLICATION_ID], $this->database->getParamsForQuery($query));
 
 		$this->assertSessionSection();
 

--- a/app/tests/Training/Applications/TrainingApplicationStorageTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationStorageTest.phpt
@@ -227,7 +227,7 @@ final class TrainingApplicationStorageTest extends TestCase
 		?int $discount,
 		int $statusId,
 	): void {
-		$params = $this->database->getParamsArrayForQuery('INSERT INTO training_applications')[0];
+		$params = $this->database->getParamsArrayForQuery('INSERT INTO ?name')[0];
 		Assert::same($dateId, $params['key_date']);
 		Assert::hasNotKey('key_training', $params);
 		Assert::same($name, $params['name']);
@@ -312,6 +312,18 @@ final class TrainingApplicationStorageTest extends TestCase
 			null,
 			null,
 		);
+	}
+
+
+	public function testDeclaresTheEmailColumn(): void
+	{
+		Assert::same('training application emails', $this->trainingApplicationStorage->getEncryptedDataLabel());
+
+		$columns = $this->trainingApplicationStorage->getEncryptedColumns();
+		Assert::count(1, $columns);
+		Assert::same('training_applications', $columns[0]->table);
+		Assert::same('id_application', $columns[0]->idColumn);
+		Assert::same('email', $columns[0]->valueColumn);
 	}
 
 

--- a/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
+++ b/app/tests/User/Notifications/UserSecurityNotifierTest.phpt
@@ -142,7 +142,7 @@ final class UserSecurityNotifierTest extends TestCase
 	private function seedNotificationEmail(int $userId, string $address): void
 	{
 		$this->userAccounts->setNotificationEmail($userId, $address);
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->addFetchFieldResult($stored);

--- a/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
+++ b/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
@@ -134,6 +134,21 @@ final class SecurityActivityTest extends TestCase
 	}
 
 
+	public function testDeclaresTheDetailsColumnWithTheKeyThatStoredIt(): void
+	{
+		Assert::same('security event details', $this->securityActivity->getEncryptedDataLabel());
+
+		$columns = $this->securityActivity->getEncryptedColumns();
+		Assert::count(1, $columns);
+		Assert::same('security_events', $columns[0]->table);
+		Assert::same('id_security_event', $columns[0]->idColumn);
+		Assert::same('details', $columns[0]->valueColumn);
+
+		// The declared key set has to be the one the column was written with, or a sweep would find every row undecryptable
+		Assert::same('{"passkey":"Yubikey"}', $columns[0]->encryption->decrypt($this->encryptDetails(['passkey' => 'Yubikey'])));
+	}
+
+
 	/**
 	 * @param array<string, string|null> $details
 	 */

--- a/app/tests/User/UserAccountsTest.phpt
+++ b/app/tests/User/UserAccountsTest.phpt
@@ -36,6 +36,8 @@ final class UserAccountsTest extends TestCase
 	{
 		$this->database->setFetchFieldDefaultResult(null);
 		Assert::null($this->userAccounts->getNotificationEmail(42));
+		// Reads the row of the user that was asked for: without this, returning somebody else's address goes unnoticed
+		Assert::same(['notification_email', 'users', 'id_user', 42], $this->database->getParamsForQuery('SELECT ?name FROM ?name WHERE ?name = ?'));
 	}
 
 
@@ -43,7 +45,7 @@ final class UserAccountsTest extends TestCase
 	{
 		$this->userAccounts->setNotificationEmail(42, 'me@example.com');
 
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		Assert::notSame('me@example.com', $stored); // stored as ciphertext, never plaintext
@@ -56,7 +58,7 @@ final class UserAccountsTest extends TestCase
 	public function testChangeNotificationEmailReturnsOldAndWritesNewInOneTransaction(): void
 	{
 		$this->userAccounts->setNotificationEmail(42, 'old@example.com');
-		$encryptedOld = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['notification_email'];
+		$encryptedOld = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?')[0]['notification_email'];
 		assert(is_string($encryptedOld));
 		$this->database->reset();
 		$this->database->setFetchFieldDefaultResult($encryptedOld); // the locked read returns the old ciphertext
@@ -65,7 +67,7 @@ final class UserAccountsTest extends TestCase
 
 		Assert::same('old@example.com', $old); // previous notification email, decrypted from the locked read
 		Assert::same(DatabaseTransactionStatus::Committed, $this->database->transactionStatus); // read + write committed together
-		$stored = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')[0]['notification_email'];
+		$stored = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?')[0]['notification_email'];
 		assert(is_string($stored));
 		Assert::notSame('new@example.com', $stored); // new notification email stored encrypted
 	}
@@ -81,7 +83,25 @@ final class UserAccountsTest extends TestCase
 
 		// the old value is decrypted before the write, so a bad one aborts the transaction instead of committing the new notification email then throwing
 		Assert::same(DatabaseTransactionStatus::RolledBack, $this->database->transactionStatus);
-		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?')); // the new notification email was never written
+		Assert::same([], $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?')); // the new notification email was never written
+	}
+
+
+	public function testDeclaresTheNotificationEmailColumnWithTheKeyThatStoredIt(): void
+	{
+		Assert::same('user notification emails', $this->userAccounts->getEncryptedDataLabel());
+
+		$columns = $this->userAccounts->getEncryptedColumns();
+		Assert::count(1, $columns);
+		Assert::same('users', $columns[0]->table);
+		Assert::same('id_user', $columns[0]->idColumn);
+		Assert::same('notification_email', $columns[0]->valueColumn);
+
+		// The declared key set has to be the one the column was written with, or a sweep would find every row undecryptable
+		$this->userAccounts->setNotificationEmail(42, 'me@example.com');
+		$stored = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?')[0]['notification_email'];
+		assert(is_string($stored));
+		Assert::same('me@example.com', $columns[0]->encryption->decrypt($stored));
 	}
 
 }

--- a/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyAddTest.phpt
@@ -125,7 +125,7 @@ final class PasskeyAddTest extends TestCase
 	private function seedNotificationEmail(int $userId, string $address): void
 	{
 		$this->userAccounts->setNotificationEmail($userId, $address);
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->setFetchFieldDefaultResult($stored);

--- a/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
+++ b/app/tests/User/WebAuthn/Registration/PasskeyResetTest.phpt
@@ -111,7 +111,7 @@ final class PasskeyResetTest extends TestCase
 	private function seedNotificationEmail(int $userId, string $address): void
 	{
 		$this->userAccounts->setNotificationEmail($userId, $address);
-		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE id_user = ?');
+		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		$stored = $params[0]['notification_email'];
 		assert(is_string($stored));
 		$this->database->addFetchFieldResult($stored);


### PR DESCRIPTION
v3 stores values in a marked envelope (`$keyId$SymV1$...`) and its `needsReEncrypt()` reports everything written by an older version as needing re-encryption. Old values keep decrypting forever, so nothing breaks without this, but without a way to re-encrypt them the data would sit in the old format indefinitely. This goes in before the upgrade so the mechanism is already there when v3 lands; on v2.1.0 `needsReEncrypt()` only compares key ids, so a run today re-encrypts nothing unless a key was rotated.

A sweep rather than re-encrypting on save or on read, because it finishes and can be verified. On-save would migrate nothing at all for `security_events`, which is only ever inserted into, and on-read means writing during a read request and needs a guard against overwriting a concurrent update at every read site, while still leaving cold rows untouched forever. The `--dry-run` flag doubles as the check that a real run left nothing behind.

Not a one-off migration: `needsReEncrypt()` is also true when a value uses a key that is no longer the active one, so this is the tool for a key rotation as well, which the site had no way to do.

A storage only declares its encrypted columns, it doesn't re-encrypt them: `getEncryptedColumns()` returns an `EncryptedColumn` each, and the sweeping happens in one loop here. That is deliberate rather than tidier: the dry run flag would otherwise be threaded through every storage and passed once per column, and a table with two columns could end up writing one of them while only pretending with the other. Now no storage can decide that, because none of them ever sees the flag. The column list is typed `non-empty-list` and the label `non-empty-string`, so the analysers reject a storage that declares nothing rather than letting it drop out of the report without a line. The report names the column when a storage declares more than one, since otherwise two lines of counts and two sets of failed rows couldn't be told apart, and identity travels in with the column while only counts come back. `EncryptedStorage` per storing service, collected with `typed()` the way `AuthTokenGarbageCollector` collects `UserAuthTokenLifetime`, except those implementations do their own deleting while these only describe, for the reason above. Each service still says which table and column are its own, and says it once: the names are constants there now, used both by the queries and by the column the sweep is handed, so the two can't drift into disagreeing. The queries pass them as `?name` parameters rather than splicing them into the SQL, which keeps each statement a single readable string. Sessions are deliberately not included: the session handler re-encrypts whenever data changes, and rows expire in 14 days, so they migrate themselves. That has a consequence the script now spells out, because the script also presents itself as the key rotation tool: a rotated session key has to stay configured until the last pre-rotation session has expired. The handler decrypts without catching anything, so an old session whose key is gone is an error on every request that visitor makes, and this sweep reporting success would otherwise read as permission to drop the key.

Rows are read in batches ordered by id because `security_events` grows without bound. The batch cursor holds the next id to read rather than the last one read, so the first batch takes everything from id 0 up: none of the three tables can hold a row with id 0 today, but the alternative silently leaves such a row out of the counts entirely, and a row nobody knows was skipped is the one way this tool could quietly leave something behind. The write is `UPDATE ... WHERE id = ? AND value = <what was read>` so a row someone else changed between the read and the write is left alone rather than overwritten with a stale round-trip; that write used the active key anyway. Rows with an empty value are skipped along with the null ones: there is nothing in them to re-encrypt, and putting one through decryption would report a failure every single run without saying why. The batch size is rejected below 1, because a batch of zero returns no rows and no rows is also how the loop knows it has reached the end, so a mistyped one would read the same empty batch forever.

A value that cannot be decrypted is logged and skipped, and makes the script exit non-zero, so one bad row doesn't abort a sweep of everything else. The result carries the ids of those rows rather than just how many there were, because they have to be sorted out by hand before the old key can go and the logged exception doesn't say which row it came from. The report writes them the way a query wants them, table and all, so finding those rows is a copy and paste rather than a translation: ``1 failed (`training_applications.id_application = 12`)``. The table because a storage's label is prose and doesn't have to resemble it, `user notification emails` living in `users` being the example. Failures and any argument error go to the error output rather than the report, so redirecting a run to a file doesn't hide them.

`SecurityActivity` implements the interface rather than `SecurityEventLogger` because the logger is deliberately best-effort and swallows its write failures, which is the opposite of what a sweep has to do with them.

The test database double now records the parameters of every read method, not just the two the sweep happens to use. It recorded none of them before, so no test could check which row a read asked for: hardcoding a user id in `UserAccounts::getNotificationEmail()`, i.e. returning somebody else's address, passed the whole suite. That one now has an assertion on the id it reads, and the rest of the read paths can get the same treatment where the parameter decides whose row comes back.
