### PR TITLE
Stop compiling secrets into the container

### DIFF
--- a/app/config/.gitignore
+++ b/app/config/.gitignore
@@ -1,2 +1,3 @@
 local.neon
+secrets.neon
 remote*.neon

--- a/app/config/common.neon
+++ b/app/config/common.neon
@@ -38,22 +38,22 @@ latte:
 database:
 	default:
 		dsn: 'mysql:host=localhost;dbname=michalspacek_cz'
-		user: ...
-		password: ...
+		user: ... # set in local.neon
+		password: %secrets.database.default.password%
 		options:
 			lazy: true
 			PDO::ATTR_EMULATE_PREPARES: false
 	upcKeys:
 		dsn: 'mysql:host=localhost;dbname=michalspacek_cz_upckeys'
-		user: ...
-		password: ...
+		user: ... # set in local.neon
+		password: %secrets.database.upcKeys.password%
 		options:
 			lazy: true
 			PDO::ATTR_EMULATE_PREPARES: false
 	pulse:
 		dsn: 'mysql:host=localhost;dbname=michalspacek_cz_pulse'
-		user: ...
-		password: ...
+		user: ... # set in local.neon
+		password: %secrets.database.pulse.password%
 		options:
 			lazy: true
 			PDO::ATTR_EMULATE_PREPARES: false

--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -40,6 +40,14 @@ contentSecurityPolicy: # list values here are added to the existing list values,
 			script-src:
 				-"'self'"
 
+database:
+	default:
+		user: dev_user # the password is in secrets.neon, see secrets.template.neon
+	upcKeys:
+		user: dev_user
+	pulse:
+		user: dev_user
+
 parameters:
 	locales:
 		supported:
@@ -56,14 +64,8 @@ parameters:
 		securityNotificationsFrom: "Fred <fred@waldo.example>"
 		trainingFrom: "Barney <barney@plugh.example>"
 
+	# The keys themselves live in secrets.neon, see secrets.template.neon
 	encryption:
-		keys:
-			email:
-				dev1: "msee_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafebabe" # [0-9a-fA-F]{64}
-			session:
-				dev1: "msse_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafed00d" # [0-9a-fA-F]{64}
-			securityEvent:
-				dev1: "msle_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe1337" # [0-9a-fA-F]{64}
 		activeKeyIds:
 			email: dev1
 			session: dev1
@@ -76,13 +78,6 @@ parameters:
 	awsLambda:
 		upcKeys:
 			url: "https://example.amazonaws.com/stage/upc_keys/%s/%s"
-			apiKey: "britishteaatfiveoclockisnotacoffee"
-
-	certificatesApi:
-		users:
-			web: sha512bin2hexrandom_bytes64
-			demo:
-			githubactions:
 
 services:
 	sleep: MichalSpacekCz\Test\Utils\Insomnia

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -60,7 +60,6 @@ parameters:
 			reauthTtl: 5 minutes
 	certificatesApi:
 		hideExpiredAfter: 10
-		users:  # Added in local.neon
 	blog:
 		updatedInfoThreshold: 30
 		allowedTags:
@@ -75,11 +74,24 @@ parameters:
 	mail:
 		securityNotificationsFrom: "Foo <foo@bar.example>"
 		trainingFrom: "Bar <bar@qux.example>"
-	encryption:
-		keys:
+	# Declares the shape only, keep every value here empty and put the real ones in config/secrets.neon:
+	# a value filled in here gets compiled into the container in temp/
+	secrets:
+		encryptionKeys:
 			email: []
 			session: []
 			securityEvent: []
+		awsLambdaApiKeys:
+			upcKeys:
+		certificatesApiUsers: []
+		database:
+			default:
+				password:
+			upcKeys:
+				password:
+			pulse:
+				password:
+	encryption:
 		activeKeyIds:
 			email: ""
 			session: ""
@@ -91,4 +103,3 @@ parameters:
 	awsLambda:
 		upcKeys:
 			url:
-			apiKey:

--- a/app/config/secrets.template.neon
+++ b/app/config/secrets.template.neon
@@ -1,0 +1,30 @@
+# Copy to secrets.neon, which is gitignored, and fill in. Bootstrap passes this to Configurator::addDynamicParameters(),
+# so the values are handed to the container at runtime and are not compiled into it in temp/.
+#
+# Everything here is reachable in config as %secrets.…%, e.g. %secrets.encryptionKeys.email%. Keep the values
+# only in this file, never in the files the Configurator loads: a dynamic parameter falls back to whatever
+# config declares, so a value there gets compiled into the container in temp/.
+#
+# The file replaces the whole %secrets% tree, there is no per-key fallback: when a new secret is added to the
+# template and to parameters.neon, it has to be added here too, or the container fails on the missing key.
+
+encryptionKeys:
+	email:
+		dev1: 'msee_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafebabe' # [0-9a-fA-F]{64}
+	session:
+		dev1: 'msse_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafed00d' # [0-9a-fA-F]{64}
+	securityEvent:
+		dev1: 'msle_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe1337' # [0-9a-fA-F]{64}
+awsLambdaApiKeys:
+	upcKeys: 'britishteaatfiveoclockisnotacoffee'
+certificatesApiUsers:
+	web: 'sha512bin2hexrandom_bytes64'
+	demo: ''
+	githubactions: ''
+database:
+	default:
+		password: ''
+	upcKeys:
+		password: ''
+	pulse:
+		password: ''

--- a/app/config/services.neon
+++ b/app/config/services.neon
@@ -160,7 +160,7 @@ services:
 	- MichalSpacekCz\Tls\CertificateFactory
 	- MichalSpacekCz\Tls\CertificateGatherer
 	- MichalSpacekCz\Tls\CertificateMonitor
-	- MichalSpacekCz\Tls\Certificates(users: %certificatesApi.users%, hideExpiredAfter: %certificatesApi.hideExpiredAfter%)
+	- MichalSpacekCz\Tls\Certificates(users: %secrets.certificatesApiUsers%, hideExpiredAfter: %certificatesApi.hideExpiredAfter%)
 	- MichalSpacekCz\Tls\CertificatesApiClient
 	- MichalSpacekCz\Tls\CertificatesList\TlsCertificatesListFactory
 	- MichalSpacekCz\Training\ApplicationForm\TrainingApplicationFormDataLogger
@@ -199,7 +199,7 @@ services:
 	- MichalSpacekCz\Training\Trainings\Trainings
 	- MichalSpacekCz\Training\Venues\TrainingVenues
 	- MichalSpacekCz\Twitter\TwitterCards
-	- MichalSpacekCz\UpcKeys\Technicolor(@database.upcKeys.explorer, apiUrl: %awsLambda.upcKeys.url%, apiKey: %awsLambda.upcKeys.apiKey%)
+	- MichalSpacekCz\UpcKeys\Technicolor(@database.upcKeys.explorer, apiUrl: %awsLambda.upcKeys.url%, apiKey: %secrets.awsLambdaApiKeys.upcKeys%)
 	- MichalSpacekCz\UpcKeys\Ubee(@database.upcKeys.explorer)
 	- MichalSpacekCz\UpcKeys\UpcKeys(routers: [@MichalSpacekCz\UpcKeys\Technicolor, @MichalSpacekCz\UpcKeys\Ubee])
 	- MichalSpacekCz\UpcKeys\UpcKeysStorageConversions
@@ -234,9 +234,9 @@ services:
 	- Nette\Schema\Processor
 	security.passwords: Nette\Security\Passwords(::PASSWORD_ARGON2ID, [memory_cost: 65536, time_cost: 16, threads: 16])
 	- PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor
-	emailEncryption: Spaze\Encryption\SymmetricKeyEncryption(%encryption.keys.email%, %encryption.activeKeyIds.email%, %encryption.keyPrefixes.email%)
-	sessionEncryption: Spaze\Encryption\SymmetricKeyEncryption(%encryption.keys.session%, %encryption.activeKeyIds.session%, %encryption.keyPrefixes.session%)
-	securityEventEncryption: Spaze\Encryption\SymmetricKeyEncryption(%encryption.keys.securityEvent%, %encryption.activeKeyIds.securityEvent%, %encryption.keyPrefixes.securityEvent%)
+	emailEncryption: Spaze\Encryption\SymmetricKeyEncryption(%secrets.encryptionKeys.email%, %encryption.activeKeyIds.email%, %encryption.keyPrefixes.email%)
+	sessionEncryption: Spaze\Encryption\SymmetricKeyEncryption(%secrets.encryptionKeys.session%, %encryption.activeKeyIds.session%, %encryption.keyPrefixes.session%)
+	securityEventEncryption: Spaze\Encryption\SymmetricKeyEncryption(%secrets.encryptionKeys.securityEvent%, %encryption.activeKeyIds.securityEvent%, %encryption.keyPrefixes.securityEvent%)
 	- Spaze\PhpInfo\PhpInfo
 	texyFormatterPhpFilesAdapter: Symfony\Component\Cache\Adapter\PhpFilesAdapter(namespace: 'TexyFormatter', directory: '%tempDir%/cache', appendOnly: true)
 	- Webauthn\AttestationStatement\AttestationStatementSupportManager

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -7,14 +7,26 @@ parameters:
 		rootDomainMapping:
 			cz: rizek.test
 			com: burger.test
-	encryption:
-		keys:
-			email!:
+	secrets!: # replaced whole, and bootTest() never loads secrets.neon, so tests run against these on any machine
+		encryptionKeys:
+			email:
 				test: "mseetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafeb053"
-			session!:
+			session:
 				test: "mssetest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe5a08"
-			securityEvent!:
+			securityEvent:
 				test: "msletest_cafecafecafecafecafecafecafecafecafecafecafecafecafecafecafe7100"
