### PR TITLE
Pin whose rows the reads ask for

### DIFF
--- a/app/src/Presentation/Pulse/Heartbleed/HeartbleedPresenter.php
+++ b/app/src/Presentation/Pulse/Heartbleed/HeartbleedPresenter.php
@@ -20,9 +20,9 @@ final class HeartbleedPresenter extends BasePresenter
 	private function getSmallPrint(): Html
 	{
 		$smallPrint = [
-			 'Knocking on yer servar\'s ports since 2014.',
-			 'Do you even scan?',
-			 'Wow. So heart. Much bleed.',
+			'Knocking on yer servar\'s ports since 2014.',
+			'Do you even scan?',
+			'Wow. So heart. Much bleed.',
 			htmlspecialchars('<script>alert(\'XSS\');</script>'),
 			'<a href="https://www.youtube.com/watch?v=DLzxrzFCyOs">admin</a>',
 		];

--- a/app/src/Talks/Talks.php
+++ b/app/src/Talks/Talks.php
@@ -63,7 +63,7 @@ final readonly class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
-			    LEFT JOIN locales l ON l.id_locale = t.key_locale
+				LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.date <= NOW()
 			ORDER BY t.date DESC
@@ -124,7 +124,7 @@ final readonly class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
-			    LEFT JOIN locales l ON l.id_locale = t.key_locale
+				LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.date > NOW()
 			ORDER BY t.date';
@@ -175,7 +175,7 @@ final readonly class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
-			    LEFT JOIN locales l ON l.id_locale = t.key_locale
+				LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.action = ?',
 			$name,
@@ -268,7 +268,7 @@ final readonly class Talks
 				ts.title AS supersededByTitle,
 				t.publish_slides AS publishSlides
 			FROM talks t
-			    LEFT JOIN locales l ON l.id_locale = t.key_locale
+				LEFT JOIN locales l ON l.id_locale = t.key_locale
 				LEFT JOIN talks ts ON t.key_superseded_by = ts.id_talk
 			WHERE t.id_talk = ?',
 			$id,

--- a/app/src/Test/Database/Database.php
+++ b/app/src/Test/Database/Database.php
@@ -3,8 +3,10 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Test\Database;
 
+use Closure;
 use DateTime;
 use DateTimeInterface;
+use Exception;
 use MichalSpacekCz\DateTime\DateTimeFormat;
 use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\WillThrow;
@@ -17,6 +19,9 @@ final class Database extends Explorer
 
 	use WillThrow;
 
+
+	/** @var Exception|(Closure(): Exception)|null */
+	private Exception|Closure|null $willThrowOnRead = null;
 
 	private string $defaultInsertId = '';
 
@@ -67,6 +72,23 @@ final class Database extends Explorer
 	private(set) DatabaseTransactionStatus $transactionStatus = DatabaseTransactionStatus::None;
 
 
+	/**
+	 * @param Exception|Closure(): Exception $e
+	 */
+	public function willThrowOnRead(Exception|Closure $e): void
+	{
+		$this->willThrowOnRead = $e;
+	}
+
+
+	private function maybeThrowOnRead(): void
+	{
+		if ($this->willThrowOnRead !== null) {
+			throw $this->willThrowOnRead instanceof Closure ? ($this->willThrowOnRead)() : $this->willThrowOnRead;
+		}
+	}
+
+
 	public function reset(): void
 	{
 		$this->defaultInsertId = '';
@@ -88,6 +110,7 @@ final class Database extends Explorer
 		$this->fetchAllResultsPosition = 0;
 		$this->resultSet = null;
 		$this->wontThrow();
+		$this->willThrowOnRead = null;
 		$this->transactionStatus = DatabaseTransactionStatus::None;
 	}
 
@@ -244,6 +267,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetch(string $sql, ...$params): ?Row
 	{
+		$this->maybeThrowOnRead();
 		$this->recordParams($sql, $params);
 		$row = $this->createRow($this->fetchResults[$this->fetchResultsPosition++] ?? $this->fetchDefaultResult);
 		return $row->count() > 0 ? $row : null;
@@ -269,6 +293,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchField(string $sql, ...$params): mixed
 	{
+		$this->maybeThrowOnRead();
 		$this->recordParams($sql, $params);
 		return $this->fetchFieldResults[$this->fetchFieldResultsPosition++] ?? $this->fetchFieldDefaultResult;
 	}
@@ -300,6 +325,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchPairs(string $sql, ...$params): array
 	{
+		$this->maybeThrowOnRead();
 		$this->recordParams($sql, $params);
 		return $this->fetchPairsResults[$this->fetchPairsResultsPosition++] ?? $this->fetchPairsDefaultResult;
 	}
@@ -353,6 +379,7 @@ final class Database extends Explorer
 	#[Override]
 	public function fetchAll(string $sql, ...$params): array
 	{
+		$this->maybeThrowOnRead();
 		$this->recordParams($sql, $params);
 		return $this->fetchAllResults[$this->fetchAllResultsPosition++] ?? $this->fetchAllDefaultResult;
 	}

--- a/app/src/Test/Database/Database.php
+++ b/app/src/Test/Database/Database.php
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Test\Database;
 use DateTime;
 use DateTimeInterface;
 use MichalSpacekCz\DateTime\DateTimeFormat;
+use MichalSpacekCz\ShouldNotHappenException;
 use MichalSpacekCz\Test\WillThrow;
 use Nette\Database\Explorer;
 use Nette\Database\Row;
@@ -181,6 +182,31 @@ final class Database extends Explorer
 	public function getParamsForQuery(string $query): array
 	{
 		return $this->queriesScalarParams[$query] ?? [];
+	}
+
+
+	/**
+	 * For queries too long to repeat in a test verbatim, where doing so would fail on reformatting rather than on
+	 * the parameters it is checking. Pass enough of the query to pick out one, an ambiguous match is an error
+	 * rather than a guess.
+	 *
+	 * @return array<int, mixed>
+	 */
+	public function getParamsForQueryContaining(string $part): array
+	{
+		$matching = [];
+		foreach ($this->queriesScalarParams as $query => $params) {
+			if (str_contains($query, $part)) {
+				$matching[$query] = $params;
+			}
+		}
+		if (count($matching) > 1) {
+			throw new ShouldNotHappenException(sprintf('%s matches %d queries: %s', $part, count($matching), implode(', ', array_keys($matching))));
+		}
+		foreach ($matching as $params) {
+			return $params;
+		}
+		return [];
 	}
 
 

--- a/app/src/Training/Dates/UpcomingTrainingDates.php
+++ b/app/src/Training/Dates/UpcomingTrainingDates.php
@@ -106,7 +106,7 @@ final class UpcomingTrainingDates
 					JOIN languages l ON a.key_language = l.id_language
 					JOIN training_date_status s ON d.key_status = s.id_status
 					LEFT JOIN training_venues v ON d.key_venue = v.id_venue
-				    LEFT JOIN training_cooperations c ON d.key_cooperation = c.id_cooperation
+					LEFT JOIN training_cooperations c ON d.key_cooperation = c.id_cooperation
 					JOIN (
 						SELECT
 							t2.id_training,

--- a/app/src/User/WebAuthn/Passkeys.php
+++ b/app/src/User/WebAuthn/Passkeys.php
@@ -53,7 +53,7 @@ final readonly class Passkeys
 			FROM ?name
 			WHERE key_user = ?
 			ORDER BY last_used DESC,
-		 	created DESC',
+			created DESC',
 			$this->passkeysTableName,
 			$this->manager->getUserId($this->user),
 		);

--- a/app/tests/Training/Applications/TrainingApplicationsTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationsTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Training\Applications;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Override;
 use Tester\Assert;
 use Tester\TestCase;
 
@@ -23,10 +24,30 @@ final class TrainingApplicationsTest extends TestCase
 	}
 
 
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->database->reset();
+	}
+
+
 	public function testGetValidUnpaidCount(): void
 	{
 		$this->database->setFetchFieldDefaultResult(909);
 		Assert::same(909, $this->trainingApplications->getValidUnpaidCount());
+	}
+
+
+	public function testGetApplicationByTokenAsksForTheTokenItWasGiven(): void
+	{
+		// The token is the whole authorization here, there is no session behind it: whoever holds the link is
+		// shown the application, so the query has to be scoped by the token that was handed in
+		Assert::null($this->trainingApplications->getApplicationByToken('a-visitors-token'));
+
+		Assert::same(
+			['a-visitors-token', 'cs_CZ'],
+			$this->database->getParamsForQueryContaining('a.access_token = ?'),
+		);
 	}
 
 

