### PR TITLE
Say whose name it is

### DIFF
--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -15,6 +15,7 @@ tracy:
 		- keyMaterial # Halite's Key copies the encryption key out of its HiddenString into this
 		- ParagonIE\HiddenString\HiddenString::$internalStringValue # spaze/encryption wraps every value in one of these before handing it to Halite
 		- SensitiveParameterValue::$value # .md dump #[SensitiveParameter] handling, remove once https://github.com/nette/tracy/pull/618 is released
+		- attendeeName # submitted under this name too, see below
 		- email # Tracy BlueScreen dumps $_POST on its own, where #[SensitiveParameter] on the parameters can't reach it
 
 session:

--- a/app/src/Form/Controls/TrainingControlsAttendee.php
+++ b/app/src/Form/Controls/TrainingControlsAttendee.php
@@ -9,15 +9,15 @@ final readonly class TrainingControlsAttendee
 {
 
 	public function __construct(
-		private TextInput $name,
+		private TextInput $attendeeName,
 		private TextInput $email,
 	) {
 	}
 
 
-	public function getName(): TextInput
+	public function getAttendeeName(): TextInput
 	{
-		return $this->name;
+		return $this->attendeeName;
 	}
 
 

--- a/app/src/Form/Controls/TrainingControlsFactory.php
+++ b/app/src/Form/Controls/TrainingControlsFactory.php
@@ -24,7 +24,7 @@ final readonly class TrainingControlsFactory
 
 	public function addAttendee(Container $container): TrainingControlsAttendee
 	{
-		$nameInput = $container->addText('name', 'Jméno a příjmení:')
+		$nameInput = $container->addText('attendeeName', 'Jméno a příjmení:')
 			->setRequired('Zadejte prosím jméno a příjmení')
 			->addRule(Form::MinLength, 'Minimální délka jména a příjmení je %d znaky', 3)
 			->addRule(Form::MaxLength, 'Maximální délka jména a příjmení je %d znaků', 200)

--- a/app/src/Form/Training/TrainingReviewFormFactory.php
+++ b/app/src/Form/Training/TrainingReviewFormFactory.php
@@ -140,12 +140,12 @@ final readonly class TrainingReviewFormFactory
 		foreach ($this->trainingApplications->getByDate($dateId) as $application) {
 			if (!$application->isDiscarded()) {
 				$option = Html::el('option');
-				if (in_array($application->getName(), $reviewApplicationNames, true)) {
+				if (in_array($application->getAttendeeName(), $reviewApplicationNames, true)) {
 					$option->disabled = true;
 				}
-				$option->setText(($application->getName() ?? 'smazáno') . ($application->getCompany() !== null ? ", {$application->getCompany()}" : ''));
+				$option->setText(($application->getAttendeeName() ?? 'smazáno') . ($application->getCompany() !== null ? ", {$application->getCompany()}" : ''));
 				$option->addAttributes([
-					'data-name' => $application->getName() ?? '',
+					'data-name' => $application->getAttendeeName() ?? '',
 					'data-company' => $application->getCompany() ?? '',
 				]);
 				$applications[$application->getId()] = $option;

--- a/app/src/Form/TrainingApplication/TrainingApplicationAdminFormFactory.php
+++ b/app/src/Form/TrainingApplication/TrainingApplicationAdminFormFactory.php
@@ -68,7 +68,7 @@ final readonly class TrainingApplicationAdminFormFactory
 			->setRequired($required)
 			->setDisabled(!$required);
 
-		$this->addDeletableFieldCheckbox($attendeeInputs->getName(), $form->addCheckbox('nameSet'), $application->getName());
+		$this->addDeletableFieldCheckbox($attendeeInputs->getName(), $form->addCheckbox('nameSet'), $application->getAttendeeName());
 		$this->addDeletableFieldCheckbox($attendeeInputs->getEmail(), $form->addCheckbox('emailSet'), $application->getEmail());
 		$this->addDeletableFieldCheckbox($companyInputs->getCompany(), $form->addCheckbox('companySet'), $application->getCompany());
 		$this->addDeletableFieldCheckbox($companyInputs->getStreet(), $form->addCheckbox('streetSet'), $application->getStreet());
@@ -176,7 +176,7 @@ final readonly class TrainingApplicationAdminFormFactory
 	{
 		$vatRate = $application->getVatRate();
 		$values = [
-			'name' => $application->getName(),
+			'name' => $application->getAttendeeName(),
 			'email' => $application->getEmail(),
 			'familiar' => $application->isFamiliar(),
 			'source' => $application->getSourceAlias(),

--- a/app/src/Form/TrainingApplication/TrainingApplicationAdminFormFactory.php
+++ b/app/src/Form/TrainingApplication/TrainingApplicationAdminFormFactory.php
@@ -68,7 +68,7 @@ final readonly class TrainingApplicationAdminFormFactory
 			->setRequired($required)
 			->setDisabled(!$required);
 
-		$this->addDeletableFieldCheckbox($attendeeInputs->getName(), $form->addCheckbox('nameSet'), $application->getAttendeeName());
+		$this->addDeletableFieldCheckbox($attendeeInputs->getAttendeeName(), $form->addCheckbox('nameSet'), $application->getAttendeeName());
 		$this->addDeletableFieldCheckbox($attendeeInputs->getEmail(), $form->addCheckbox('emailSet'), $application->getEmail());
 		$this->addDeletableFieldCheckbox($companyInputs->getCompany(), $form->addCheckbox('companySet'), $application->getCompany());
 		$this->addDeletableFieldCheckbox($companyInputs->getStreet(), $form->addCheckbox('streetSet'), $application->getStreet());
@@ -93,7 +93,7 @@ final readonly class TrainingApplicationAdminFormFactory
 		$form->onSuccess[] = function (Form $form) use ($application, $onSuccess): void {
 			$values = $form->getValues();
 			assert(is_bool($values->nameSet));
-			assert(is_string($values->name));
+			assert(is_string($values->attendeeName));
 			assert(is_bool($values->emailSet));
 			assert(is_string($values->email));
 			assert(is_bool($values->companySet));
@@ -123,7 +123,7 @@ final readonly class TrainingApplicationAdminFormFactory
 			assert(is_int($values->date) || $values->date === null);
 			$this->trainingApplicationStorage->updateApplicationData(
 				$application->getId(),
-				$values->nameSet ? $values->name : null,
+				$values->nameSet ? $values->attendeeName : null,
 				$values->emailSet ? $values->email : null,
 				$values->companySet ? $values->company : null,
 				$values->streetSet ? $values->street : null,
@@ -176,7 +176,7 @@ final readonly class TrainingApplicationAdminFormFactory
 	{
 		$vatRate = $application->getVatRate();
 		$values = [
-			'name' => $application->getAttendeeName(),
+			'attendeeName' => $application->getAttendeeName(),
 			'email' => $application->getEmail(),
 			'familiar' => $application->isFamiliar(),
 			'source' => $application->getSourceAlias(),

--- a/app/src/Form/TrainingApplication/TrainingMultipleApplicationsFormFactory.php
+++ b/app/src/Form/TrainingApplication/TrainingMultipleApplicationsFormFactory.php
@@ -66,7 +66,7 @@ final readonly class TrainingMultipleApplicationsFormFactory
 			assert(is_string($values->date));
 			foreach ($values->applications as $application) {
 				assert($application instanceof ArrayHash);
-				assert(is_string($application->name));
+				assert(is_string($application->attendeeName));
 				assert(is_string($application->email));
 				assert(is_string($application->company));
 				assert(is_string($application->street));
@@ -78,7 +78,7 @@ final readonly class TrainingMultipleApplicationsFormFactory
 				$this->trainingApplicationStorage->insertApplication(
 					$trainingDate->getTrainingId(),
 					$trainingDate->getId(),
-					$application->name,
+					$application->attendeeName,
 					$application->email,
 					$application->company,
 					$application->street,

--- a/app/src/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactory.php
+++ b/app/src/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactory.php
@@ -29,11 +29,11 @@ final readonly class TrainingPreliminaryApplicationFormFactory
 		$form->addSubmit('signUp', 'Odeslat');
 		$form->onSuccess[] = function (Form $form) use ($onSuccess, $onError, $trainingId, $action): void {
 			$values = $form->getValues();
-			assert(is_string($values->name));
+			assert(is_string($values->attendeeName));
 			assert(is_string($values->email));
 			try {
-				$this->formSpam->check($values->name);
-				$this->trainingApplicationStorage->addPreliminaryInvitation($trainingId, $values->name, $values->email);
+				$this->formSpam->check($values->attendeeName);
+				$this->trainingApplicationStorage->addPreliminaryInvitation($trainingId, $values->attendeeName, $values->email);
 				$onSuccess($action);
 			} catch (SpammyApplicationException) {
 				$onError('messages.trainings.spammyapplication');

--- a/app/src/Presentation/Admin/Emails/default.latte
+++ b/app/src/Presentation/Admin/Emails/default.latte
@@ -31,7 +31,7 @@
 		<tr>
 			<td class="positionCell"><small>{$iterator->getCounter()}.</small></td>
 			<td>{input send}</td>
-			<td><small n:tag-if="$application->getName() === null"><a n:href="Trainings:application $application->getId()" n:attr="title => $application->getCompany()">{$application->getName() ?? smazáno}</a></small></td>
+			<td><small n:tag-if="$application->getAttendeeName() === null"><a n:href="Trainings:application $application->getId()" n:attr="title => $application->getCompany()">{$application->getAttendeeName() ?? smazáno}</a></small></td>
 			<td class="button"><small>{$application->getEmail() ?? smazáno}</small></td>
 			<td>
 				{$application->getTrainingName()}

--- a/app/src/Presentation/Admin/Trainings/TrainingsPresenter.php
+++ b/app/src/Presentation/Admin/Trainings/TrainingsPresenter.php
@@ -145,7 +145,7 @@ final class TrainingsPresenter extends BasePresenter
 		$this->template->trainingEnd = $this->training->getEnd();
 		$this->template->trainingName = $this->training->getName();
 		$this->template->trainingCity = $this->training->getVenueCity();
-		$this->template->name = $application->getName();
+		$this->template->name = $application->getAttendeeName();
 		$this->template->dateId = $dateId;
 	}
 
@@ -187,7 +187,7 @@ final class TrainingsPresenter extends BasePresenter
 			$name = $this->trainings->getIncludingCustom($this->application->getTrainingAction())->getName();
 		}
 
-		$this->template->pageTitle = $this->application->getName() ?? 'smazáno';
+		$this->template->pageTitle = $this->application->getAttendeeName() ?? 'smazáno';
 		$this->template->applicationId = $param;
 		$this->template->applicationDateId = $applicationDateId;
 		$this->template->status = $this->application->getStatus();

--- a/app/src/Presentation/Admin/Trainings/application.latte
+++ b/app/src/Presentation/Admin/Trainings/application.latte
@@ -31,7 +31,7 @@
 		</td>
 	</tr>
 	<tr>
-		<th>{label name /}</th><td>{input nameSet:} {input name} <small n:if="$toBeInvited"><a n:href=":Www:Redirect:application#prihlaska $accessToken">předvyplněná přihláška</a></small></td>
+		<th>{label attendeeName /}</th><td>{input nameSet:} {input attendeeName} <small n:if="$toBeInvited"><a n:href=":Www:Redirect:application#prihlaska $accessToken">předvyplněná přihláška</a></small></td>
 	</tr>
 	<tr>
 		<th>{label email /}</th><td>{input emailSet:} {input email}</td>

--- a/app/src/Presentation/Admin/Trainings/date.latte
+++ b/app/src/Presentation/Admin/Trainings/date.latte
@@ -32,7 +32,7 @@
 	<tbody n:inner-foreach="$applications as $application">
 		<tr n:class="$application->isDiscarded() ? discarded">
 			<td><small>{$iterator->getCounter()}.</small></td>
-			<td><small n:tag-if="$application->getName() === null"><a n:href="Trainings:application $application->getId()">{$application->getName() ?? smazáno}</a></small></td>
+			<td><small n:tag-if="$application->getAttendeeName() === null"><a n:href="Trainings:application $application->getId()">{$application->getAttendeeName() ?? smazáno}</a></small></td>
 			<td><small>{$application->getEmail() ?? smazáno}</small></td>
 			<td><span n:tag-if="$application->getCompany() && ($application->getCompany()|length) > 40" title="{$application->getCompany()}">{$application->getCompany()|truncate:40}</span></td>
 			<td><small n:attr="title: $application->getNote() && ($application->getNote()|length) > 20 ? $application->getNote()">{$application->getNote()|truncate:20}</small></td>

--- a/app/src/Presentation/Admin/Trainings/date.latte
+++ b/app/src/Presentation/Admin/Trainings/date.latte
@@ -76,7 +76,7 @@
 			{formContainer applications-0}
 			<thead>
 				<tr>
-					<th>{label name /}</th>
+					<th>{label attendeeName /}</th>
 					<th>{label email /}</th>
 					<th>{label companyId /}</th>
 					<th>{label companyTaxId /}</th>
@@ -91,7 +91,7 @@
 			</thead>
 			<tbody>
 				<tr>
-					<td>{input name}</td>
+					<td>{input attendeeName}</td>
 					<td>{input email}</td>
 					<td>{input companyId}</td>
 					<td>{input companyTaxId}</td>

--- a/app/src/Presentation/Admin/Trainings/preliminary.latte
+++ b/app/src/Presentation/Admin/Trainings/preliminary.latte
@@ -39,7 +39,7 @@
 		<tr n:foreach="$training->getApplications() as $application">
 			<td>{input (string)$application->getId():}</td>
 			<td><label n:name="(string)$application->getId()"><small>{$iterator->getCounter()}.</small></label></td>
-			<td><small n:tag-if="$application->getName() === null"><a n:href="Trainings:application $application->getId()">{$application->getName() ?? smazáno}</a></small></td>
+			<td><small n:tag-if="$application->getAttendeeName() === null"><a n:href="Trainings:application $application->getId()">{$application->getAttendeeName() ?? smazáno}</a></small></td>
 			<td><small>{$application->getEmail() ?? smazáno}</small></td>
 			<td><small><code title="{$application->getStatusTime()|localeDay} {$application->getStatusTime()|date:'H:i:s'}">{$application->getStatus()->value}</code></small></td>
 		</tr>

--- a/app/src/Presentation/Www/Trainings/success.latte
+++ b/app/src/Presentation/Www/Trainings/success.latte
@@ -21,7 +21,7 @@
 	<legend>{_messages.label.participant}</legend>
 	<table>
 		<tr>
-			<th scope="row" id="th-name">{$form[name]->caption}</th><td headers="th-name">{$form[name]->value}</td>
+			<th scope="row" id="th-name">{$form[attendeeName]->caption}</th><td headers="th-name">{$form[attendeeName]->value}</td>
 			<th scope="row" id="th-email">{$form[email]->caption}</th><td headers="th-email">{$form[email]->value}</td>
 		</tr>
 	</table>

--- a/app/src/Presentation/Www/Trainings/training.latte
+++ b/app/src/Presentation/Www/Trainings/training.latte
@@ -25,7 +25,7 @@
 	<legend>{_messages.label.participant}</legend>
 	<table>
 		<tr>
-			<th scope="row" id="th-name">{label name /}</th><td headers="th-name">{input name}</td>
+			<th scope="row" id="th-name">{label attendeeName /}</th><td headers="th-name">{input attendeeName}</td>
 			<th scope="row" id="th-email">{label email /}</th><td headers="th-email">{input email}</td>
 		</tr>
 	</table>
@@ -80,7 +80,7 @@
 	<legend>{_messages.label.participant}</legend>
 	<table>
 		<tr>
-			<th scope="row" id="th-name">{label name /}</th><td headers="th-name">{input name}</td>
+			<th scope="row" id="th-name">{label attendeeName /}</th><td headers="th-name">{input attendeeName}</td>
 			<th scope="row" id="th-email">{label email /}</th><td headers="th-email">{input email}</td>
 		</tr>
 	</table>

--- a/app/src/Test/Training/TrainingTestDataFactory.php
+++ b/app/src/Test/Training/TrainingTestDataFactory.php
@@ -27,7 +27,7 @@ final readonly class TrainingTestDataFactory
 
 	public function getTrainingApplication(
 		int $id,
-		?string $name = null,
+		#[SensitiveParameter] ?string $attendeeName = null,
 		#[SensitiveParameter] ?string $email = null,
 		bool $familiar = false,
 		TrainingApplicationStatus $status = TrainingApplicationStatus::Attended,
@@ -46,7 +46,7 @@ final readonly class TrainingTestDataFactory
 			$this->trainingMailMessageFactory,
 			$this->trainingFiles,
 			$id,
-			$name,
+			$attendeeName,
 			$email,
 			$familiar,
 			null,

--- a/app/src/Training/ApplicationForm/TrainingApplicationFormSuccess.php
+++ b/app/src/Training/ApplicationForm/TrainingApplicationFormSuccess.php
@@ -54,7 +54,7 @@ final readonly class TrainingApplicationFormSuccess
 		TrainingApplicationSessionSection $sessionSection,
 	): void {
 		$values = $form->getValues();
-		assert(is_string($values->name));
+		assert(is_string($values->attendeeName));
 		assert(is_string($values->email));
 		assert(is_string($values->company));
 		assert(is_string($values->street));
@@ -65,7 +65,7 @@ final readonly class TrainingApplicationFormSuccess
 		assert(is_string($values->companyTaxId));
 		assert(is_string($values->note));
 		try {
-			$this->formSpam->check($values->name, $values->company, $values->companyId, $values->companyTaxId, $values->note);
+			$this->formSpam->check($values->attendeeName, $values->company, $values->companyId, $values->companyTaxId, $values->note);
 			if ($multipleDates) {
 				assert(is_int($values->trainingId));
 				$this->checkTrainingDate((array)$values, $action, $values->trainingId, $dates, $sessionSection);
@@ -80,7 +80,7 @@ final readonly class TrainingApplicationFormSuccess
 			if ($date->isTentative()) {
 				$this->trainingApplicationStorage->addInvitation(
 					$date,
-					$values->name,
+					$values->attendeeName,
 					$values->email,
 					$values->company,
 					$values->street,
@@ -97,7 +97,7 @@ final readonly class TrainingApplicationFormSuccess
 					$this->trainingApplicationStorage->updateApplication(
 						$date,
 						$applicationId,
-						$values->name,
+						$values->attendeeName,
 						$values->email,
 						$values->company,
 						$values->street,
@@ -112,7 +112,7 @@ final readonly class TrainingApplicationFormSuccess
 				} else {
 					$applicationId = $this->trainingApplicationStorage->addApplication(
 						$date,
-						$values->name,
+						$values->attendeeName,
 						$values->email,
 						$values->company,
 						$values->street,
@@ -132,7 +132,7 @@ final readonly class TrainingApplicationFormSuccess
 					$applicationId,
 					$this->templateFactory->createTemplate($presenter),
 					$values->email,
-					$values->name,
+					$values->attendeeName,
 					$date->getStart(),
 					$date->getEnd(),
 					$action,

--- a/app/src/Training/Applications/TrainingApplication.php
+++ b/app/src/Training/Applications/TrainingApplication.php
@@ -29,7 +29,7 @@ final class TrainingApplication
 		private readonly TrainingMailMessageFactory $trainingMailMessageFactory,
 		private readonly TrainingFiles $trainingFiles,
 		private readonly int $id,
-		private readonly ?string $name,
+		#[SensitiveParameter] private readonly ?string $attendeeName,
 		#[SensitiveParameter] private readonly ?string $email,
 		private readonly bool $familiar,
 		private readonly ?string $company,
@@ -84,9 +84,9 @@ final class TrainingApplication
 	}
 
 
-	public function getName(): ?string
+	public function getAttendeeName(): ?string
 	{
-		return $this->name;
+		return $this->attendeeName;
 	}
 
 

--- a/app/src/Training/Applications/TrainingApplicationSessionSection.php
+++ b/app/src/Training/Applications/TrainingApplicationSessionSection.php
@@ -20,7 +20,7 @@ final class TrainingApplicationSessionSection extends SessionSection
 		$data = (array)parent::get('application');
 		$data[$trainingAction] = ['id' => $application->getId(), 'dateId' => $application->getDateId()];
 		parent::set('application', $data);
-		parent::set('name', $application->getName());
+		parent::set('name', $application->getAttendeeName());
 		parent::set('email', $application->getEmail());
 		parent::set('company', $application->getCompany());
 		parent::set('street', $application->getStreet());

--- a/app/src/Training/Applications/TrainingApplicationSessionSection.php
+++ b/app/src/Training/Applications/TrainingApplicationSessionSection.php
@@ -20,7 +20,7 @@ final class TrainingApplicationSessionSection extends SessionSection
 		$data = (array)parent::get('application');
 		$data[$trainingAction] = ['id' => $application->getId(), 'dateId' => $application->getDateId()];
 		parent::set('application', $data);
-		parent::set('name', $application->getAttendeeName());
+		parent::set('attendeeName', $application->getAttendeeName());
 		parent::set('email', $application->getEmail());
 		parent::set('company', $application->getCompany());
 		parent::set('street', $application->getStreet());
@@ -74,7 +74,7 @@ final class TrainingApplicationSessionSection extends SessionSection
 	public function setOnSuccess(TrainingDate $date, stdClass $values): void
 	{
 		parent::set('trainingId', $date->getId());
-		parent::set('name', $values->name);
+		parent::set('attendeeName', $values->attendeeName);
 		parent::set('email', $values->email);
 		parent::set('company', $values->company);
 		parent::set('street', $values->street);
@@ -104,7 +104,7 @@ final class TrainingApplicationSessionSection extends SessionSection
 	public function getApplicationValues(): array
 	{
 		return [
-			'name' => parent::get('name'),
+			'attendeeName' => parent::get('attendeeName'),
 			'email' => parent::get('email'),
 			'company' => parent::get('company'),
 			'street' => parent::get('street'),
@@ -122,7 +122,7 @@ final class TrainingApplicationSessionSection extends SessionSection
 	{
 		parent::remove([
 			'application',
-			'name',
+			'attendeeName',
 			'email',
 			'company',
 			'street',

--- a/app/src/Training/Applications/TrainingApplicationStorage.php
+++ b/app/src/Training/Applications/TrainingApplicationStorage.php
@@ -48,7 +48,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	 */
 	public function addInvitation(
 		TrainingDate $date,
-		string $name,
+		#[SensitiveParameter] string $attendeeName,
 		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
@@ -62,7 +62,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 		return $this->insertApplication(
 			$date->getTrainingId(),
 			$date->getId(),
-			$name,
+			$attendeeName,
 			$email,
 			$company,
 			$street,
@@ -87,7 +87,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	 */
 	public function addApplication(
 		TrainingDate $date,
-		string $name,
+		#[SensitiveParameter] string $attendeeName,
 		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
@@ -101,7 +101,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 		return $this->insertApplication(
 			$date->getTrainingId(),
 			$date->getId(),
-			$name,
+			$attendeeName,
 			$email,
 			$company,
 			$street,
@@ -127,12 +127,12 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	 * @throws SodiumException
 	 * @throws HaliteAlert
 	 */
-	public function addPreliminaryInvitation(int $trainingId, string $name, #[SensitiveParameter] string $email): int
+	public function addPreliminaryInvitation(int $trainingId, #[SensitiveParameter] string $attendeeName, #[SensitiveParameter] string $email): int
 	{
 		return $this->insertApplication(
 			$trainingId,
 			null,
-			$name,
+			$attendeeName,
 			$email,
 			null,
 			null,
@@ -158,7 +158,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	public function insertApplication(
 		int $trainingId,
 		?int $dateId,
-		string $name,
+		#[SensitiveParameter] string $attendeeName,
 		#[SensitiveParameter] string $email,
 		?string $company,
 		?string $street,
@@ -186,7 +186,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 		$timeZone = $datetime->getTimezone()->getName();
 		$data = [
 			'key_date' => $dateId,
-			'name' => $name,
+			'name' => $attendeeName,
 			self::EMAIL_COLUMN => $this->emailEncryption->encrypt($email),
 			'company' => $company !== '' ? $company : null,
 			'street' => $street !== '' ? $street : null,
@@ -240,7 +240,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	public function updateApplication(
 		TrainingDate $date,
 		int $applicationId,
-		string $name,
+		#[SensitiveParameter] string $attendeeName,
 		#[SensitiveParameter] string $email,
 		string $company,
 		string $street,
@@ -258,7 +258,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 			function () use (
 				$date,
 				$applicationId,
-				$name,
+				$attendeeName,
 				$email,
 				$company,
 				$street,
@@ -274,7 +274,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 					'UPDATE ?name SET ? WHERE ?name = ?',
 					self::TABLE,
 					[
-						'name' => $name,
+						'name' => $attendeeName,
 						self::EMAIL_COLUMN => $this->emailEncryption->encrypt($email),
 						'company' => $company,
 						'street' => $street,
@@ -303,7 +303,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 	 */
 	public function updateApplicationData(
 		int $applicationId,
-		?string $name,
+		#[SensitiveParameter] ?string $attendeeName,
 		#[SensitiveParameter] ?string $email,
 		?string $company,
 		?string $street,
@@ -329,7 +329,7 @@ final readonly class TrainingApplicationStorage implements EncryptedStorage
 			$discount = null;
 		}
 		$data = [
-			'name' => $name,
+			'name' => $attendeeName,
 			self::EMAIL_COLUMN => $email !== null ? $this->emailEncryption->encrypt($email) : null,
 			'company' => $company,
 			'familiar' => $familiar,

--- a/app/src/Training/DateList/trainingApplicationsList.latte
+++ b/app/src/Training/DateList/trainingApplicationsList.latte
@@ -5,7 +5,7 @@
 {define #listItems, MichalSpacekCz\Training\Applications\TrainingApplication[] $applications}
 	<tr class="summary" n:foreach="$applications as $application">
 		<td><small>{$iterator->getCounter()}.</small></td>
-		<td><small n:tag-if="$application->getName() === null"><a href="{plink Trainings:application $application->getId()}">{$application->getName() ?? smazáno}</a></small></td>
+		<td><small n:tag-if="$application->getAttendeeName() === null"><a href="{plink Trainings:application $application->getId()}">{$application->getAttendeeName() ?? smazáno}</a></small></td>
 		<td><small>{$application->getEmail() ?? smazáno}</small></td>
 		<td><span n:tag-if="$application->getCompany() && ($application->getCompany()|length) > 40" title="{$application->getCompany()}">{$application->getCompany()|truncate:40}</span></td>
 		<td><small n:attr="title: $application->getNote() && ($application->getNote()|length) > 20 ? $application->getNote()">{$application->getNote()|truncate:20}</small></td>

--- a/app/src/Training/Mails/TrainingMails.php
+++ b/app/src/Training/Mails/TrainingMails.php
@@ -161,7 +161,7 @@ final readonly class TrainingMails
 		$template->setFile($message->getFilename());
 		$template->application = $application;
 		$template->additional = $additional;
-		$this->sendMail($application->getEmail(), $application->getName(), $message->getSubject(), $template);
+		$this->sendMail($application->getEmail(), $application->getAttendeeName(), $message->getSubject(), $template);
 	}
 
 
@@ -173,7 +173,7 @@ final readonly class TrainingMails
 		$template->application = $application;
 		$template->feedbackRequest = $feedbackRequest;
 		$template->additional = $additional;
-		$this->sendMail($application->getEmail(), $application->getName(), $message->getSubject(), $template);
+		$this->sendMail($application->getEmail(), $application->getAttendeeName(), $message->getSubject(), $template);
 	}
 
 
@@ -184,7 +184,7 @@ final readonly class TrainingMails
 		$template->setFile($message->getFilename());
 		$template->application = $application;
 		$template->additional = $additional;
-		$this->sendMail($application->getEmail(), $application->getName(), $message->getSubject(), $template, [$invoice->getUntrustedName() => $invoice->getTemporaryFile()], $cc);
+		$this->sendMail($application->getEmail(), $application->getAttendeeName(), $message->getSubject(), $template, [$invoice->getUntrustedName() => $invoice->getTemporaryFile()], $cc);
 	}
 
 
@@ -203,7 +203,7 @@ final readonly class TrainingMails
 		$template->application = $application;
 		$template->phoneNumber = $this->phoneNumber;
 		$template->additional = $additional;
-		$this->sendMail($application->getEmail(), $application->getName(), $message->getSubject(), $template);
+		$this->sendMail($application->getEmail(), $application->getAttendeeName(), $message->getSubject(), $template);
 	}
 
 

--- a/app/tests/Application/ExceptionLogSecretsTest.phpt
+++ b/app/tests/Application/ExceptionLogSecretsTest.phpt
@@ -171,18 +171,20 @@ final class ExceptionLogSecretsTest extends TestCase
 
 	/**
 	 * The attribute only covers the value while it is a stack frame's argument. The blue screen also dumps `$_POST`
-	 * on its own, so a form submission that errors would log what was typed into it regardless, which the `email`
-	 * entry in `keysToHide` is what stops. That section renders only on the web (`section-http.phtml` returns early
+	 * on its own, so a form submission that errors would log what was typed into it regardless, which the entries
+	 * in `keysToHide` are what stop. That section renders only on the web (`section-http.phtml` returns early
 	 * under CLI), so what is checked here is the dumper it hands each key and value to.
 	 */
-	public function testEmailIsHiddenWhereverItIsDumpedByName(): void
+	public function testPersonalDataIsHiddenWhereverItIsDumpedByName(): void
 	{
-		$email = bin2hex(random_bytes(8)) . '@example.com';
+		$value = 'probe-' . bin2hex(random_bytes(8));
 
 		$dumper = $this->blueScreen->getAgentDumper(); // the section dumps each entry as $dump($value, $key)
 
-		Assert::notContains($email, $dumper($email, 'email'), 'an email dumped under an `email` key leaked');
-		Assert::contains($email, $dumper($email, 'note'), 'the same value under another key vanished too, so this passes whatever the config says');
+		foreach (['email', 'attendeeName'] as $key) {
+			Assert::notContains($value, $dumper($value, $key), "a value dumped under a `{$key}` key leaked");
+		}
+		Assert::contains($value, $dumper($value, 'note'), 'the same value under another key vanished too, so this passes whatever the config says');
 	}
 
 

--- a/app/tests/Application/ExceptionLogSecretsTest.phpt
+++ b/app/tests/Application/ExceptionLogSecretsTest.phpt
@@ -6,6 +6,7 @@ namespace MichalSpacekCz\Application;
 
 use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\Training\Applications\TrainingApplicationStorage;
 use MichalSpacekCz\User\UserAccounts;
 use Nette\Database\DriverException;
 use Override;
@@ -45,6 +46,7 @@ final class ExceptionLogSecretsTest extends TestCase
 		private readonly BlueScreen $blueScreen,
 		private readonly Database $database,
 		private readonly UserAccounts $userAccounts,
+		private readonly TrainingApplicationStorage $trainingApplicationStorage,
 	) {
 		FileMock::register(); // can't use FileMock::create(), it creates the file and Tracy's fopen(..., 'x') would fail
 	}
@@ -115,6 +117,31 @@ final class ExceptionLogSecretsTest extends TestCase
 
 		foreach ($this->logAndReadBack($thrown, 'A key with the wrong prefix should have been rejected') as $extension => $contents) {
 			Assert::notContains($goodKey, $contents, "a valid key leaked into the {$extension} log because another one was malformed");
+		}
+	}
+
+
+	/**
+	 * The applicant's name travels beside the email through the same writes, and identifies them more directly
+	 * than the address does, so it is marked and checked the same way.
+	 */
+	public function testAttendeeNameIsNotLoggedWhenTheWriteFails(): void
+	{
+		$attendeeName = 'Probe ' . bin2hex(random_bytes(6));
+		$email = bin2hex(random_bytes(8)) . '@example.com';
+		// The status id is read before anything is written, so failing the read puts both parameters on the stack
+		$this->database->willThrowOnRead(fn(): DriverException => new DriverException('The database fell over'));
+
+		$thrown = null;
+		try {
+			$this->trainingApplicationStorage->addPreliminaryInvitation(1, $attendeeName, $email);
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+
+		foreach ($this->logAndReadBack($thrown, 'Adding a preliminary invitation should have failed') as $extension => $contents) {
+			Assert::notContains($attendeeName, $contents, "the attendee name leaked into the {$extension} log");
+			Assert::notContains($email, $contents, "the email leaked into the {$extension} log");
 		}
 	}
 

--- a/app/tests/Application/SensitiveParametersTest.phpt
+++ b/app/tests/Application/SensitiveParametersTest.phpt
@@ -36,6 +36,7 @@ final class SensitiveParametersTest extends TestCase
 {
 
 	private const array PERSONAL_DATA_PARAMETERS = [
+		'attendeeName',
 		'email',
 	];
 

--- a/app/tests/Form/Controls/TrainingControlsFactoryTest.phpt
+++ b/app/tests/Form/Controls/TrainingControlsFactoryTest.phpt
@@ -1,0 +1,43 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Form\Controls;
+
+use MichalSpacekCz\Form\UnprotectedFormFactory;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/*
+ * The control's name is the key the value is submitted under, so it is also the key `keysToHide` matches on to
+ * keep the applicant out of the exception log. Nothing else ties the two together: rename a control and the
+ * config in common.neon quietly stops covering it, with every other test still green.
+ */
+
+/** @testCase */
+final class TrainingControlsFactoryTest extends TestCase
+{
+
+	public function __construct(
+		private readonly TrainingControlsFactory $trainingControlsFactory,
+		private readonly UnprotectedFormFactory $formFactory,
+	) {
+	}
+
+
+	public function testAttendeeControlsAreNamedAsTheConfigExpects(): void
+	{
+		$form = $this->formFactory->create();
+
+		$attendee = $this->trainingControlsFactory->addAttendee($form);
+
+		Assert::same('attendeeName', $attendee->getAttendeeName()->getName());
+		Assert::same('email', $attendee->getEmail()->getName());
+	}
+
+}
+
+TestCaseRunner::run(TrainingControlsFactoryTest::class);

--- a/app/tests/Form/Training/TrainingMailsOutboxFormFactoryTest.phpt
+++ b/app/tests/Form/Training/TrainingMailsOutboxFormFactoryTest.phpt
@@ -59,7 +59,7 @@ final class TrainingMailsOutboxFormFactoryTest extends TestCase
 		PrivateProperty::setValue($this->application, 'presenter', $presenter);
 		$application = $this->dataFactory->getTrainingApplication(
 			3212,
-			name: 'John Doe',
+			attendeeName: 'John Doe',
 			email: 'email@example.com',
 			trainingStart: $this->trainingStart,
 			trainingEnd: new DateTime('2024-04-05 06:07:08'),

--- a/app/tests/Form/TrainingApplication/TrainingApplicationAdminFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingApplicationAdminFormFactoryTest.phpt
@@ -10,6 +10,8 @@ use MichalSpacekCz\Test\Database\Database;
 use MichalSpacekCz\Test\TestCaseRunner;
 use MichalSpacekCz\Test\Training\TrainingTestDataFactory;
 use MichalSpacekCz\Training\Dates\TrainingDateStatus;
+use Nette\Forms\Controls\BaseControl;
+use Nette\Forms\Form;
 use Nette\Utils\Arrays;
 use Tester\Assert;
 use Tester\TestCase;
@@ -20,6 +22,7 @@ require __DIR__ . '/../../bootstrap.php';
 final class TrainingApplicationAdminFormFactoryTest extends TestCase
 {
 
+	private const string ATTENDEE_NAME = 'Name';
 	private const int TRAINING_DATE_ID = 14;
 	private const string TRAINING_ACTION = 'action-1';
 
@@ -84,9 +87,12 @@ final class TrainingApplicationAdminFormFactoryTest extends TestCase
 			},
 			function (): void {
 			},
-			$this->dataFactory->getTrainingApplication(12, dateId: null, trainingAction: self::TRAINING_ACTION, sourceAlias: 'foo-bar'),
+			$this->dataFactory->getTrainingApplication(12, attendeeName: self::ATTENDEE_NAME, dateId: null, trainingAction: self::TRAINING_ACTION, sourceAlias: 'foo-bar'),
 		);
 		$this->applicationPresenter->anchorForm($form);
+		// Before the test's own defaults overwrite them: what setApplication() prefilled from the application,
+		// which is where the admin form and the control's name have to agree
+		Assert::same(self::ATTENDEE_NAME, $this->valueOf($form, 'attendeeName'));
 		$form->setDefaults([
 			'date' => self::TRAINING_DATE_ID,
 			'familiar' => true,
@@ -99,6 +105,14 @@ final class TrainingApplicationAdminFormFactoryTest extends TestCase
 		$params = $this->database->getParamsArrayForQuery('UPDATE ?name SET ? WHERE ?name = ?');
 		Assert::true($params[0]['familiar']);
 		Assert::same(self::TRAINING_DATE_ID, $params[0]['key_date']);
+	}
+
+
+	private function valueOf(Form $form, string $name): mixed
+	{
+		$control = $form->getComponent($name);
+		assert($control instanceof BaseControl);
+		return $control->getValue();
 	}
 
 }

--- a/app/tests/Form/TrainingApplication/TrainingApplicationFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingApplicationFormFactoryTest.phpt
@@ -1,0 +1,121 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Form\TrainingApplication;
+
+use MichalSpacekCz\Test\Application\ApplicationPresenter;
+use MichalSpacekCz\Test\TestCaseRunner;
+use MichalSpacekCz\Test\Training\TrainingTestDataFactory;
+use MichalSpacekCz\Training\Applications\TrainingApplicationSessionSection;
+use Nette\Forms\Controls\BaseControl;
+use Nette\Forms\Form;
+use Nette\Http\Session;
+use Nette\Utils\Html;
+use Override;
+use stdClass;
+use Tester\Assert;
+use Tester\TestCase;
+
+require __DIR__ . '/../../bootstrap.php';
+
+/*
+ * What half-filled applications are restored from, so the keys the session stores under and the names of the
+ * controls have to agree. They are set in two different classes and nothing else checks that they match: rename
+ * a control and the form silently stops being prefilled, which nobody notices until an applicant retypes their
+ * address.
+ */
+
+/** @testCase */
+final class TrainingApplicationFormFactoryTest extends TestCase
+{
+
+	private const string ATTENDEE_NAME = 'Patrick Star';
+	private const string EMAIL = 'patrick@example.com';
+
+
+	private readonly TrainingApplicationSessionSection $sessionSection;
+	private ?string $action = null;
+	private ?string $message = null;
+
+
+	public function __construct(
+		private readonly TrainingApplicationFormFactory $formFactory,
+		private readonly TrainingTestDataFactory $dataFactory,
+		private readonly ApplicationPresenter $applicationPresenter,
+		Session $sessionHandler,
+	) {
+		$this->sessionSection = $sessionHandler->getSection('training', TrainingApplicationSessionSection::class);
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		$this->sessionSection->removeApplicationValues();
+	}
+
+
+	public function testFormIsPrefilledFromTheSession(): void
+	{
+		$values = new stdClass();
+		$values->attendeeName = self::ATTENDEE_NAME;
+		$values->email = self::EMAIL;
+		$values->company = 'Krusty Krab';
+		$values->street = 'Conch Street 1';
+		$values->city = 'Bikini Bottom';
+		$values->zip = '12345';
+		$values->country = 'cz';
+		$values->companyId = '123';
+		$values->companyTaxId = 'CZ123';
+		$values->note = 'no pickles';
+		$this->sessionSection->setOnSuccess($this->dataFactory->getTrainingDate(remote: true), $values);
+
+		$form = $this->createForm();
+
+		Assert::same(self::ATTENDEE_NAME, $this->valueOf($form, 'attendeeName'));
+		Assert::same(self::EMAIL, $this->valueOf($form, 'email'));
+		Assert::same('Bikini Bottom', $this->valueOf($form, 'city'));
+	}
+
+
+	public function testFormIsEmptyWithoutASession(): void
+	{
+		$form = $this->createForm();
+
+		Assert::same('', $this->valueOf($form, 'attendeeName'));
+		Assert::same('', $this->valueOf($form, 'email'));
+		Assert::null($this->action); // building the form doesn't run the handlers
+		Assert::null($this->message);
+	}
+
+
+	private function createForm(): Form
+	{
+		$form = $this->formFactory->create(
+			function (string $action): void {
+				$this->action = $action;
+			},
+			function (string $message): void {
+				$this->message = $message;
+			},
+			'action',
+			Html::el()->setText('Training'),
+			[$this->dataFactory->getTrainingDate(remote: true)],
+			$this->sessionSection,
+		);
+		$this->applicationPresenter->anchorForm($form);
+		return $form;
+	}
+
+
+	private function valueOf(Form $form, string $name): mixed
+	{
+		$control = $form->getComponent($name);
+		assert($control instanceof BaseControl);
+		return $control->getValue();
+	}
+
+}
+
+TestCaseRunner::run(TrainingApplicationFormFactoryTest::class);

--- a/app/tests/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactoryTest.phpt
+++ b/app/tests/Form/TrainingApplication/TrainingPreliminaryApplicationFormFactoryTest.phpt
@@ -83,7 +83,7 @@ final class TrainingPreliminaryApplicationFormFactoryTest extends TestCase
 	public function testCreateOnSuccessSpam(): void
 	{
 		$this->form->setDefaults([
-			'name' => 'lowercase',
+			'attendeeName' => 'lowercase',
 		]);
 		Arrays::invoke($this->form->onSuccess, $this->form);
 		Assert::null($this->action);

--- a/app/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
+++ b/app/tests/Training/ApplicationForm/TrainingApplicationFormSuccessTest.phpt
@@ -76,7 +76,7 @@ final class TrainingApplicationFormSuccessTest extends TestCase
 		$trainingControlsFactory->addNote($this->form);
 		$trainingControlsFactory->addCountry($this->form);
 		$this->form->setDefaults([
-			'name' => self::NAME,
+			'attendeeName' => self::NAME,
 			'email' => self::EMAIL,
 			'company' => self::COMPANY,
 			'companyId' => self::COMPANY_ID,
@@ -252,7 +252,7 @@ final class TrainingApplicationFormSuccessTest extends TestCase
 	private function assertSessionSection(): void
 	{
 		Assert::same(self::DATE_ID, $this->sessionSectionGet('trainingId'));
-		Assert::same(self::NAME, $this->sessionSectionGet('name'));
+		Assert::same(self::NAME, $this->sessionSectionGet('attendeeName'));
 		Assert::same(self::EMAIL, $this->sessionSectionGet('email'));
 		Assert::same(self::COMPANY, $this->sessionSectionGet('company'));
 		Assert::same(self::STREET, $this->sessionSectionGet('street'));

--- a/app/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationFactoryTest.phpt
@@ -81,7 +81,7 @@ final class TrainingApplicationFactoryTest extends TestCase
 		$application = $this->trainingApplicationFactory->createFromDatabaseRow($row);
 
 		Assert::same(1, $application->getId());
-		Assert::null($application->getName());
+		Assert::null($application->getAttendeeName());
 		Assert::null($application->getEmail());
 		Assert::false($application->isFamiliar());
 		Assert::null($application->getCompany());

--- a/app/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
@@ -52,7 +52,7 @@ final class TrainingApplicationSessionSectionTest extends TestCase
 		$this->sessionSection->set('application', ['foo' => 'bar']);
 		$this->trainingApplicationSessionSection->setApplicationForTraining('training-action', $application);
 		Assert::same(['foo' => 'bar', 'training-action' => ['id' => $application->getId(), 'dateId' => $application->getDateId()]], $this->sessionSection->get('application'));
-		Assert::same($this->sessionSection->get('name'), $application->getAttendeeName());
+		Assert::same($this->sessionSection->get('attendeeName'), $application->getAttendeeName());
 		Assert::same($this->sessionSection->get('email'), $application->getEmail());
 		Assert::same($this->sessionSection->get('company'), $application->getCompany());
 		Assert::same($this->sessionSection->get('street'), $application->getStreet());
@@ -129,7 +129,7 @@ final class TrainingApplicationSessionSectionTest extends TestCase
 		$trainingDate = $this->buildTrainingDate();
 		$this->trainingApplicationSessionSection->setOnSuccess($trainingDate, $this->buildValues());
 		Assert::same(self::DATE_ID, $this->sessionSection->get('trainingId'));
-		Assert::same('Name', $this->sessionSection->get('name'));
+		Assert::same('Name', $this->sessionSection->get('attendeeName'));
 		Assert::same('Email', $this->sessionSection->get('email'));
 		Assert::same('Company', $this->sessionSection->get('company'));
 		Assert::same('Street', $this->sessionSection->get('street'));
@@ -221,7 +221,7 @@ final class TrainingApplicationSessionSectionTest extends TestCase
 	private function buildValues(): stdClass
 	{
 		$values = new stdClass();
-		$values->name = 'Name';
+		$values->attendeeName = 'Name';
 		$values->email = 'Email';
 		$values->company = 'Company';
 		$values->street = 'Street';

--- a/app/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
+++ b/app/tests/Training/Applications/TrainingApplicationSessionSectionTest.phpt
@@ -52,7 +52,7 @@ final class TrainingApplicationSessionSectionTest extends TestCase
 		$this->sessionSection->set('application', ['foo' => 'bar']);
 		$this->trainingApplicationSessionSection->setApplicationForTraining('training-action', $application);
 		Assert::same(['foo' => 'bar', 'training-action' => ['id' => $application->getId(), 'dateId' => $application->getDateId()]], $this->sessionSection->get('application'));
-		Assert::same($this->sessionSection->get('name'), $application->getName());
+		Assert::same($this->sessionSection->get('name'), $application->getAttendeeName());
 		Assert::same($this->sessionSection->get('email'), $application->getEmail());
 		Assert::same($this->sessionSection->get('company'), $application->getCompany());
 		Assert::same($this->sessionSection->get('street'), $application->getStreet());

--- a/app/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
+++ b/app/tests/Training/Preliminary/PreliminaryTrainingsTest.phpt
@@ -44,8 +44,8 @@ final class PreliminaryTrainingsTest extends TestCase
 		Assert::same('Training 2', $preliminaryTrainings[1]->getName());
 		$training2Applications = $preliminaryTrainings[1]->getApplications();
 		Assert::count(1, $training2Applications);
-		Assert::same('Name One', $training1Applications[0]->getName());
-		Assert::same('Name Two', $training2Applications[0]->getName());
+		Assert::same('Name One', $training1Applications[0]->getAttendeeName());
+		Assert::same('Name Two', $training2Applications[0]->getAttendeeName());
 	}
 
 
@@ -59,7 +59,7 @@ final class PreliminaryTrainingsTest extends TestCase
 		$this->setDatabaseResultsForGetPreliminary();
 		$trainingApplications = $this->preliminaryTrainings->getPreliminaryWithDateSet();
 		Assert::count(1, $trainingApplications);
-		Assert::same('Name One', $trainingApplications[0]->getName());
+		Assert::same('Name One', $trainingApplications[0]->getAttendeeName());
 	}
 
 


### PR DESCRIPTION
Follows #860, which marked emails `#[SensitiveParameter]` and added `email` to `keysToHide`. The applicant's name leaks the same way and identifies them more directly than their address does.

It couldn't just be added to the list guarding that: the check is by parameter name, and `$name` is 98 parameters in `src/` — header names, session keys, talk titles. So the parameter says what it is instead, and the flat rule works.

- `$name` → `$attendeeName`, `getName()` → `getAttendeeName()`, and the form control with it
- the control rename is the part that matters for logs: the blue screen dumps `$_POST` separately, so the attribute alone never covered the submitted value
- the name now has to agree in four places that don't know about each other — control, session keys, two templates, `common.neon`
- `TrainingControlsFactory` and `TrainingApplicationFormFactory` had no tests at all; they have one each now, pinning exactly that agreement

Form values arrive as `ArrayHash`, so a missing property reads as null instead of failing — renaming the control silently emptied the prefill and dropped the spam check's input, and only the tests noticed. Hence the two new ones.