### PR TITLE
Take the SMTP password out of the config too

### DIFF
--- a/app/config/local.template.neon
+++ b/app/config/local.template.neon
@@ -5,6 +5,8 @@ mail:
 	smtp: true
 	host: localhost
 	port: 2525
+	username: ''
+	password: %secrets.mail.password%
 
 contentSecurityPolicy: # list values here are added to the existing list values, they do not replace them, unless the directive ends with !
 	policies:

--- a/app/config/parameters.neon
+++ b/app/config/parameters.neon
@@ -84,6 +84,8 @@ parameters:
 		awsLambdaApiKeys:
 			upcKeys:
 		certificatesApiUsers: []
+		mail:
+			password:
 		database:
 			default:
 				password:

--- a/app/config/secrets.template.neon
+++ b/app/config/secrets.template.neon
@@ -1,3 +1,5 @@
+# WARNING: secrets.neon is live, changing a value takes effect on the next request, nothing to recompile or purge.
+#
 # Copy to secrets.neon, which is gitignored, and fill in. Bootstrap passes this to Configurator::addDynamicParameters(),
 # so the values are handed to the container at runtime and are not compiled into it in temp/.
 #

--- a/app/config/secrets.template.neon
+++ b/app/config/secrets.template.neon
@@ -23,6 +23,8 @@ certificatesApiUsers:
 	web: 'sha512bin2hexrandom_bytes64'
 	demo: ''
 	githubactions: ''
+mail:
+	password: ''
 database:
 	default:
 		password: ''

--- a/app/config/tests.neon
+++ b/app/config/tests.neon
@@ -19,6 +19,8 @@ parameters:
 			upcKeys: "thisismychurchthisiswhereihealmyhurts"
 		certificatesApiUsers:
 			foo: f7fbba6e0636f890e56fbbf3283e524c6fa3204ae298382d624741d0dc6638326e282c41be5e4254d8820772c5518a2c5a8c0c7f7eda19594a7eb539453e1ed7 # foo
+		mail:
+			password: ""
 		database:
 			default:
 				password: ""

--- a/app/src/Application/ContainerSecretsChecker.php
+++ b/app/src/Application/ContainerSecretsChecker.php
@@ -67,6 +67,7 @@ final class ContainerSecretsChecker extends CompilerExtension
 		$hidden = array_fill_keys(array_keys($secretValues), '…');
 
 		$filled = [];
