### PR TITLE
Keep emails out of the exception log

### DIFF
--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -15,6 +15,7 @@ tracy:
 		- keyMaterial # Halite's Key copies the encryption key out of its HiddenString into this
 		- ParagonIE\HiddenString\HiddenString::$internalStringValue # spaze/encryption wraps every value in one of these before handing it to Halite
 		- SensitiveParameterValue::$value # .md dump #[SensitiveParameter] handling, remove once https://github.com/nette/tracy/pull/618 is released
+		- email # Tracy BlueScreen dumps $_POST on its own, where #[SensitiveParameter] on the parameters can't reach it
 
 session:
 	name: __Host-yourluckynumbers

--- a/app/src/Test/Training/TrainingTestDataFactory.php
+++ b/app/src/Test/Training/TrainingTestDataFactory.php
@@ -12,6 +12,7 @@ use MichalSpacekCz\Training\Dates\TrainingDateStatus;
 use MichalSpacekCz\Training\Files\TrainingFiles;
 use MichalSpacekCz\Training\Mails\TrainingMailMessageFactory;
 use Nette\Utils\Html;
+use SensitiveParameter;
 
 final readonly class TrainingTestDataFactory
 {
@@ -27,7 +28,7 @@ final readonly class TrainingTestDataFactory
 	public function getTrainingApplication(
 		int $id,
 		?string $name = null,
-		?string $email = null,
+		#[SensitiveParameter] ?string $email = null,
 		bool $familiar = false,
 		TrainingApplicationStatus $status = TrainingApplicationStatus::Attended,
 		?int $dateId = null,

--- a/app/src/Training/Applications/TrainingApplication.php
+++ b/app/src/Training/Applications/TrainingApplication.php
@@ -11,6 +11,7 @@ use MichalSpacekCz\Training\Files\TrainingFilesCollection;
 use MichalSpacekCz\Training\Mails\MailMessageAdmin;
 use MichalSpacekCz\Training\Mails\TrainingMailMessageFactory;
 use Nette\Utils\Html;
+use SensitiveParameter;
 
 final class TrainingApplication
 {
@@ -29,7 +30,7 @@ final class TrainingApplication
 		private readonly TrainingFiles $trainingFiles,
 		private readonly int $id,
 		private readonly ?string $name,
-		private readonly ?string $email,
+		#[SensitiveParameter] private readonly ?string $email,
 		private readonly bool $familiar,
 		private readonly ?string $company,
 		private readonly ?string $street,

--- a/app/src/Training/Applications/TrainingApplicationStorage.php
+++ b/app/src/Training/Applications/TrainingApplicationStorage.php
@@ -18,6 +18,7 @@ use Nette\Utils\Random;
 use Override;
 use ParagonIE\Halite\Alerts\HaliteAlert;
 use RuntimeException;
+use SensitiveParameter;
 use SodiumException;
 use Spaze\Encryption\SymmetricKeyEncryption;
 use Tracy\Debugger;
@@ -48,7 +49,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	public function addInvitation(
 		TrainingDate $date,
 		string $name,
-		string $email,
+		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
 		string $city,
@@ -87,7 +88,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	public function addApplication(
 		TrainingDate $date,
 		string $name,
-		string $email,
+		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
 		string $city,
@@ -126,7 +127,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	 * @throws SodiumException
 	 * @throws HaliteAlert
 	 */
-	public function addPreliminaryInvitation(int $trainingId, string $name, string $email): int
+	public function addPreliminaryInvitation(int $trainingId, string $name, #[SensitiveParameter] string $email): int
 	{
 		return $this->insertApplication(
 			$trainingId,
@@ -158,7 +159,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 		int $trainingId,
 		?int $dateId,
 		string $name,
-		string $email,
+		#[SensitiveParameter] string $email,
 		?string $company,
 		?string $street,
 		?string $city,
@@ -240,7 +241,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 		TrainingDate $date,
 		int $applicationId,
 		string $name,
-		string $email,
+		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
 		string $city,
@@ -303,7 +304,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	public function updateApplicationData(
 		int $applicationId,
 		?string $name,
-		?string $email,
+		#[SensitiveParameter] ?string $email,
 		?string $company,
 		?string $street,
 		?string $city,

--- a/app/src/User/UserAccounts.php
+++ b/app/src/User/UserAccounts.php
@@ -9,6 +9,7 @@ use MichalSpacekCz\Encryption\EncryptedColumn;
 use MichalSpacekCz\Encryption\EncryptedStorage;
 use Nette\Database\Explorer;
 use Override;
+use SensitiveParameter;
 use Spaze\Encryption\SymmetricKeyEncryption;
 
 /**
@@ -43,7 +44,7 @@ final readonly class UserAccounts implements EncryptedStorage
 	}
 
 
-	public function setNotificationEmail(int $userId, string $email): void
+	public function setNotificationEmail(int $userId, #[SensitiveParameter] string $email): void
 	{
 		$this->database->query(
 			'UPDATE ?name SET ? WHERE ?name = ?',

--- a/app/tests/Application/ExceptionLogSecretsTest.phpt
+++ b/app/tests/Application/ExceptionLogSecretsTest.phpt
@@ -4,7 +4,10 @@ declare(strict_types = 1);
 
 namespace MichalSpacekCz\Application;
 
+use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\User\UserAccounts;
+use Nette\Database\DriverException;
 use Override;
 use ParagonIE\Halite\Symmetric\Crypto;
 use ParagonIE\Halite\Symmetric\EncryptionKey;
@@ -40,6 +43,8 @@ final class ExceptionLogSecretsTest extends TestCase
 	 */
 	public function __construct(
 		private readonly BlueScreen $blueScreen,
+		private readonly Database $database,
+		private readonly UserAccounts $userAccounts,
 	) {
 		FileMock::register(); // can't use FileMock::create(), it creates the file and Tracy's fopen(..., 'x') would fail
 	}
@@ -49,6 +54,7 @@ final class ExceptionLogSecretsTest extends TestCase
 	protected function tearDown(): void
 	{
 		FileMock::$files = [];
+		$this->database->reset();
 	}
 
 
@@ -110,6 +116,46 @@ final class ExceptionLogSecretsTest extends TestCase
 		foreach ($this->logAndReadBack($thrown, 'A key with the wrong prefix should have been rejected') as $extension => $contents) {
 			Assert::notContains($goodKey, $contents, "a valid key leaked into the {$extension} log because another one was malformed");
 		}
+	}
+
+
+	/**
+	 * Unlike the key and the HiddenString above, an email arrives as a plain string parameter, which `keysToHide`
+	 * can't help with: the name is `$email` and the value is just a string. `#[SensitiveParameter]` is what hides it.
+	 */
+	public function testEmailIsNotLoggedWhenTheWriteFails(): void
+	{
+		$email = bin2hex(random_bytes(8)) . '@example.com';
+		// Built when thrown, not here: an exception created up front captures its trace here, without the frame being tested
+		$this->database->willThrow(fn(): DriverException => new DriverException('The database fell over'));
+
+		$thrown = null;
+		try {
+			$this->userAccounts->setNotificationEmail(42, $email);
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+
+		foreach ($this->logAndReadBack($thrown, 'Writing the notification email should have failed') as $extension => $contents) {
+			Assert::notContains($email, $contents, "the email leaked into the {$extension} log");
+		}
+	}
+
+
+	/**
+	 * The attribute only covers the value while it is a stack frame's argument. The blue screen also dumps `$_POST`
+	 * on its own, so a form submission that errors would log what was typed into it regardless, which the `email`
+	 * entry in `keysToHide` is what stops. That section renders only on the web (`section-http.phtml` returns early
+	 * under CLI), so what is checked here is the dumper it hands each key and value to.
+	 */
+	public function testEmailIsHiddenWhereverItIsDumpedByName(): void
+	{
+		$email = bin2hex(random_bytes(8)) . '@example.com';
+
+		$dumper = $this->blueScreen->getAgentDumper(); // the section dumps each entry as $dump($value, $key)
+
+		Assert::notContains($email, $dumper($email, 'email'), 'an email dumped under an `email` key leaked');
+		Assert::contains($email, $dumper($email, 'note'), 'the same value under another key vanished too, so this passes whatever the config says');
 	}
 
 

--- a/app/tests/Application/SensitiveParametersTest.phpt
+++ b/app/tests/Application/SensitiveParametersTest.phpt
@@ -1,0 +1,89 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use MichalSpacekCz\Test\TestCaseRunner;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionNamedType;
+use RuntimeException;
+use SensitiveParameter;
+use SplFileInfo;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../bootstrap.php';
+
+/*
+ * Tracy writes every stack frame's arguments into the exception log, so a value passed as a plain string ends up
+ * there whenever something deeper throws. ExceptionLogSecretsTest proves `#[SensitiveParameter]` hides it; this one
+ * makes sure the attribute is on every parameter that carries one, including ones added later.
+ *
+ * The list is deliberately short. A name has to mean personal data wherever it appears, or the failures become
+ * noise and get waved through: `$name` alone is 98 parameters in src/, nearly all of them header names, session
+ * keys and talk titles. Widen it when a name earns its place, and add an allow-list here if one ever needs an
+ * exception, with the reason written down.
+ *
+ * Strings only. An object holding the same data leaks it too, `TrainingControlsAttendee` takes the form's
+ * `TextInput $email` and Tracy would dump its value, but `#[SensitiveParameter]` is meant for scalars and objects
+ * need `keysToHide` or `__debugInfo()` instead. Different fix, so not this test's business.
+ */
+
+/** @testCase */
+final class SensitiveParametersTest extends TestCase
+{
+
+	private const array PERSONAL_DATA_PARAMETERS = [
+		'email',
+	];
+
+
+	public function testPersonalDataParametersAreMarkedSensitive(): void
+	{
+		$srcDir = realpath(__DIR__ . '/../../src');
+		if ($srcDir === false) {
+			throw new RuntimeException('Could not resolve app/src/ directory');
+		}
+
+		$unmarked = [];
+		$found = 0;
+		foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($srcDir)) as $file) {
+			if (!$file instanceof SplFileInfo || !$file->isFile() || $file->getExtension() !== 'php') {
+				continue;
+			}
+			$class = 'MichalSpacekCz\\' . str_replace(['/', '.php'], ['\\', ''], substr($file->getPathname(), strlen($srcDir) + 1));
+			if (!class_exists($class) && !interface_exists($class) && !trait_exists($class) && !enum_exists($class)) {
+				continue;
+			}
+			$reflection = new ReflectionClass($class);
+			foreach ($reflection->getMethods() as $method) {
+				if ($method->getDeclaringClass()->getName() !== $class) { // inherited ones belong to whoever declares them
+					continue;
+				}
+				foreach ($method->getParameters() as $parameter) {
+					$type = $parameter->getType();
+					if (
+						!in_array($parameter->getName(), self::PERSONAL_DATA_PARAMETERS, true)
+						|| !$type instanceof ReflectionNamedType
+						|| $type->getName() !== 'string'
+					) {
+						continue;
+					}
+					$found++;
+					if ($parameter->getAttributes(SensitiveParameter::class) === []) {
+						$unmarked[] = sprintf('%s::%s($%s)', $class, $method->getName(), $parameter->getName());
+					}
+				}
+			}
+		}
+
+		sort($unmarked);
+		Assert::same([], $unmarked, 'Add #[SensitiveParameter] to these, or they end up in the exception log in full');
+		Assert::true($found > 0, 'Found no parameters to check at all, so this test is passing without checking anything');
+	}
+
+}
+
+TestCaseRunner::run(SensitiveParametersTest::class);


### PR DESCRIPTION
Tracy writes every stack frame's arguments into the log, so an email passed as a plain string is in there in full whenever something deeper throws: a database error while writing the notification email puts the address next to the stack trace. `keysToHide` can't reach that one, the parameter is named `email` and the value is an ordinary string, which is what `#[SensitiveParameter]` exists for.

The attribute alone isn't enough, though, and that is the more interesting half. The blue screen dumps `$_POST` in its own section, straight from the superglobal, so a form submission that errors logs whatever was typed into it no matter what the parameters are marked as. `email` in `keysToHide` is what covers that, and between them the two close both paths.

Emails first because they are the clear case: we already encrypt them at rest, so writing them to a log in plaintext undoes that for anything with access to `app/log`. The rest of the personal data on the training application, name and address and company, leaks the same way and is not covered here.

The test is the point of the change rather than the nine attributes, which would otherwise be a thing to remember. It reflects over `src/`, and a `string $email` parameter without the attribute fails the suite, whether it was added today or in two years.

The list of names it checks has one entry on purpose. It has to mean personal data everywhere it appears, and most candidates don't: `$name` is 98 parameters in `src/`, nearly all header names, session keys and talk titles, so including it would produce ninety-odd allow-list entries that nobody reads and one real finding lost among them. `$street`, `$zip` and `$city` are a line each when the training application data gets the same treatment.

Objects are out of scope, though they leak too: `TrainingControlsAttendee` takes the form's `TextInput $email` and Tracy dumps its value. Hiding that means `Nette\Forms\Controls\BaseControl::$value`, which blanks every form field everywhere, so it is a decision about whether submitted data belongs in the log at all rather than a fix for this one field.

The `$_POST` section renders only on the web, `section-http.phtml` returns early under CLI, so the test can't go through it and checks the dumper the section hands each key and value to instead.