+		awsLambdaApiKeys:
+			upcKeys: "thisismychurchthisiswhereihealmyhurts"
+		certificatesApiUsers:
+			foo: f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7 # foo
+		database:
+			default:
+				password: ""
+			upcKeys:
+				password: ""
+			pulse:
+				password: ""
+	encryption:
 		activeKeyIds:
 			email: test
 			session: test
@@ -29,11 +41,8 @@ parameters:
 	awsLambda:
 		upcKeys:
 			url: "https://was.example/%s/%s"
-			apiKey: "thisismychurchthisiswhereihealmyhurts"
 	certificatesApi:
 		hideExpiredAfter: 7
-		users:
-			foo: f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7 # foo
 
 services:
 	garbageCollectorRunner: MichalSpacekCz\GarbageCollector\GarbageCollectorRunner(lockFilePath: %tempDir%/tests/garbageCollectorRunner.lock)

--- a/app/psalm.xml
+++ b/app/psalm.xml
@@ -86,6 +86,11 @@
 				<file name="src/Training/Dates/TrainingDates.php" /> <!-- Keep add() similar to other methods and return even if not used -->
 			</errorLevel>
 		</PossiblyUnusedReturnValue>
+		<PropertyNotSetInConstructor>
+			<errorLevel type="suppress">
+				<file name="src/Application/ContainerSecretsChecker.php"/> <!-- $compiler, $name and $initialization are declared by Nette\DI\CompilerExtension and set by Compiler::addExtension() right after construction -->
+			</errorLevel>
+		</PropertyNotSetInConstructor>
 		<ReservedWord>
 			<errorLevel type="suppress">
 				<directory name="src/Test" /> <!-- The void keyword is reported in @throws void -->

--- a/app/src/Application/Bootstrap.php
+++ b/app/src/Application/Bootstrap.php
@@ -8,8 +8,14 @@ use MichalSpacekCz\Application\Cli\CliArgs;
 use MichalSpacekCz\Application\Cli\CliArgsProvider;
 use Nette\Bootstrap\Configurator;
 use Nette\CommandLine\Parser;
+use Nette\DI\Compiler;
 use Nette\DI\Container;
+use Nette\Neon\Neon;
 use PHP_Parallel_Lint\PhpConsoleColor\ConsoleColor;
