### PR TITLE
Add a wrapper for running the bin scripts on the server

### DIFF
--- a/app/bin/as-web-app-user.sh
+++ b/app/bin/as-web-app-user.sh
@@ -1,0 +1,22 @@
+#!/bin/sh
+
+# Runs a script from this directory as the web app user, e.g. `bin/as-web-app-user.sh reencrypt.php --dry-run`
+# The scripts write the same compiled DI container and log files as the web app, so if executed
+# directly they may fail on a dir permission error or leave files the web app can't rewrite
+
+WEB_APP_USER="www-data"
+SCRIPT="$1"
+
+if [ -z "$SCRIPT" ]; then
+	echo "Usage: $0 <script> [args], e.g. $0 reencrypt.php --dry-run"
+	exit 2
+fi
+shift
+
+SCRIPT_PATH="$(dirname "$0")/$SCRIPT"
+if [ ! -x "$SCRIPT_PATH" ]; then
+	echo "$SCRIPT_PATH not found or not executable"
+	exit 2
+fi
+
+exec sudo runuser --user "$WEB_APP_USER" -- "$SCRIPT_PATH" "$@"


### PR DESCRIPTION
The scripts here boot the same DI container and write the same log files as the web app, so running one as yourself stops on a permission error before it does anything, and running one as root works but leaves files behind that the web app can no longer write. Both are avoided by running them as the web app user, and the invocation is easy to get wrong from memory, so it was being copied out of `collect_garbage.php`'s docblock every time.

A script rather than a note somewhere: the note would be a third copy of the same line and could drift from what actually works, while this one can't be out of date with itself. It resolves the target against its own directory so the path isn't repeated, which is what makes it shorter to type than the command it replaces.