+		$unknownKeys = [];
 		$copied = [];
 		foreach ($this->compiler->getExtensions() as $name => $extension) {
 			if ($extension === $this) {
@@ -86,12 +87,17 @@ final class ContainerSecretsChecker extends CompilerExtension
 			foreach (self::configKeys($extension->getConfig(), $name) as [$holder, $key]) {
 				if ($holder === 'parameters.secrets' || str_starts_with($holder, 'parameters.secrets.')) {
 					// Keys under parameters.secrets are compiled into the container as the fallback structure
-					// even with nothing under them, an empty array say, and a stale secret left as a key there
-					// equals nothing current, so every key has to be one the current secrets declare. With no
-					// secrets loaded there's no shape to compare against, and nothing current to protect either
-					$declaredPath = $this->declaredSecretsPath("{$holder}.{$key}");
-					if ($this->secrets !== [] && str_ends_with($declaredPath, '…')) {
-						$filled[] = $declaredPath;
+					// even with nothing under them, an empty array say, so every key has to be one the current
+					// secrets declare: what isn't is either a secret nobody has put in secrets.neon yet or one
+					// left there after a rotation. With no secrets loaded there's no shape to compare against,
+					// and nothing current to protect either
+					$holderPath = $this->declaredSecretsPath($holder);
+					if (
+						$this->secrets !== []
+						&& !str_ends_with($holderPath, '…')
+						&& str_ends_with($this->declaredSecretsPath("{$holder}.{$key}"), '…')
+					) {
+						$unknownKeys[] = $holderPath; // the topmost unknown key only, everything below it is unknown by definition
 					}
 				} elseif (isset($secretValues[$key])) {
 					$copied[] = "{$secretValues[$key]} (a key under " . strtr($holder, $hidden) . ')';
@@ -100,6 +106,9 @@ final class ContainerSecretsChecker extends CompilerExtension
 		}
 		if ($filled !== []) {
 			throw new RuntimeException('Values of ' . implode(', ', array_unique($filled)) . ' are defined statically in the config files and would be compiled into the container as the fallback for the dynamic parameter; they belong only in config/secrets.neon');
+		}
+		if ($unknownKeys !== []) {
+			throw new RuntimeException('The config files declare keys under ' . implode(', ', array_unique($unknownKeys)) . " that config/secrets.neon does not have, and that file replaces the whole tree: add them there, or delete them from the config files if they are left over after a rotation; the names aren't printed because a key can be a secret itself, compare the two files to find them");
 		}
 		if ($copied !== []) {
 			throw new RuntimeException('Values of ' . implode(', ', $copied) . ' are written into the configuration statically and would be compiled into the container; they belong only in config/secrets.neon');

--- a/app/tests/Application/CompiledContainerSecretsTest.phpt
+++ b/app/tests/Application/CompiledContainerSecretsTest.phpt
@@ -116,7 +116,7 @@ final class CompiledContainerSecretsTest extends TestCase
 		$thrown = $this->compileRefused('a stale key with an empty array under parameters.secrets was accepted', ['apiKey' => $secret], [
 			'factory' => 'ArrayObject',
 		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => [$staleValue => []]]]]);
-		Assert::match('%a%secrets.apiKey.…%a%statically%a%', $thrown->getMessage());
+		Assert::match('%a%keys under secrets.apiKey%a%does not have%a%', $thrown->getMessage());
 		Assert::notContains(substr($staleValue, -16), $thrown->getMessage(), 'the message leaked the stale key');
 	}
 
@@ -129,7 +129,7 @@ final class CompiledContainerSecretsTest extends TestCase
 		$thrown = $this->compileRefused('a stale numeric key with an empty array under parameters.secrets was accepted', ['apiKey' => $secret], [
 			'factory' => 'ArrayObject',
 		], extraConfig: ['parameters' => ['secrets' => ['apiKey' => [12345678 => []]]]]);
-		Assert::match('%a%secrets.apiKey.…%a%statically%a%', $thrown->getMessage());
+		Assert::match('%a%keys under secrets.apiKey%a%does not have%a%', $thrown->getMessage());
 	}
 
 
@@ -235,8 +235,9 @@ final class CompiledContainerSecretsTest extends TestCase
 		Assert::match('%a%secrets.apiKey (parameters.probe)%a%', $thrown->getMessage());
 		Assert::notContains($secret, $thrown->getMessage(), 'the message leaked the value it exists to protect');
 
-		// A stale key under parameters.secrets with the adapter's ! suffix: the adapter strips it, so the
-		// shape rule has to see the bare key
+		// A stale key under parameters.secrets with the adapter's ! suffix: the adapter strips the suffix and
+		// puts its own merge marker under the key, so what the rules see is neither the key nor the value the
+		// file has, and this is here to notice if that ever stops being caught
 		$staleValue = 'stalebang-' . bin2hex(random_bytes(8));
 		$thrown = $this->compileRefused('a file-backed config with a stale key under parameters.secrets was accepted', ['apiKey' => $secret], [
 			'factory' => 'ArrayObject',


### PR DESCRIPTION
#864 moved every secret it could see, and this one it couldn't: the SMTP block exists only in the server's `local.neon`, so nothing in the repo pointed at it and the migration went straight past it. It is the same thing that PR was about, a credential compiled into the container as a literal, sitting in `temp/` and in any exception log where building the mailer is somewhere in the trace.

`MailExtension` declares `password` as a dynamic value in its schema, the same as the database credentials, so `%secrets.mail.password%` resolves at runtime and nothing else has to change: compiling a container with it produces a factory that reads `$this->getParameter('secrets')['mail']['password']`, with the value absent from the file and the built mailer holding it. The username stays in `local.neon` next to the host for the reason the database username does, knowing it grants nothing. The mail block in `local.template.neon` gains both lines because dev talks to a local debugging SMTP server that wants no credentials at all, and there was nothing to say a real one needs them, let alone where they belong.

Declaring a new secret is also exactly what the shape rule from #864 refuses on every machine that has not provisioned it yet, and it was reporting that with the message written for a stale value: defined statically in the config files, belongs only in `secrets.neon`, which reads as "delete it from the config" and is backwards when the answer is to add it. It now names both causes, says the key names are not printed because an unknown key can be a stale secret itself, and reports the topmost unknown key only instead of repeating the same subtree once per level.

Before deploying: the real value goes into the server's `secrets.neon` first, and only then does the value in `local.neon` become the reference. A leftover copy is refused at compile time with the path named, but a missing one is not, and an empty SMTP password boots perfectly well and fails only when something tries to send.

Follow-up to #864