+use RuntimeException;
+use SensitiveParameter;
+use Throwable;
+use Tracy\Debugger;
 
 final class Bootstrap
 {
@@ -22,10 +28,32 @@ final class Bootstrap
 
 	public static function boot(): Container
 	{
-		return self::createConfigurator(
+		return self::bootWebApp(null, null);
+	}
+
+
+	/**
+	 * The web boot with its file dependencies as parameters, for BootstrapTest, which boots the real config
+	 * chain: it passes the committed template on machines that have no secrets, and its own temp directory,
+	 * because the container cache key includes dynamic parameter names, never values, so a container compiled
+	 * into the shared temp/ and checked only against the template's placeholders could be reused by a real
+	 * boot with the same key.
+	 */
+	public static function bootContainerTest(string $secretsFile, string $tempDir): Container
+	{
+		return self::bootWebApp($secretsFile, $tempDir);
+	}
+
+
+	private static function bootWebApp(?string $secretsFile, ?string $tempDir): Container
+	{
+		$configurator = self::createConfigurator(
 			ServerEnv::tryGetString('ENVIRONMENT') === self::MODE_DEVELOPMENT,
 			self::SITE_DIR . '/config/extra-' . ServerEnv::getString('SERVER_NAME') . '.neon',
-		)->createContainer();
+			tempDir: $tempDir,
+		);
+		$secrets = self::addSecrets($configurator, true, $secretsFile);
+		return self::createContainer($configurator, $secrets);
 	}
 
 
@@ -37,10 +65,12 @@ final class Bootstrap
 		ServerEnv::setString('HTTPS', 'on');
 		$cliArgs = self::getCliArgs($argsProvider);
 		$debugMode = ServerEnv::tryGetString('PHP_CLI_ENVIRONMENT') === self::MODE_DEVELOPMENT || $cliArgs->getFlag(self::DEBUG);
-		$container = self::createConfigurator(
+		$configurator = self::createConfigurator(
 			$debugMode,
 			self::SITE_DIR . '/config/' . ($debugMode ? 'extra-cli-debug.neon' : 'extra-cli.neon'),
-		)->createContainer();
+		);
+		$secrets = self::addSecrets($configurator, false);
+		$container = self::createContainer($configurator, $secrets);
 		if ($cliArgs->getFlag(self::COLORS)) {
 			$container->getByType(ConsoleColor::class)->setForceStyle(true);
 		}
@@ -51,6 +81,8 @@ final class Bootstrap
 
 	public static function bootTest(): Container
 	{
+		// No addSecrets() here, deliberately: the fakes in tests.neon are static parameters, and a dynamic
+		// parameter would override them, running the whole suite against the real keys on any machine that has them
 		$configurator = self::createConfigurator(true, finalConfig: self::SITE_DIR . '/config/tests.neon');
 		$configurator->addStaticParameters([
 			'wwwDir' => self::SITE_DIR . '/tests',
@@ -79,7 +111,7 @@ final class Bootstrap
 	}
 
 
-	private static function createConfigurator(bool $debugMode, ?string $extraConfig = null, ?string $finalConfig = null): Configurator
+	private static function createConfigurator(bool $debugMode, ?string $extraConfig = null, ?string $finalConfig = null, ?string $tempDir = null): Configurator
 	{
 		$configurator = new Configurator();
 		$configurator->addStaticParameters(['siteDir' => self::SITE_DIR]);
@@ -87,7 +119,7 @@ final class Bootstrap
 		$configurator->setDebugMode($debugMode);
 		$configurator->enableTracy(self::SITE_DIR . '/log');
 		$configurator->setTimeZone('Europe/Prague');
-		$configurator->setTempDirectory(self::SITE_DIR . '/temp');
+		$configurator->setTempDirectory($tempDir ?? self::SITE_DIR . '/temp');
 
 		$existingFiles = array_filter(self::getConfigurationFiles($extraConfig, $finalConfig), function (?string $path) {
 			return $path !== null && is_file($path);
@@ -97,6 +129,84 @@ final class Bootstrap
 		}
 
 		return $configurator;
+	}
+
+
+	/**
+	 * Passes the secrets to the container as dynamic parameters, so the values are handed over at runtime and not
+	 * compiled into the container in temp/. Call after createConfigurator(): Tracy is set up there, so a mistake
+	 * in the hand-edited secrets file ends up in the exception log.
+	 *
+	 * @return array<array-key, mixed>|null What was loaded, so createContainer() can check none of it got compiled in
+	 */
+	private static function addSecrets(Configurator $configurator, bool $required, ?string $secretsFile = null): ?array
+	{
+		$secrets = self::loadSecrets($required, $secretsFile);
+		// Installed even when there's no file, a CLI boot without one say: hiding anything keyed `secrets`
+		// doesn't depend on the values, and the compile check can still refuse a stale value it would
+		// otherwise dump from the config arrays in the trace
+		ContainerSecretsChecker::hideSecrets(Debugger::getBlueScreen(), $secrets ?? []);
+		if ($secrets !== null) {
+			ContainerSecretsChecker::checkValues($secrets);
+			$configurator->addDynamicParameters(['secrets' => $secrets]);
+		}
+		return $secrets;
+	}
+
+
+	/**
+	 * The web app can't do anything useful without the secrets, so a missing file stops it right away with a message
+	 * that says what to do (if `$required` is `true`). CLI scripts tolerate a missing file because CI runs some of them
+	 * with no secrets.neon anywhere.
+	 *
+	 * @return array<array-key, mixed>|null
+	 */
+	private static function loadSecrets(bool $required, ?string $secretsFile = null): ?array
+	{
+		$secretsFile ??= self::SITE_DIR . '/config/secrets.neon';
+		if (!is_file($secretsFile)) {
+			if ($required) {
+				throw new RuntimeException("Missing {$secretsFile}, copy config/secrets.template.neon there and fill in the real values");
+			}
+			return null;
+		}
+		try {
+			$secrets = Neon::decodeFile($secretsFile);
+		} catch (Throwable $e) {
+			// Deliberately not chained, and without the original message: the message quotes the file's tokens,
+			// and the original's trace holds the whole file as the decoder's argument, so either would put
+			// the secrets in the exception log
+			throw new RuntimeException("Loading {$secretsFile} failed with " . $e::class);
+		}
+		if (!is_array($secrets)) {
+			throw new RuntimeException("{$secretsFile} must contain a neon mapping, it contains " . get_debug_type($secrets));
+		}
+		if ($secrets !== [] && array_is_list($secrets)) {
+			// A list would pass as %secrets% and the boot would then die later, on the first service reading
+			// a named path like secrets.database.default.password, with an error that never says what's wrong
+			throw new RuntimeException("{$secretsFile} must contain a neon mapping keyed by the secret names, it contains a list");
+		}
+		if ($secrets === []) {
+			// An empty mapping would replace the whole declared %secrets% tree with nothing, and the boot would
+			// then die later, on the first service reading a secret, with an error that never says what's missing
+			throw new RuntimeException("{$secretsFile} is empty, fill in the real values, see config/secrets.template.neon");
+		}
+		return $secrets;
+	}
+
+
+	/**
+	 * The check runs only when the container is really compiled: `onCompile` fires from `generateContainer()`,
+	 * which `ContainerLoader` calls just when there is no container to load, so a cached boot costs nothing.
+	 *
+	 * @param array<array-key, mixed>|null $secrets
+	 */
+	private static function createContainer(#[SensitiveParameter] Configurator $configurator, #[SensitiveParameter] ?array $secrets): Container
+	{
+		$configurator->onCompile[] = function (#[SensitiveParameter] Configurator $configurator, #[SensitiveParameter] Compiler $compiler) use ($secrets): void {
+			$compiler->addExtension('containerSecretsChecker', new ContainerSecretsChecker($secrets ?? []));
+		};
+		return $configurator->createContainer();
 	}
 
 

--- a/app/src/Application/ContainerSecretsChecker.php
+++ b/app/src/Application/ContainerSecretsChecker.php
@@ -1,0 +1,329 @@
+<?php
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use Composer\Pcre\Preg;
+use Nette\DI\CompilerExtension;
+use Nette\Neon\Exception as NeonException;
+use Nette\Neon\Neon;
+use Override;
+use ReflectionObject;
+use RuntimeException;
+use SensitiveParameter;
+use SensitiveParameterValue;
+use Tracy\BlueScreen;
+
+/**
+ * Refuses to compile a container whose configuration carries a secret. Everything a secret could ride into the
+ * generated code on is some configuration value, so the merged config is checked instead of the generated text,
+ * and it happens before a single line is generated: a refused config means no container file was written, and
+ * every following boot recompiles and refuses again until the config is fixed.
+ *
+ * Bootstrap registers this from its onCompile hook, with the values currently loaded from config/secrets.neon.
+ */
+final class ContainerSecretsChecker extends CompilerExtension
+{
+
+	/**
+	 * A shorter value can equal an ordinary configuration value by accident, and the check would then refuse
+	 * a perfectly clean config, so short values are refused up front instead.
+	 */
+	private const int MIN_CHECKABLE_LENGTH = 8;
+
+
+	/**
+	 * @param array<array-key, mixed> $secrets
+	 */
+	public function __construct(
+		#[SensitiveParameter] private readonly array $secrets,
+	) {
+	}
+
+
+	/**
+	 * Runs after every extension got its configuration and before any code is generated.
+	 *
+	 * Two rules: `parameters.secrets` must hold no value at all, whatever it is, because the config is compiled
+	 * into the container as the dynamic parameter's fallback, and a stale value left there after a rotation
+	 * equals nothing in secrets.neon while still being a secret. Everywhere else, no configuration value or key
+	 * may equal a current secret, keys are emitted into the generated code as literals just like values: a whole
+	 * value equal to one isn't a coincidence, it's a copy, while a mere substring somewhere would be, so only
+	 * exact matches count.
+	 *
+	 * The refusals name paths, and a path can have a pasted secret as a segment, so every current secret is
+	 * replaced in them before they reach the exception message; under `parameters.secrets` only the declared
+	 * part of the path is named, the keys there can be stale secrets nothing can recognize.
+	 */
+	#[Override]
+	public function beforeCompile(): void
+	{
+		$secretValues = [];
+		foreach (self::scalarLeaves($this->secrets, 'secrets') as $path => $value) {
+			if (is_string($value) && $value !== '') {
+				$secretValues[$value] = $path;
+			}
+		}
+		$hidden = array_fill_keys(array_keys($secretValues), '…');
+
+		$filled = [];
+		$copied = [];
+		foreach ($this->compiler->getExtensions() as $name => $extension) {
+			if ($extension === $this) {
+				continue;
+			}
+			foreach (self::configLeaves($extension->getConfig(), $name) as $path => $value) {
+				if ($path === 'parameters.secrets' || str_starts_with($path, 'parameters.secrets.')) {
+					if ($value !== null && $value !== '') {
+						$filled[] = $this->declaredSecretsPath($path);
+					}
+				} elseif (is_string($value) && isset($secretValues[$value])) {
+					// Strings only: checkValues() refuses secrets that would decode as numbers or dates when
+					// unquoted, so no value of another type can equal one
+					$copied[] = "{$secretValues[$value]} (" . strtr($path, $hidden) . ')';
+				}
+			}
+			foreach (self::configKeys($extension->getConfig(), $name) as [$holder, $key]) {
+				if ($holder === 'parameters.secrets' || str_starts_with($holder, 'parameters.secrets.')) {
+					// Keys under parameters.secrets are compiled into the container as the fallback structure
+					// even with nothing under them, an empty array say, and a stale secret left as a key there
+					// equals nothing current, so every key has to be one the current secrets declare. With no
+					// secrets loaded there's no shape to compare against, and nothing current to protect either
+					$declaredPath = $this->declaredSecretsPath("{$holder}.{$key}");
+					if ($this->secrets !== [] && str_ends_with($declaredPath, '…')) {
+						$filled[] = $declaredPath;
+					}
+				} elseif (isset($secretValues[$key])) {
+					$copied[] = "{$secretValues[$key]} (a key under " . strtr($holder, $hidden) . ')';
+				}
+			}
+		}
+		if ($filled !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', array_unique($filled)) . ' are defined statically in the config files and would be compiled into the container as the fallback for the dynamic parameter; they belong only in config/secrets.neon');
+		}
+		if ($copied !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $copied) . ' are written into the configuration statically and would be compiled into the container; they belong only in config/secrets.neon');
+		}
+	}
+
+
+	/**
+	 * Makes the blue screen hide every value equal to a current secret, wherever it appears. A failed compile
+	 * puts the whole configuration in the trace's frame arguments: the `Configurator` with its dynamic parameters,
+	 * closure captures, the raw config arrays, under keys no `keysToHide` list can all name, so hiding goes by
+	 * value. An array holding a secret as a KEY is hidden whole: Tracy always renders key names, so hiding
+	 * the key's value wouldn't hide the key. Anything keyed `secrets` is hidden whatever it holds, because
+	 * a STALE value under `parameters.secrets` equals no current secret, and its carrier in the dumped config
+	 * arrays is always keyed that. Strings are all that's compared, checkValues() refuses secrets that would
+	 * decode as something else when unquoted. The closure keeps the values wrapped in `SensitiveParameterValue`,
+	 * which Tracy redacts natively, so dumping the closure itself shows no values, and there is no derived
+	 * list, hashes say, to attack offline if a dump ever gets out.
+	 *
+	 * @param array<array-key, mixed> $secrets
+	 */
+	public static function hideSecrets(BlueScreen $blueScreen, #[SensitiveParameter] array $secrets): void
+	{
+		$secretValues = [];
+		foreach (self::scalarLeaves($secrets, 'secrets') as $value) {
+			if (is_string($value) && $value !== '') {
+				$secretValues[] = new SensitiveParameterValue($value);
+			}
+		}
+		$blueScreen->scrubber = static function (string $key, mixed $value = null) use ($secretValues): bool {
+			if ($key === 'secrets') {
+				return true;
+			}
+			if (is_string($value)) {
+				$candidates = [$value];
+			} elseif (is_array($value)) {
+				$candidates = array_filter(array_keys($value), is_string(...));
+			} else {
+				return false;
+			}
+			foreach ($candidates as $candidate) {
+				foreach ($secretValues as $secretValue) {
+					if ($candidate === $secretValue->getValue()) {
+						return true;
+					}
+				}
+			}
+			return false;
+		};
+	}
+
+
+	/**
+	 * @param array<array-key, mixed> $secrets
+	 * @throws RuntimeException
+	 */
+	public static function checkValues(#[SensitiveParameter] array $secrets): void
+	{
+		$notStrings = [];
+		$tooShort = [];
+		$controlCharacters = [];
+		$activeConfigSyntax = [];
+		$wrongWhenUnquoted = [];
+		foreach (self::scalarLeaves($secrets, 'secrets') as $path => $value) {
+			if ($value === null || $value === '') {
+				continue; // not set, same meaning the declared shape gives an empty value
+			} elseif (!is_string($value)) {
+				$notStrings[] = $path;
+			} elseif (strlen($value) < self::MIN_CHECKABLE_LENGTH) {
+				$tooShort[] = $path;
+			} elseif (Preg::isMatch('/[\x00-\x1F\x7F]/', $value)) {
+				// A value with a newline in it decodes on its own terms only: standalone it's a parse error,
+				// which decodesDifferently() treats as safe, while pasted after a config key it splits into
+				// several entries carrying the pieces
+				$controlCharacters[] = $path;
+			} elseif (str_starts_with($value, '@') || substr_count($value, '%') >= 2) {
+				// Nette config syntax, not NEON: a leading @ is a service reference, which the neon adapter
+				// escapes to @@ so an exact comparison never sees the secret's bytes, and the resolver unescapes
+				// it only into the generated code; a % pair expands as a parameter, throwing Nette's own error
+				// with the secret's insides quoted before any check here runs. A single % stays literal
+				$activeConfigSyntax[] = $path;
+			} elseif (self::decodesDifferently($value)) {
+				$wrongWhenUnquoted[] = $path;
+			}
+		}
+		if ($notStrings !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $notStrings) . ' are not strings; secrets are strings, a number would lose leading zeros and the compiled-container check only compares strings');
+		}
+		if ($tooShort !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $tooShort) . ' are shorter than ' . self::MIN_CHECKABLE_LENGTH . ' characters, and a value that short can equal an ordinary configuration value by accident, which the compiled-container check would then refuse; use longer values');
+		}
+		if ($controlCharacters !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $controlCharacters) . ' contain control characters, a newline say, so a copy pasted into a config file splits into several entries carrying the pieces, which the whole-string comparisons can\'t see; use single-line values');
+		}
+		if ($activeConfigSyntax !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $activeConfigSyntax) . ' read as Nette config syntax: a leading @ is a service reference and a % pair expands as a parameter, so a copy pasted into a config file changes shape before the compiled-container check can see it, or makes Nette\'s own error message quote it; use values that don\'t start with @ and have at most one %');
+		}
+		if ($wrongWhenUnquoted !== []) {
+			throw new RuntimeException('Values of ' . implode(', ', $wrongWhenUnquoted) . ' would decode as something else (a number, a date, an array, a piece of themselves) if copied into a config file without quotes, NEON is quote-optional, and the compiled-container check and the blue screen scrubber compare whole strings only, so such a copy would slip through both; use values that decode back to exactly themselves, hex and base64 without the trailing padding do');
+		}
+	}
+
+
+	/**
+	 * NEON is quote-optional, so a copy of a secret pasted into a config file without quotes decodes as whatever
+	 * the parser sees in it: `12345678` as an integer, `2026-08-11` as a date object, `[whatever]` as an array
+	 * holding the bracketless inside, `whatever # tail` as the part before the comment. Each of those is compiled
+	 * into the container carrying the secret's bytes, or a large piece of them, in a shape the string comparisons
+	 * in beforeCompile() and the scrubber can't see, so the only safe values are the ones that decode back to
+	 * exactly themselves, and everything else is refused up front. A value that fails to decode at all is fine
+	 * too: pasting it unquoted breaks the config loudly instead of compiling quietly.
+	 */
+	private static function decodesDifferently(#[SensitiveParameter] string $value): bool
+	{
+		try {
+			$decoded = Neon::decode($value);
+		} catch (NeonException) {
+			return false;
+		}
+		return $decoded !== $value;
+	}
+
+
+	/**
+	 * The path under `parameters.secrets` cut down to what the current secrets declare: everything under there
+	 * is refused whatever it is, so its keys can be anything, a stale secret from before a rotation too, and
+	 * a refusal can only safely name the declared part.
+	 */
+	private function declaredSecretsPath(string $path): string
+	{
+		$declared = 'secrets';
+		if ($path === 'parameters.secrets') {
+			return $declared;
+		}
+		$known = $this->secrets;
+		foreach (explode('.', substr($path, strlen('parameters.secrets.'))) as $segment) {
+			if (!is_array($known) || !array_key_exists($segment, $known)) {
+				return "{$declared}.…";
+			}
+			$declared .= ".{$segment}";
+			$known = $known[$segment];
+		}
+		return $declared;
+	}
+
+
+	/**
+	 * @param array<array-key, mixed> $values
+	 * @return array<string, mixed> Path => leaf, everything that isn't an array, so checkValues() can refuse
+	 *     what doesn't belong rather than this quietly leaving it out
+	 */
+	private static function scalarLeaves(#[SensitiveParameter] array $values, string $path): array
+	{
+		$leaves = [];
+		foreach ($values as $key => $value) {
+			$keyPath = "{$path}.{$key}";
+			if (is_array($value)) {
+				$leaves = array_merge($leaves, self::scalarLeaves($value, $keyPath));
+			} else {
+				$leaves[$keyPath] = $value;
+			}
+		}
+		return $leaves;
+	}
+
+
+	/**
+	 * Like scalarLeaves(), but for the shapes extension configs come in: a schema-processed config is an object,
+	 * a service definition holds its arguments in Statement objects, so objects are walked by their properties
+	 * too, the private ones included: a Statement keeps its entity, the class name it compiles into a `new`,
+	 * in one.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private static function configLeaves(mixed $config, string $path): array
+	{
+		$leaves = [];
+		if (is_array($config)) {
+			foreach ($config as $key => $value) {
+				$leaves = array_merge($leaves, self::configLeaves($value, "{$path}.{$key}"));
+			}
+		} elseif (is_object($config)) {
+			foreach (self::configItems($config) as $key => $value) {
+				$leaves = array_merge($leaves, self::configLeaves($value, "{$path}.{$key}"));
+			}
+		} else {
+			$leaves[$path] = $config;
+		}
+		return $leaves;
+	}
+
+
+	/**
+	 * @return array<string, mixed>
+	 */
+	private static function configItems(object $config): array
+	{
+		$items = [];
+		foreach ((new ReflectionObject($config))->getProperties() as $property) {
+			if (!$property->isStatic() && $property->isInitialized($config)) {
+				$items[$property->getName()] = $property->getValue($config);
+			}
+		}
+		return $items;
+	}
+
+
+	/**
+	 * Every key from every level of a config, each with the path of the structure holding it, which is what
+	 * a refusal can safely name: the key itself may be the secret. Keys come out as strings, because PHP turns
+	 * a digit-only key into an integer on its own, and a stale numeric key under `parameters.secrets` still
+	 * compiles into the fallback structure.
+	 *
+	 * @return list<array{string, string}>
+	 */
+	private static function configKeys(mixed $config, string $path): array
+	{
+		$keys = [];
+		$items = is_array($config) ? $config : (is_object($config) ? self::configItems($config) : []);
+		foreach ($items as $key => $value) {
+			$keys[] = [$path, (string)$key];
+			$keys = array_merge($keys, self::configKeys($value, "{$path}.{$key}"));
+		}
+		return $keys;
+	}
+
+}

--- a/app/tests/Application/BootstrapTest.phpt
+++ b/app/tests/Application/BootstrapTest.phpt
@@ -6,9 +6,13 @@ namespace MichalSpacekCz\Application;
 
 use MichalSpacekCz\Test\TestCaseRunner;
 use Nette\DI\Container;
+use Nette\Utils\FileSystem;
+use Override;
+use RuntimeException;
 use Tester\Assert;
 use Tester\TestCase;
 use Tracy\Debugger;
+use Tracy\Dumper;
 use Tracy\ILogger;
 
 require __DIR__ . '/../bootstrap.php';
@@ -19,6 +23,9 @@ final class BootstrapTest extends TestCase
 
 	private string $exceptionLog;
 	private ?string $tempLog = null;
+
+	/** @var list<string> */
+	private array $tempDirs = [];
 
 
 	public function __construct()
@@ -31,6 +38,29 @@ final class BootstrapTest extends TestCase
 			rename($this->exceptionLog, $this->tempLog);
 		}
 		ServerEnv::setString('SERVER_NAME', 'michalspacek.cz');
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		foreach ($this->tempDirs as $tempDir) {
+			FileSystem::delete($tempDir);
+		}
+		$this->tempDirs = [];
+	}
+
+
+	/**
+	 * Each boot gets its own temp directory: the container cache key includes dynamic parameter names, never
+	 * values, so a container compiled into the shared temp/ and checked only against the template's placeholders
+	 * could be reused by a real boot with the same key
+	 */
+	private function newTempDir(): string
+	{
+		$tempDir = sys_get_temp_dir() . '/bootstrap-test-' . bin2hex(random_bytes(8));
+		$this->tempDirs[] = $tempDir;
+		return $tempDir;
 	}
 
 