--- a/app/tests/Training/Files/TrainingFilesTest.phpt
+++ b/app/tests/Training/Files/TrainingFilesTest.phpt
@@ -40,6 +40,18 @@ final class TrainingFilesTest extends TestCase
 	}
 
 
+	public function testGetFileAsksForTheApplicationTokenAndFilenameGivenToIt(): void
+	{
+		// Same as the application itself, the token is the authorization, and the file is only this
+		// application's file: a query missing either would hand a visitor somebody else's materials
+		$this->database->setFetchFieldDefaultResult(1); // getAllowFilesStatuses() looks up status ids before this query runs
+
+		Assert::null($this->trainingFiles->getFile(42, 'a-visitors-token', 'materials.pdf'));
+
+		Assert::same([42, 'a-visitors-token', 'materials.pdf'], $this->database->getParamsForQueryContaining('AND a.access_token = ?'));
+	}
+
+
 	public function testIsAllowedExtension(): void
 	{
 		Assert::true($this->trainingFiles->isAllowedExtension('pdf'));

--- a/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
+++ b/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
@@ -20,6 +20,9 @@ require __DIR__ . '/../../bootstrap.php';
 final class SecurityActivityTest extends TestCase
 {
 
+	private const int USER_ID = 42;
+
+
 	public function __construct(
 		private readonly Database $database,
 		private readonly SecurityActivity $securityActivity,
@@ -33,7 +36,7 @@ final class SecurityActivityTest extends TestCase
 	#[Override]
 	protected function setUp(): void
 	{
-		$this->user->login(new SimpleIdentity(42));
+		$this->user->login(new SimpleIdentity(self::USER_ID));
 	}
 
 
@@ -74,6 +77,19 @@ final class SecurityActivityTest extends TestCase
 		Assert::same('TestBrowser/1.0', $events[0]->userAgent);
 		Assert::same(['passkey' => 'Yubikey'], $events[0]->details);
 		Assert::same('messages.account.securityLog.event.passkeyRenamed', $events[0]->labelKey());
+	}
+
+
+	public function testGetEventsForCurrentUserReadsOnlyTheSignedInUsersRows(): void
+	{
+		$this->securityActivity->getEventsForCurrentUser();
+
+		// The WHERE parameter is the whole authorization here, and the double returns its rows whoever asks,
+		// so without this a hardcoded id would show one admin another's security log with every test still green
+		Assert::same(
+			['details', 'security_events', self::USER_ID, 'id_security_event'],
+			$this->database->getParamsForQueryContaining('WHERE key_user = ?'),
+		);
 	}
 
 

--- a/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
+++ b/app/tests/User/SecurityActivity/SecurityActivityTest.phpt
@@ -7,6 +7,7 @@ namespace MichalSpacekCz\User\SecurityActivity;
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\NullLogger;
 use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Database\DriverException;
 use Nette\Security\SimpleIdentity;
 use Nette\Security\User;
 use Nette\Utils\DateTime;
@@ -147,6 +148,19 @@ final class SecurityActivityTest extends TestCase
 
 		Assert::same([], $this->securityActivity->getEventsForCurrentUser()); // bad row skipped, the page survives
 		Assert::count(1, $this->logger->getLogged()); // the skipped row is logged for the operator
+	}
+
+
+	public function testFailingReadIsNotHiddenTheWayABadRowIs(): void
+	{
+		$this->database->willThrowOnRead(new DriverException('The database fell over'));
+
+		// A row this method can't make sense of is logged and skipped so the rest of the log still renders.
+		// A read that fails outright has no rest to render, and an empty page would read as "no events".
+		Assert::exception(function (): void {
+			$this->securityActivity->getEventsForCurrentUser();
+		}, DriverException::class);
+		Assert::same([], $this->logger->getLogged());
 	}
 
 

--- a/app/tests/User/WebAuthn/PasskeyStorageTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeyStorageTest.phpt
@@ -39,6 +39,7 @@ final class PasskeyStorageTest extends TestCase
 	{
 		$this->database->setFetchFieldDefaultResult('user-handle-42');
 		Assert::same('user-handle-42', $this->passkeyStorage->getUserHandleByUserId(42));
+		Assert::same(['users', 42], $this->database->getParamsForQuery('SELECT passkey_user_handle FROM ?name WHERE id_user = ?'));
 	}
 
 
@@ -143,6 +144,9 @@ final class PasskeyStorageTest extends TestCase
 	{
 		$this->database->setFetchPairsDefaultResult([0 => 'cred-id-1', 1 => 'cred-id-2']);
 		$result = $this->passkeyStorage->getDescriptorsByUserId(42);
+		// These descriptors are handed to the authenticator as the credentials it may sign with,
+		// so descriptors read for the wrong user would offer someone else's passkeys
+		Assert::same(['passkeys', 42], $this->database->getParamsForQuery('SELECT credential_id FROM ?name WHERE key_user = ?'));
 		Assert::count(2, $result);
 		Assert::same(PublicKeyCredentialDescriptor::CREDENTIAL_TYPE_PUBLIC_KEY, $result[0]->type);
 		Assert::same('cred-id-1', $result[0]->id);

--- a/app/tests/User/WebAuthn/PasskeysTest.phpt
+++ b/app/tests/User/WebAuthn/PasskeysTest.phpt
@@ -27,6 +27,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class PasskeysTest extends TestCase
 {
 
+	private const int USER_ID = 42;
 	private const string ID_1 = '019e08b4-8b1e-77b7-bb24-3c8e4aee3444';
 	private const string ID_2 = '019e08b4-8b1e-77b7-bb24-3c8e4aee3445';
 
@@ -45,7 +46,7 @@ final class PasskeysTest extends TestCase
 	#[Override]
 	protected function setUp(): void
 	{
-		$this->user->login(new SimpleIdentity(42));
+		$this->user->login(new SimpleIdentity(self::USER_ID));
 	}
 
 
@@ -62,6 +63,15 @@ final class PasskeysTest extends TestCase
 	public function testGetPasskeysEmpty(): void
 	{
 		Assert::same([], $this->passkeys->getPasskeys());
+	}
+
+
+	public function testGetPasskeysListsOnlyTheSignedInUsersOwn(): void
+	{
+		$this->passkeys->getPasskeys();
+
+		// The double hands back its rows whoever asks, so only the parameter says whose passkeys the page lists
+		Assert::same(['passkeys', self::USER_ID], $this->database->getParamsForQueryContaining('WHERE key_user = ?'));
 	}
 
 
@@ -162,6 +172,11 @@ final class PasskeysTest extends TestCase
 	{
 		$this->database->setFetchFieldDefaultResult('My Phone');
 		Assert::same('My Phone', $this->passkeys->getCredentialNameById(Uuid::fromRfc4122(self::ID_1)));
+		// Without the user in the WHERE this would name someone else's passkey to whoever guesses an id
+		Assert::same(
+			['passkeys', Uuid::fromRfc4122(self::ID_1)->toBinary(), self::USER_ID],
+			$this->database->getParamsForQuery('SELECT name FROM ?name WHERE id_passkey = ? AND key_user = ?'),
+		);
 	}
 
 
@@ -178,7 +193,7 @@ final class PasskeysTest extends TestCase
 		$this->database->setResultSet(new ResultSet(1));
 		$this->passkeys->renameCredential(Uuid::fromRfc4122(self::ID_1), 'New Name');
 		Assert::same(
-			['passkeys', 'New Name', Uuid::fromRfc4122(self::ID_1)->toBinary(), 42],
+			['passkeys', 'New Name', Uuid::fromRfc4122(self::ID_1)->toBinary(), self::USER_ID],
 			$this->database->getParamsForQuery('UPDATE ?name SET name = ? WHERE id_passkey = ? AND key_user = ?'),
 		);
 		Assert::same('passkey.renamed', $this->database->getParamsArrayForQuery('INSERT INTO security_events')[0]['action']);
@@ -193,6 +208,12 @@ final class PasskeysTest extends TestCase
 			$this->passkeys->renameCredential(Uuid::fromRfc4122(self::ID_1), 'Same Name');
 		});
 		Assert::same([], $this->database->getParamsArrayForQuery('INSERT INTO security_events')); // renaming to the same name changes no row, so nothing is recorded
+		// The zero-row update is ambiguous, and this is the query that decides between "not yours" and "same name",
+		// so it has to ask about this user's row and not just the id
+		Assert::same(
+			['passkeys', Uuid::fromRfc4122(self::ID_1)->toBinary(), self::USER_ID],
+			$this->database->getParamsForQuery('SELECT 1 FROM ?name WHERE id_passkey = ? AND key_user = ?'),
+		);
 	}
 
 
