### PR TITLE
Run shellcheck on the shell scripts too

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -132,6 +132,14 @@ jobs:
         persist-credentials: false
     - run: make --directory=app lint-xml-auto-install-download-xsd
 
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      with:
+        persist-credentials: false
+    - run: make --directory=app shellcheck
+
   phpcs:
     runs-on: ubuntu-latest
     strategy:

--- a/app/Makefile
+++ b/app/Makefile
@@ -1,6 +1,6 @@
-.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt dump-db-schema
+.PHONY: test composer-audit composer-update composer-validate composer-outdated npm-audit cs-fix check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml lint-xml-auto-install-download-xsd shellcheck phpcs phpstan phpstan-vendor psalm psalm-clear-cache tester tester-include-skipped gitleaks composer-dependency-analyser update-security-txt dump-db-schema
 
-test: composer-audit composer-validate npm-audit check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
+test: composer-audit composer-validate npm-audit check-file-patterns check-makefile check-sri-macros-concat check-dependabot-directories lint-php lint-latte lint-neon lint-xml shellcheck phpcs phpstan tester psalm phpstan-vendor composer-dependency-analyser
 
 composer-audit:
 	composer audit
@@ -51,6 +51,9 @@ lint-xml:
 
 lint-xml-auto-install-download-xsd:
 	bin/xmllint.sh --auto-install-with-apt --auto-download-xsd
+
+shellcheck:
+	shellcheck --external-sources bin/*.sh
 
 phpcs:
 	vendor-dev/vendor/bin/phpcs src/ public/ tests/ bin/

--- a/app/bin/colors.sh
+++ b/app/bin/colors.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 
+# The variables are used by the scripts that source this one
+# shellcheck disable=SC2034
+
 COLOR_LIGHT_GRAY=$(tput setaf 7)
 COLOR_GREEN=$(tput setaf 2)
-COLOR_DARKER_GREEN=$(tput setaf 22)  # will only work with TERM=xterm-256color
 COLOR_RED=$(tput setaf 9)
 COLOR_NORMAL=$(tput sgr0)

--- a/app/bin/update-security.txt.sh
+++ b/app/bin/update-security.txt.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# shellcheck source=bin/colors.sh
 source "$(dirname "$0")/colors.sh"
 
 # The new date is less than a year/365 days into the future because the spec says that it is recommended that the value be less


### PR DESCRIPTION
The other languages here are checked on every build, shell was the gap: nine scripts, some of them running on the server, none of them looked at by anything. Seven were already clean, so the gap was cheap to close rather than a pile of work waiting.

Named after the tool rather than `lint-shell`, because every `lint-*` target here answers "is this file well-formed" and shellcheck doesn't: quoting and unused variables are findings in files that parse fine, which puts it with `phpcs`, `phpstan` and `gitleaks`.

Two findings had to be dealt with first, both about `colors.sh` being a library rather than a script. Its variables look unused when it is read on its own, and the script that sources it builds the path with `$(dirname "$0")`, which shellcheck can't evaluate, so it wasn't following the file. The `source=` directive tells it where to look and `--external-sources` lets it, which also means the sourcing script is checked against what the palette actually defines.

`COLOR_DARKER_GREEN` goes rather than being silenced along with the rest. The palette came over from the `cert-*` scripts in spaze/home, where the second green marks the variable part of a line, as in `Renewing a certificate for <domain>`. The script here colours a status tag and leaves the variable part plain, so that one entry arrived with nothing to do and no script has ever referenced it. The disable now hides four warnings that are wrong and none that aren't.