@@ -72,9 +102,81 @@ final class BootstrapTest extends TestCase
 		}
 		$container = null;
 		Assert::noError(function () use (&$container): void {
-			$container = Bootstrap::boot();
+			// The committed template stands in for the gitignored secrets.neon, so this boots the same on every machine
+			$container = Bootstrap::bootContainerTest(__DIR__ . '/../../config/secrets.template.neon', $this->newTempDir());
 		});
 		Assert::type(Container::class, $container);
+
+		// Booting has to leave the scrubber on the blue screen, so no dump in the exception log shows a value
+		// equal to a current secret; checked with a placeholder from the template that booted above
+		$scrubber = Debugger::getBlueScreen()->scrubber;
+		Assert::notNull($scrubber);
+		assert($scrubber !== null); // Assert::notNull() doesn't narrow the type for phpstan and psalm
+		Assert::true($scrubber('apiKey', 'britishteaatfiveoclockisnotacoffee', null), 'the blue screen scrubber does not hide a current secret');
+		Assert::true($scrubber('users', ['britishteaatfiveoclockisnotacoffee' => 'web'], null), 'the blue screen scrubber does not hide a structure with a secret as a key, and Tracy always renders key names');
+		Assert::false($scrubber('apiKey', 'no secret has this value', null), 'the blue screen scrubber hides more than the secrets, which would make every dump useless');
+		// The closure holds the values it compares against, and Tracy dumps closure captures, so they're wrapped
+		// in SensitiveParameterValue, which Tracy redacts: dumping the scrubber itself must show nothing
+		Assert::notContains('britishteaatfiveoclockisnotacoffee', Dumper::toText($scrubber, [Dumper::DEPTH => 8]), 'dumping the scrubber closure shows the secrets it holds');
+	}
+
+
+	public function testEmptySecretsFileIsRefused(): void
+	{
+		// An empty mapping would replace the whole declared %secrets% tree with nothing, and the boot would
+		// then die later, on the first service reading a secret, with an error that never says what's missing
+		$file = sys_get_temp_dir() . '/bootstrap-test-secrets-' . bin2hex(random_bytes(8)) . '.neon';
+		FileSystem::write($file, "[]\n");
+		try {
+			Assert::exception(function () use ($file): void {
+				Bootstrap::bootContainerTest($file, $this->newTempDir());
+			}, RuntimeException::class, "{$file} is empty%a%");
+		} finally {
+			FileSystem::delete($file);
+		}
+	}
+
+
+	public function testListSecretsFileIsRefused(): void
+	{
+		// Decodes to a PHP array like a mapping does, but no named path can ever resolve in it, so the boot
+		// would die later with an error that never says what's wrong
+		$file = sys_get_temp_dir() . '/bootstrap-test-secrets-' . bin2hex(random_bytes(8)) . '.neon';
+		FileSystem::write($file, "- abcdefgh\n");
+		try {
+			Assert::exception(function () use ($file): void {
+				Bootstrap::bootContainerTest($file, $this->newTempDir());
+			}, RuntimeException::class, '%a%neon mapping keyed by the secret names%a%list');
+		} finally {
+			FileSystem::delete($file);
+		}
+	}
+
+
+	public function testBrokenSecretsFileIsReportedWithoutItsContents(): void
+	{
+		// Built at runtime so the value can't reach any log through the source excerpt of this frame
+		$token = 'brokenfile-' . bin2hex(random_bytes(8));
+		$file = sys_get_temp_dir() . '/bootstrap-test-secrets-' . bin2hex(random_bytes(8)) . '.neon';
+		// The unclosed quote is what a hand-edit typo looks like; the parser's own message quotes the file
+		FileSystem::write($file, "apiKey: '{$token}\n");
+		try {
+			$e = Assert::exception(function () use ($file): void {
+				Bootstrap::bootContainerTest($file, $this->newTempDir());
+			}, RuntimeException::class, "Loading {$file} failed with %a%");
+			assert($e !== null); // Assert::exception() doesn't narrow the type for phpstan and psalm
+			Assert::notContains($token, $e->getMessage(), 'the replacement message quotes the broken file');
+			// The rendered log guards the not-chained part too: a chained original carries the whole file
+			// as the decoder's argument, and Tracy dumps arguments
+			$log = $file . '.bluescreen.html';
+			Assert::true(Debugger::getBlueScreen()->renderToFile($e, $log), 'Tracy refused to write the blue screen');
+			Assert::notContains($token, FileSystem::read($log), 'the exception log leaked the broken file');
+			Assert::notContains($token, FileSystem::read($file . '.bluescreen.md'), 'the agent log leaked the broken file');
+		} finally {
+			FileSystem::delete($file);
+			FileSystem::delete($file . '.bluescreen.html');
+			FileSystem::delete($file . '.bluescreen.md');
+		}
 	}
 
 }