@@ -212,7 +233,7 @@ final class PasskeysTest extends TestCase
 		$this->database->addFetchFieldResult('uPhone');
 		$this->passkeys->deleteCredential(Uuid::fromRfc4122(self::ID_1));
 		Assert::same(
-			['passkeys', $idBinary, 42, null, null],
+			['passkeys', $idBinary, self::USER_ID, null, null],
 			$this->database->getParamsForQuery('DELETE FROM ?name WHERE id_passkey = ? AND key_user = ? AND (? IS NULL OR credential_id != ?)'),
 		);
 		$event = $this->database->getParamsArrayForQuery('INSERT INTO security_events');
@@ -249,6 +270,11 @@ final class PasskeysTest extends TestCase
 		Assert::exception(function (): void {
 			$this->passkeys->deleteCredential(Uuid::fromRfc4122(self::ID_1));
 		}, PasskeyCredentialSignedInWithException::class);
+		// Asking about somebody else's row here would call a concurrent delete a signed-in credential and the other way round
+		Assert::same(
+			['passkeys', Uuid::fromRfc4122(self::ID_1)->toBinary(), self::USER_ID],
+			$this->database->getParamsForQuery('SELECT 1 FROM ?name WHERE id_passkey = ? AND key_user = ?'),
+		);
 	}
 
 


### PR DESCRIPTION
Nine reads are authorized entirely by a WHERE parameter and nothing asserted it. Hardcoding a user id in `UserAccounts::getNotificationEmail()` used to pass all 327 tests and that's how ~~I met your mother~~ this was found.

- Security log, passkey list, passkey name by id, both existence checks, user handle, descriptors
- The two `access_token` reads, where the token is the whole authorization and no session sits behind it
- The double can now make a read fail, not just a write
- One stray tab-tab-space-tab, spotted on the way

Eleven mutations, one at a time: each wrong id, token or filename fails exactly the test that covers it.

Wrong id in the `WHERE`? The suite goes red instead of mailing someone else.