--- a/app/tests/Application/CompiledContainerSecretsTest.phpt
+++ b/app/tests/Application/CompiledContainerSecretsTest.phpt
@@ -1,0 +1,654 @@
+<?php
+/** @noinspection PhpUnhandledExceptionInspection */
+declare(strict_types = 1);
+
+namespace MichalSpacekCz\Application;
+
+use Composer\Pcre\Preg;
+use MichalSpacekCz\Test\TestCaseRunner;
+use Nette\Bootstrap\Configurator;
+use Nette\DI\Compiler;
+use Nette\DI\Container;
+use Nette\DI\Definitions\Statement;
+use Nette\Neon\Neon;
+use Nette\Utils\FileSystem;
+use Override;
+use RuntimeException;
+use SensitiveParameter;
+use Tester\Assert;
+use Tester\TestCase;
+use Throwable;
+use Tracy\BlueScreen;
+
+require __DIR__ . '/../bootstrap.php';
+
+/*
+ * The secrets from config/secrets.neon must never be written into the container Nette compiles into temp/:
+ * Tracy renders the source of every frame into the exception log, and `#[SensitiveParameter]` and `keysToHide`
+ * both work on values, so neither reaches source code. Building an encryption service is where that bites,
+ * its constructor rejects a bad key and the frame is the generated factory, with the key in the excerpt if it
+ * was compiled in. Bootstrap passes the secrets as dynamic parameters, supplied at runtime and never written
+ * to the container, and these tests hold that in place.
+ */
+
+/** @testCase */
+final class CompiledContainerSecretsTest extends TestCase
+{
+
+	/** @var list<string> */
+	private array $tempDirs = [];
+
+
+	public function __construct(
+		private readonly BlueScreen $blueScreen, // the container's, so this runs against the configured keysToHide
+	) {
+	}
+
+
+	#[Override]
+	protected function tearDown(): void
+	{
+		foreach ($this->tempDirs as $tempDir) {
+			FileSystem::delete($tempDir);
+		}
+		$this->tempDirs = [];
+		$this->blueScreen->scrubber = null; // the container's blue screen is shared, the scrubber isn't this test's to keep
+	}
+
+
+	public function testKeyIsNotInTheExceptionLogWhenTheEncryptionServiceFailsToBuild(): void
+	{
+		$key = 'msee_' . str_repeat('ab', 32);
+
+		Assert::false($this->keyInRenderedBlueScreen($key, dynamic: true), 'the key reached the exception log even as a dynamic parameter');
+		Assert::true($this->keyInRenderedBlueScreen($key, dynamic: false), 'a key written into the container was not found either, so this would pass whatever it rendered');
+	}
+
+
+	public function testStaleValueUnderParametersSecretsIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		// A stale value under parameters.secrets, different from everything in secrets.neon: what a local.neon
+		// not cleaned up after a rotation looks like; refused whatever the value is. Built at runtime, a literal
+		// would leak into the log check below through the source excerpt Tracy renders for this very frame
+		$staleValue = 'stale-rotated-' . bin2hex(random_bytes(8));
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, ['apiKey' => $secret]);
+
+		$thrown = $this->compileRefused('a config with a static value under parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+			'arguments' => [['key' => '%secrets.apiKey%']],
+		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => $staleValue]]]);
+		Assert::match('%a%secrets.apiKey%a%statically%a%', $thrown->getMessage());
+		$files = glob($this->lastTempDir() . '/cache/nette.configurator/Container_*.php');
+		Assert::same([], $files === false ? [] : $files, 'the refused container was written anyway');
+		// The stale value isn't a current secret, so the scrubber doesn't know it and nothing hides it by name
+		// either: it stays out of the log only as long as the config arrays sit deeper than Tracy's maxDepth,
+		// and this is here to notice when that stops being true
+		$this->assertNoLeakInRenderedBlueScreen($thrown, 'refused-stale', substr($staleValue, -16));
+	}
+
+
+	public function testScalarDirectlyAtParametersSecretsIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		// The leaf path is then exactly `parameters.secrets`, which a prefix match with the trailing dot would miss
+		$staleValue = 'stale-rotated-' . bin2hex(random_bytes(8));
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, ['apiKey' => $secret]);
+
+		$thrown = $this->compileRefused('a scalar assigned directly to parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfig: ['parameters' => ['secrets' => $staleValue]]);
+		Assert::match('%a%secrets%a%statically%a%', $thrown->getMessage());
+		// The direct scalar sits one level shallower in the dumped config arrays than the nested cases, so its
+		// staying out of the log is pinned separately
+		$this->assertNoLeakInRenderedBlueScreen($thrown, 'refused-direct', substr($staleValue, -16));
+	}
+
+
+	public function testStaleKeyUnderParametersSecretsIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		$staleValue = 'stale-rotated-' . bin2hex(random_bytes(8));
+
+		// A stale key with nothing under it, an empty array here: no leaf comes out of that, while Nette still
+		// compiles the key text into the dynamic parameter's fallback structure, so the keys themselves have to
+		// be ones the current secrets declare
+		$thrown = $this->compileRefused('a stale key with an empty array under parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => [$staleValue => []]]]]);
+		Assert::match('%a%secrets.apiKey.…%a%statically%a%', $thrown->getMessage());
+		Assert::notContains(substr($staleValue, -16), $thrown->getMessage(), 'the message leaked the stale key');
+	}
+
+
+	public function testStaleNumericKeyUnderParametersSecretsIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+
+		// A digit-only stale key, which PHP has turned into an integer by the time it's a key
+		$thrown = $this->compileRefused('a stale numeric key with an empty array under parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => [12345678 => []]]]]);
+		Assert::match('%a%secrets.apiKey.…%a%statically%a%', $thrown->getMessage());
+	}
+
+
+	public function testValueUnderStaleKeyBelowParametersSecretsIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		$staleValue = 'stale-rotated-' . bin2hex(random_bytes(8));
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, ['apiKey' => $secret]);
+
+		// Nothing can recognize a stale secret, so the refusal names the path only down to what the current
+		// secrets declare
+		$thrown = $this->compileRefused('a config with a value under a stale key below parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => [$staleValue => 'x']]]]);
+		Assert::match('%a%secrets.apiKey.…%a%statically%a%', $thrown->getMessage());
+		Assert::notContains(substr($staleValue, -16), $thrown->getMessage(), 'the message leaked the stale key');
+		$this->assertNoLeakInRenderedBlueScreen($thrown, 'refused-stale-key', substr($staleValue, -16));
+	}
+
+
+	public function testConfigValueEqualToACurrentSecretIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, ['apiKey' => $secret]);
+
+		// A current secret copied verbatim anywhere in the config, a pasted password say; a substring inside
+		// a longer value is deliberately not a match, that's how an unrelated `localhost` stays a coincidence
+		$thrown = $this->compileRefused('a config value equal to a current secret was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+			'arguments' => [$secret],
+		]);
+		Assert::match('%a%secrets.apiKey%a%statically%a%', $thrown->getMessage());
+		Assert::notContains($secret, $thrown->getMessage(), 'the message leaked the value it exists to protect');
+		$this->assertNoLeakInRenderedBlueScreen($thrown, 'refused-value', substr($secret, -16));
+	}
+
+
+	public function testConfigKeyEqualToACurrentSecretIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, ['apiKey' => $secret]);
+
+		// A current secret pasted as a KEY: Nette emits config keys into the generated code as literals just
+		// like values. The value under it is the secret too, so this also checks that the refusal names only
+		// what holds the key, the paths of value matches included, a path can have the key as a segment.
+		// The scrubber can't hide a key by hiding its value, Tracy always renders key names, so the structure
+		// holding the key has to disappear from the rendered log whole
+		$thrown = $this->compileRefused('a config key equal to a current secret was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+			'arguments' => [[$secret => $secret]],
+		]);
+		Assert::match('%a%secrets.apiKey (a key under%a%statically%a%', $thrown->getMessage());
+		Assert::notContains($secret, $thrown->getMessage(), 'the message leaked the key it exists to protect');
+		$this->assertNoLeakInRenderedBlueScreen($thrown, 'refused-key', substr($secret, -16));
+	}
+
+
+	public function testStatementEntityEqualToACurrentSecretIsRefused(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+
+		// The entity, the class name a `new` is compiled from, sits in a private property that get_object_vars()
+		// would miss. Nested in arguments, because a secret in the factory position dies earlier, on Nette
+		// resolving the class, before any check here can run
+		$thrown = $this->compileRefused('a Statement entity equal to a current secret was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+			'arguments' => [new Statement($secret)],
+		]);
+		Assert::match('%a%secrets.apiKey%a%statically%a%', $thrown->getMessage());
+		Assert::notContains($secret, $thrown->getMessage(), 'the message leaked the value it exists to protect');
+	}
+
+
+	public function testConfigWithoutCopiesCompilesWithTheGuardInPlace(): void
+	{
+		$secret = "refused-o'brien-" . bin2hex(random_bytes(8));
+
+		// Including a config value that is a substring of a secret: that's the `localhost` coincidence, not a copy
+		Assert::noError(function () use ($secret): void {
+			$this->compile(['apiKey' => $secret], dynamic: true, guarded: true, service: [
+				'factory' => 'ArrayObject',
+				'arguments' => [['key' => '%secrets.apiKey%', 'coincidence' => substr($secret, 0, 12)]],
+			]);
+		});
+	}
+
+
+	/**
+	 * Real configs arrive as files and go through the NeonAdapter before any extension sees them: it rewrites
+	 * values and strips key suffixes, and the array-based compiles above never exercise it, so this does.
+	 * Parameter expansion runs only after the check, but it can only copy what some parameter already holds,
+	 * and that parameter is itself a config leaf the checker sees raw.
+	 */
+	public function testFileBackedConfigIsCheckedAfterTheAdapter(): void
+	{
+		$secret = 'filebacked-' . bin2hex(random_bytes(8));
+
+		// A secret pasted as an ordinary parameter, referenced by a service: the refusal names the parameter,
+		// the source every later expansion would copy from
+		$thrown = $this->compileRefused('a file-backed config with a secret pasted as a parameter was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfigNeon: "parameters:\n\tprobe: '{$secret}'\n\nservices:\n\tprobe2: ArrayObject(%probe%)\n");
+		Assert::match('%a%secrets.apiKey (parameters.probe)%a%', $thrown->getMessage());
+		Assert::notContains($secret, $thrown->getMessage(), 'the message leaked the value it exists to protect');
+
+		// A stale key under parameters.secrets with the adapter's ! suffix: the adapter strips it, so the
+		// shape rule has to see the bare key
+		$staleValue = 'stalebang-' . bin2hex(random_bytes(8));
+		$thrown = $this->compileRefused('a file-backed config with a stale key under parameters.secrets was accepted', ['apiKey' => $secret], [
+			'factory' => 'ArrayObject',
+		], extraConfigNeon: "parameters:\n\tsecrets:\n\t\t{$staleValue}!: []\n");
+		Assert::match('%a%secrets.…%a%statically%a%', $thrown->getMessage());
+		Assert::notContains(substr($staleValue, -16), $thrown->getMessage(), 'the message leaked the stale key');
+	}
+
+
+	/**
+	 * A boot with no secrets file, a CLI one on CI say, still compiles, and the compile check can still refuse
+	 * a stale value under parameters.secrets, dumping the config arrays into the exception log: the rule hiding
+	 * anything keyed `secrets` must hold with nothing loaded at all
+	 */
+	public function testScrubberHidesTheSecretsKeyWithNoSecretsLoaded(): void
+	{
+		ContainerSecretsChecker::hideSecrets($this->blueScreen, []);
+		$scrubber = $this->blueScreen->scrubber;
+		Assert::notNull($scrubber);
+		assert($scrubber !== null); // Assert::notNull() doesn't narrow the type for phpstan and psalm
+		Assert::true($scrubber('secrets', 'stale-rotated-away-value', null), 'a structure keyed `secrets` is not hidden when no secrets are loaded');
+		Assert::false($scrubber('anything', 'ordinary-value', null), 'an empty secrets list hides unrelated values, which would make every dump useless');
+	}
+
+
+	public function testSecretsTooShortToVerifyAreRefusedNotSkipped(): void
+	{
+		$e = Assert::exception(function (): void {
+			// a value this short can equal an ordinary config value by accident, `www` would match a subdomain
+			ContainerSecretsChecker::checkValues(['database' => ['default' => ['password' => 'www']]]);
+		}, RuntimeException::class, '%a%secrets.database.default.password%a%');
+		assert($e !== null);
+		Assert::notContains("'www'", $e->getMessage(), 'the message leaked the value it exists to protect');
+
+		Assert::exception(function (): void {
+			// a number would lose leading zeros, and the compiled-container check only searches for strings
+			ContainerSecretsChecker::checkValues(['database' => ['default' => ['password' => 12345678901]]]);
+		}, RuntimeException::class, '%a%secrets.database.default.password%a%not strings%a%');
+
+		Assert::noError(function (): void {
+			// an empty string means not set, that's the declared shape's own convention, and long values are fine
+			ContainerSecretsChecker::checkValues(['database' => ['default' => ['password' => 'long-enough-password'], 'admin' => ['password' => '']]]);
+		});
+	}
+
+
+	/**
+	 * NEON is quote-optional, so a copy of a secret pasted into a config file without quotes decodes as whatever
+	 * the parser sees in it, and a purely numeric or date-shaped value becomes another type carrying the same
+	 * bytes, invisible to the string comparisons in the compile-time check and the scrubber. Refused up front,
+	 * so every secret that exists is one the checks cover.
+	 */
+	public function testSecretsThatWouldNotStayStringsUnquotedAreRefused(): void
+	{
+		Assert::exception(function (): void {
+			ContainerSecretsChecker::checkValues(['apiKey' => '1629074133397642']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			ContainerSecretsChecker::checkValues(['apiKey' => '12345678.5']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			ContainerSecretsChecker::checkValues(['apiKey' => '2026-08-11']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			// decodes as an array holding the bracketless inside, which is the secret minus two characters
+			ContainerSecretsChecker::checkValues(['apiKey' => '[abcdefgh]']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			// decodes as the part before the comment, a piece of the secret big enough to matter
+			ContainerSecretsChecker::checkValues(['apiKey' => 'abcdefgh # ijklmnop']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			// base64 WITH the trailing padding: NEON reads `foo=` as a mapping with `foo` as its key, so a paste
+			// puts the secret minus the padding into the container as a key, off by one `=` from what the exact
+			// comparisons look for; the padding carries nothing, strip it or use hex
+			ContainerSecretsChecker::checkValues(['apiKey' => 'c2VjcmV0dmFsdWU=']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%without quotes%a%');
+
+		Assert::exception(function (): void {
+			// standalone this fails to decode, which would count as safe, but pasted after a config key it
+			// splits into two entries carrying the pieces
+			ContainerSecretsChecker::checkValues(['apiKey' => "abcdefgh\nother: ijklmnop"]);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%control characters%a%');
+
+		Assert::exception(function (): void {
+			// a leading @ is a service reference: the neon adapter escapes a quoted copy to @@, so the exact
+			// comparison never sees the secret's bytes, and the resolver unescapes it only into the generated code
+			ContainerSecretsChecker::checkValues(['apiKey' => '@abcdefgh']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%config syntax%a%');
+
+		Assert::exception(function (): void {
+			// a % pair expands as a parameter, and the pasted copy throws Nette's own "Missing parameter"
+			// with the secret's insides quoted, before any check here runs
+			ContainerSecretsChecker::checkValues(['apiKey' => 'pre%mid%post']);
+		}, RuntimeException::class, '%a%secrets.apiKey%a%config syntax%a%');
+
+		Assert::noError(function (): void {
+			// hex and unpadded base64 decode back to themselves, a mid-string @ isn't a reference, a single %
+			// stays literal, and a value NEON can't parse at all is fine too: pasting that unquoted breaks
+			// the config loudly instead of compiling quietly
+			ContainerSecretsChecker::checkValues(['apiKey' => 'msee_cafecafe1629074133397642', 'unpadded' => 'c2VjcmV0dmFsdWU', 'atInside' => 'ab@cdefgh', 'onePercent' => '50%offabc', 'other' => "o'brien: {weird"]);
+		});
+	}
+
+
+	public function testDynamicParametersAreNotCompiledIntoTheContainer(): void
+	{
+		$secret = 'probe-' . bin2hex(random_bytes(8)); // plain on purpose, this checks the raw bytes; escaped values are the refused test's subject
+
+		Assert::false($this->secretInCompiledContainer($secret, dynamic: true), 'a secret passed as a dynamic parameter was written into the compiled container');
+		Assert::true($this->secretInCompiledContainer($secret, dynamic: false), 'a static parameter was not found either, so this would pass however the container was built');
+	}
+
+
+	/**
+	 * Every value under `parameters.secrets` in a committed config file has to stay empty, and it is every file
+	 * because the compiled fallback is built from the merged config, not from parameters.neon alone: a value
+	 * hot-fixed into common.neon or an extra-*.neon is compiled into the container with the two checks above
+	 * still green. tests.neon is the exception, its fakes are the point, and the gitignored files are skipped
+	 * because they aren't committed and a dev machine may legitimately have them.
+	 */
+	public function testCommittedConfigsDeclareTheSecretsWithoutValues(): void
+	{
+		$files = glob(__DIR__ . '/../../config/*.neon');
+		assert(is_array($files));
+		$declarationSeen = false;
+		$filled = [];
+		foreach ($files as $file) {
+			$basename = basename($file);
+			if ($basename === 'tests.neon' || $basename === 'local.neon' || str_starts_with($basename, 'remote')) {
+				continue;
+			}
+			$config = Neon::decodeFile($file);
+			if (!is_array($config) || !is_array($config['parameters'] ?? null) || !is_array($config['parameters']['secrets'] ?? null)) {
+				continue;
+			}
+			$declarationSeen = $declarationSeen || $basename === 'parameters.neon';
+			$filled = array_merge($filled, $this->filledLeaves($config['parameters']['secrets'], "{$basename}: secrets"));
+		}
+		Assert::true($declarationSeen, 'parameters.neon no longer declares the secrets shape, so nothing does');
+		Assert::same([], $filled, 'these belong in config/secrets.neon, a value in a committed file is compiled into the container');
+	}
+
+
+	/**
+	 * A `%secrets.…%` reference compiles to a runtime lookup, so referencing a path the shape doesn't declare
+	 * compiles fine everywhere and fails only when the service is first built on the machine with the real
+	 * secrets: renaming a secret and missing one reference is exactly that. tests.neon and the gitignored
+	 * files are skipped like everywhere else here, they're not the committed shape.
+	 */
+	public function testCommittedConfigsReferenceOnlyDeclaredSecrets(): void
+	{
+		$config = Neon::decodeFile(__DIR__ . '/../../config/parameters.neon');
+		assert(is_array($config) && is_array($config['parameters']) && is_array($config['parameters']['secrets']));
+		$declared = $config['parameters']['secrets'];
+
+		$files = glob(__DIR__ . '/../../config/*.neon');
+		assert(is_array($files));
+		$references = 0;
+		$undeclared = [];
+		foreach ($files as $file) {
+			$basename = basename($file);
+			if ($basename === 'tests.neon' || $basename === 'local.neon' || $basename === 'secrets.neon' || str_starts_with($basename, 'remote')) {
+				continue;
+			}
+			Preg::matchAllStrictGroups('/%secrets\.([\w.]+)%/', FileSystem::read($file), $matches);
+			foreach ($matches[1] as $referencePath) {
+				$references++;
+				$known = $declared;
+				foreach (explode('.', $referencePath) as $segment) {
+					if (!is_array($known) || !array_key_exists($segment, $known)) {
+						$undeclared[] = "{$basename}: %secrets.{$referencePath}%";
+						continue 2;
+					}
+					$known = $known[$segment];
+				}
+			}
+		}
+		Assert::true($references > 0, 'no %secrets.…% references found at all, so this scanned nothing');
+		Assert::same([], $undeclared, 'these reference paths parameters.neon does not declare, so they would fail only at runtime, on the machine with the real secrets');
+	}
+
+
+	/**
+	 * secrets.neon replaces the whole declared tree at runtime with no per-key fallback, so the shape in
+	 * parameters.neon and the template people copy have to agree, or a machine ends up with a container that
+	 * compiles everywhere except where it runs.
+	 */
+	public function testTemplateAndDeclaredShapeAgree(): void
+	{
+		$template = $this->asArray(Neon::decodeFile(__DIR__ . '/../../config/secrets.template.neon'));
+		$config = Neon::decodeFile(__DIR__ . '/../../config/parameters.neon');
+		assert(is_array($config) && is_array($config['parameters']) && is_array($config['parameters']['secrets']));
+
+		Assert::same([], $this->shapeDifferences($config['parameters']['secrets'], $template, 'secrets'));
+	}
+
+
+	/**
+	 * @return array<array-key, mixed>
+	 */
+	private function asArray(mixed $values): array
+	{
+		if (!is_array($values)) {
+			throw new RuntimeException('An array expected, got ' . get_debug_type($values));
+		}
+		return $values;
+	}
+
+
+	/**
+	 * The directory of the latest compile() call, the way to reach its files when the compile threw
+	 */
+	private function lastTempDir(): string
+	{
+		$tempDir = end($this->tempDirs);
+		if ($tempDir === false) {
+			throw new RuntimeException('Nothing compiled anything yet, call compile() first');
+		}
+		return $tempDir;
+	}
+
+
+	/**
+	 * @param array<array-key, mixed> $values
+	 * @return list<string> The paths of every non-empty leaf, so a failure names the secret, not just its key
+	 */
+	private function filledLeaves(array $values, string $path): array
+	{
+		$filled = [];
+		foreach ($values as $key => $value) {
+			$keyPath = "{$path}.{$key}";
+			if (is_array($value)) {
+				$filled = array_merge($filled, $this->filledLeaves($value, $keyPath));
+			} elseif ($value !== null && $value !== '') {
+				$filled[] = $keyPath;
+			}
+		}
+		return $filled;
+	}
+
+
+	/**
+	 * Compares key sets level by level, descending only where the declared side has keys of its own: below an
+	 * empty declared leaf are the key ids, which legitimately differ between machines.
+	 *
+	 * @param array<array-key, mixed> $declared
+	 * @param array<array-key, mixed> $template
+	 * @return list<string>
+	 */
+	private function shapeDifferences(array $declared, array $template, string $path): array
+	{
+		$differences = [];
+		foreach (array_keys(array_diff_key($declared, $template)) as $key) {
+			$differences[] = "{$path}.{$key} is declared in parameters.neon but missing from secrets.template.neon";
+		}
+		foreach (array_keys(array_diff_key($template, $declared)) as $key) {
+			$differences[] = "{$path}.{$key} is in secrets.template.neon but not declared in parameters.neon";
+		}
+		foreach ($declared as $key => $value) {
+			if (!array_key_exists($key, $template)) {
+				continue; // already reported above
+			}
+			$templateValue = $template[$key];
+			if (is_array($value)) {
+				if (!is_array($templateValue)) {
+					$differences[] = "{$path}.{$key} is an array in parameters.neon but not in secrets.template.neon";
+				} elseif ($value !== []) {
+					$differences = array_merge($differences, $this->shapeDifferences($value, $templateValue, "{$path}.{$key}"));
+				}
+			} elseif (is_array($templateValue)) {
+				$differences[] = "{$path}.{$key} is a single value in parameters.neon but an array in secrets.template.neon";
+			}
+		}
+		return $differences;
+	}
+
+
+	/**
+	 * @param string $key Marked, or it is dumped as an argument of this very method and the test measures its own harness
+	 */
+	private function keyInRenderedBlueScreen(#[SensitiveParameter] string $key, bool $dynamic): bool
+	{
+		// An active key id that doesn't exist, so the constructor throws the way a misconfigured key would
+		[$container, $tempDir] = $this->compile(['encryptionKeys' => ['email' => ['dev1' => $key]]], $dynamic, [
+			'factory' => 'Spaze\Encryption\SymmetricKeyEncryption',
+			'arguments' => ['%secrets.encryptionKeys.email%', 'nope', 'msee'],
+		]);
+
+		$thrown = null;
+		try {
+			$container->getService('probe');
+		} catch (Throwable $e) {
+			$thrown = $e;
+		}
+		Assert::notNull($thrown, 'building the service should have failed on the unknown active key id');
+		assert($thrown !== null); // Assert::notNull() doesn't narrow the type for phpstan and psalm
+
+		$log = $tempDir . '/bluescreen.html';
+		Assert::true($this->blueScreen->renderToFile($thrown, $log), 'Tracy refused to write the blue screen, it will not overwrite an existing file');
+		$agentLog = $tempDir . '/bluescreen.md';
+		Assert::true(is_file($agentLog), 'Tracy no longer writes the .md log, drop it here rather than silently checking less');
+		// Both, because the two hide values differently: the .md redaction leans on the SensitiveParameterValue
+		// entry in keysToHide, which is marked as removable once the fix lands in Tracy itself
+		return str_contains(FileSystem::read($log), $key) || str_contains(FileSystem::read($agentLog), $key);
+	}
+
+
+	private function secretInCompiledContainer(#[SensitiveParameter] string $secret, bool $dynamic): bool
+	{
+		[, $tempDir] = $this->compile(['apiKey' => $secret], $dynamic, [
+			'factory' => 'ArrayObject',
+			'arguments' => [['key' => '%secrets.apiKey%']],
+		]);
+
+		$files = glob($tempDir . '/cache/nette.configurator/Container_*.php');
+		Assert::type('array', $files, 'no compiled container to look at, so this proves nothing');
+		assert(is_array($files));
+		$found = false;
+		foreach ($files as $file) {
+			$found = $found || str_contains(FileSystem::read($file), $secret);
+		}
+		return $found;
+	}
+
+
+	/**
+	 * A guarded compile that must refuse the config; returns what it threw. No Assert::exception() here:
+	 * its closure would capture the secrets, and Tracy dumps captured variables, so the log checks in the
+	 * tests would fail on the harness rather than on what they test.
+	 *
+	 * @param array<string, mixed> $secrets
+	 * @param array<string, mixed> $service
+	 * @param array<string, mixed> $extraConfig
+	 */
+	private function compileRefused(string $acceptedDescription, #[SensitiveParameter] array $secrets, array $service, #[SensitiveParameter] array $extraConfig = [], #[SensitiveParameter] ?string $extraConfigNeon = null): RuntimeException
+	{
+		$thrown = null;
+		try {
+			$this->compile($secrets, dynamic: true, guarded: true, service: $service, extraConfig: $extraConfig, extraConfigNeon: $extraConfigNeon);
+		} catch (RuntimeException $e) {
+			$thrown = $e;
+		}
+		Assert::notNull($thrown, $acceptedDescription);
+		assert($thrown !== null); // Assert::notNull() doesn't narrow the type for phpstan and psalm
+		return $thrown;
+	}
+
+
+	/**
+	 * Renders the refusal's blue screen, the .md twin included, and checks the value stayed out of both.
+	 * Callers pass only a tail of the value: the blue screen escapes characters differently in every context
+	 * (&#039; in HTML, \u0027 in the dump JSON), so looking for a whole value with an apostrophe in it would
+	 * pass whatever leaked.
+	 */
+	private function assertNoLeakInRenderedBlueScreen(RuntimeException $thrown, string $name, #[SensitiveParameter] string $valueTail): void
+	{
+		$log = $this->lastTempDir() . "/{$name}-bluescreen.html";
+		Assert::true($this->blueScreen->renderToFile($thrown, $log), 'Tracy refused to write the blue screen');
+		Assert::notContains($valueTail, FileSystem::read($log), 'the exception log leaked the value');
+		Assert::notContains($valueTail, FileSystem::read($this->lastTempDir() . "/{$name}-bluescreen.md"), 'the agent log leaked the value');
+	}
+
+
+	/**
+	 * @param array<string, mixed> $secrets
+	 * @param array<string, mixed> $service Registered as `probe`, the one thing that reads the secret
+	 * @param array<string, mixed> $extraConfig Merged in on top, the way another config file would be
+	 * @param bool $guarded Registers ContainerSecretsChecker the way Bootstrap does; off for the tests that
+	 *     deliberately compile a secret in to look at the result
+	 * @return array{Container, string} The container and the temp directory it was compiled into
+	 */
+	private function compile(#[SensitiveParameter] array $secrets, bool $dynamic, array $service, #[SensitiveParameter] array $extraConfig = [], bool $guarded = false, #[SensitiveParameter] ?string $extraConfigNeon = null): array
+	{
+		$tempDir = sys_get_temp_dir() . '/compiled-container-secrets-test-' . bin2hex(random_bytes(8));
+		$this->tempDirs[] = $tempDir;
+
+		$configurator = new Configurator();
+		$configurator->setDebugMode(false);
+		$configurator->setTempDirectory($tempDir);
+		if ($dynamic) {
+			$configurator->addDynamicParameters(['secrets' => $secrets]);
+		} else {
+			$configurator->addStaticParameters(['secrets' => $secrets]);
+		}
+		$configurator->addConfig([
+			'application' => ['scanDirs' => false], // or it finds this app's presenters and fails on their dependencies
+			'services' => ['probe' => $service],
+		]);
+		if ($extraConfig !== []) {
+			$configurator->addConfig($extraConfig);
+		}
+		if ($extraConfigNeon !== null) {
+			// added as a FILE: a real config goes through the NeonAdapter, which rewrites values and keys
+			// in ways an addConfig(array) never sees
+			FileSystem::createDir($tempDir);
+			FileSystem::write($tempDir . '/extra.neon', $extraConfigNeon);
+			$configurator->addConfig($tempDir . '/extra.neon');
+		}
+		if ($guarded) {
+			$configurator->onCompile[] = function (Configurator $configurator, Compiler $compiler) use ($secrets): void {
+				$compiler->addExtension('containerSecretsChecker', new ContainerSecretsChecker($secrets));
+			};
+		}
+		return [$configurator->createContainer(initialize: false), $tempDir];
+	}
+
+}
+
+TestCaseRunner::run(CompiledContainerSecretsTest::class);


### PR DESCRIPTION
Every key and password is written into the container Nette compiles into `temp/`, inlined as a literal into each service factory that uses it. The copy that matters is the one in the exception log: Tracy renders the source of every frame, and `#[SensitiveParameter]` and `keysToHide` both work on values, so neither touches source code. Building an encryption service is exactly where a failure happens, the constructor rejects a bad key, and the frame is the generated factory with the key sitting in the excerpt. So the key ends up in `app/log`, in the one form the redaction can't reach, and logs are kept, copied off the machine and read by tooling long after the fact.

> [!NOTE]
> There is one mechanism that does touch source code, and it isn't enough either: `nette/di` wraps `#[SensitiveParameter]` service arguments in the generated container in `/*sensitive{*/.../*}*/`, and Tracy replaces those spans with `*hidden*` when it renders a source excerpt into a blue screen. It covers source excerpts only, while a failed compile puts the whole configuration into the trace's frame arguments, which is why this change installs a scrubber on the blue screen as well.
>
> It covers only what someone remembered to annotate, so a secret passed to a constructor whose author didn't add the attribute is written into the container in plain text with nothing to notice. It doesn't enforce anything, so a password left in a config file after a rotation, or a copy pasted into a config file, is still compiled in: redaction hides a value while something renders it, it doesn't keep the value out of the file. And the value stays in `temp/` either way, so rotating one still means recompiling. 

The secrets live in `config/secrets.neon`, gitignored, template in `config/secrets.template.neon`, and Bootstrap passes them to the container with `addDynamicParameters()`, one parameter with everything under it so `%secrets.…%` says what a value is where it's used. A dynamic parameter is handed over at runtime and never written into the generated code: the factory reads `$this->getParameter('secrets')[...]`, so the value exists only as an argument, and there the attribute already covers it. A test builds that exact failure both ways and reads the rendered blue screen back, the `.md` one as well as the `.html`: the key shows up when the parameter is static and is gone from both when it's dynamic.

A data file, deliberately not a PHP one: loading a PHP file compiles it, and some mistakes in it, an empty array element say, are compile fatals that no `catch (Throwable)` sees, so Tracy's shutdown handler renders the source excerpt around the error, the secrets themselves, into the exception log. A data file is never compiled and never a stack frame, so that failure class doesn't exist, and a hand-edited server file that can't execute code is no loss either. A malformed file throws a catchable exception, replaced unchained and without its message by one naming just the file and the error class: the original's message quotes the file's tokens and its trace carries the whole file as the decoder's argument, so either would put the secrets in the very log this keeps them out of. A file that doesn't decode to a mapping keyed by the secret names, a scalar, a list, an empty one, is refused by name: anything else would boot and die later, on the first service reading a secret, with an error that never says what's missing.

The web app refuses to boot without the file, and any boot refuses an empty one, naming it and what to put there, because booting on the empty declared fallbacks means dying later on errors that never say what's missing. CLI scripts tolerate its absence, CI runs some of them with no secrets anywhere. `bootTest()` never loads it, because a dynamic parameter overrides the static fakes from `tests.neon` wholesale and the suite would quietly run against the real keys on any machine that has the file. `checkValues()` refuses at load time what the checks below couldn't vouch for: values that aren't strings, a number would lose leading zeros; values shorter than 8 characters, which can equal an ordinary configuration value by accident, `www` say, and the refusal would then hit a config with nothing to fix; values with control characters in them, because a multiline paste splits into several config entries carrying the pieces; values that read as Nette config syntax, a leading `@` is a service reference (the neon adapter escapes a quoted copy to `@@`, so an exact comparison never sees the secret's bytes, and the resolver unescapes it only into the generated code) and a `%` pair expands as a parameter, quoting the secret's insides in Nette's own error before any check runs; and values that wouldn't decode back to exactly themselves if pasted into a config file without quotes, NEON is quote-optional, so such a copy lands in the container as a number, a date, an array holding the bracketless inside, or the piece before a comment or a trailing `=`, the secret's bytes in a shape the whole-string comparisons can't see. Hex and unpadded base64 pass, and refusing the rest up front keeps every check a plain string comparison.

The declaration in `parameters.neon` has to stay empty, which is the trap worth knowing: a dynamic parameter falls back to what the merged config declares, so a value left in ANY committed config file is compiled in after all and none of this does anything. A guard test scans every committed neon for values under `parameters.secrets`, another checks that every `%secrets.…%` reference resolves to a declared path, a dangling reference compiles fine and fails only on the machine with the real secrets, and a shape test keeps `parameters.neon` and `secrets.template.neon` agreeing, since the runtime file replaces the whole tree with no per-key fallback.

The files the tests can't see, the server's `local.neon` above all, are checked by the app itself on every real compile: `ContainerSecretsChecker` is a compiler extension registered from Bootstrap's `onCompile` hook, which only fires when `ContainerLoader` had nothing to load, so a cached boot costs nothing. Its `beforeCompile()` walks the merged configuration after every other extension got its piece and before a single line of code is generated, so a refused config means no container file was written at all: every following boot recompiles, refuses again with the parameter path and never the value, and keeps the domain down until the config is fixed, which the deploy script's own health check prints the minute it happens.

The extension checks the forbidden subtree and the copies. Under `parameters.secrets`, and at it directly, no value at all is allowed, whatever it is: the config is compiled into the container as the dynamic parameter's fallback, and a stale value left there after a rotation equals nothing in `secrets.neon` while still being a secret. The keys under it have to be ones the current secrets declare, even with nothing beneath them, an empty array say, because Nette compiles the fallback structure keys and all, numeric keys included, and a stale secret left as a key equals nothing current either. Everywhere else a configuration value or key equal to a current secret is refused, keys are emitted into the generated code as literals just like values, and only equal counts, not containing: a whole value equal to a secret is a copy, a substring is how an unrelated `localhost` stays a coincidence and how the check can't start refusing clean configs once some value grows until it happens to contain one. The price is that a secret pasted into the middle of a longer composed value isn't seen, a thin slice here, the MySQL DSNs carry no password. The refusals name paths with every current secret replaced in them and, under `parameters.secrets`, only down to what the current secrets declare: a pasted key would otherwise ride into the message as a path segment.

A failed compile is also precisely when the whole configuration lands in the exception log: the trace's frame arguments carry the `Configurator` with its dynamic parameters, Bootstrap's closure with its captures and the raw config arrays, and a copied secret sits under whatever key it was pasted at, so no `keysToHide` list can name them all. Booting therefore leaves a scrubber on Tracy's blue screen that hides every value equal to a current secret, hides whole any structure keyed by one, Tracy always renders key names, so hiding a key's value wouldn't hide the key, and hides anything keyed `secrets` whatever it holds, which is what covers a stale value the current list can't know. The closure keeps the values it compares against wrapped in `SensitiveParameterValue`, which Tracy redacts natively, so dumping the scrubber itself shows no values and there is no derived list, hashes say, to attack offline. It's installed the moment the secrets are loaded, before anything that could throw with them in memory, and with an empty value list when there's no file to load, a CLI boot on CI say: hiding anything keyed `secrets` doesn't depend on the values, and the compile check can still refuse a stale value it would otherwise dump.

`BootstrapTest` boots the real config chain, so `bootContainerTest()` exposes the two file dependencies the web boot itself hardcodes: the secrets file, pointed at the committed template on machines that have no secrets, and the temp directory, the test's own, because the container cache key includes dynamic parameter names, never values, and a container compiled into the shared temp/ against the template's placeholders could be reused by a real boot with the same key, skipping the check against the real values. The smoke test covers the dynamic-parameters path end to end and checks that booting left the scrubber behind. The test deletes the containers it compiles: the cache key includes dynamic parameter names, never values, so a real boot with the same key could otherwise reuse a container that was only ever checked against the template's placeholders. Another test hands it a file with an unclosed quote, the shape of a hand-edit typo, and reads the message and the rendered blue screen back: neither may contain what's in the file.

Follow-ups:
- #865