### PR TITLE
Build formatters once, and drop a self-join that stopped filtering

### DIFF
--- a/app/src/DateTime/DateTimeFormatter.php
+++ b/app/src/DateTime/DateTimeFormatter.php
@@ -7,7 +7,7 @@ use DateTimeInterface;
 use IntlDateFormatter;
 use RuntimeException;
 
-final readonly class DateTimeFormatter
+final class DateTimeFormatter
 {
 
 	private const string DATE_DAY = 'day';
@@ -106,9 +106,23 @@ final readonly class DateTimeFormatter
 	];
 
 
+	/**
+	 * Creating one costs an order of magnitude more than using it.
+	 *
+	 * @var array<string, IntlDateFormatter>
+	 */
+	private array $formatters = [];
+
+
 	public function __construct(
-		private string $defaultLocale,
+		private readonly string $defaultLocale,
 	) {
+	}
+
+
+	private function getFormatter(string $locale): IntlDateFormatter
+	{
+		return $this->formatters[$locale] ??= new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE);
 	}
 
 
@@ -118,7 +132,7 @@ final readonly class DateTimeFormatter
 			$locale = $this->defaultLocale;
 		}
 
-		$formatter = new IntlDateFormatter($locale, IntlDateFormatter::NONE, IntlDateFormatter::NONE);
+		$formatter = $this->getFormatter($locale);
 		if ($end === null || $this->sameDates($start, $end, $type, self::NO_INTERVAL)) {
 			$formatter->setPattern(self::LOCAL_DATE_FORMAT[$locale][$type][self::NO_INTERVAL]);
 			$result = $formatter->format($start);

--- a/app/src/Training/Dates/TrainingDates.php
+++ b/app/src/Training/Dates/TrainingDates.php
@@ -488,21 +488,11 @@ final class TrainingDates
 				JOIN training_url_actions ta ON t.id_training = ta.key_training
 				JOIN url_actions a ON ta.key_url_action = a.id_url_action
 				LEFT JOIN training_cooperations c ON d.key_cooperation = c.id_cooperation
-				JOIN (
-					SELECT
-						t2.id_training,
-						d2.key_venue,
-						d2.start
-					FROM
-						trainings t2
-						JOIN training_dates d2 ON t2.id_training = d2.key_training
-						JOIN training_date_status s2 ON d2.key_status = s2.id_status
-					WHERE
-						d2.public
-						AND t2.id_training = ?
-						AND d2.end > NOW()
-						AND s2.status IN (?, ?)
-				) u ON t.id_training = u.id_training AND (v.id_venue = u.key_venue OR u.key_venue IS NULL) AND d.start = u.start
+			WHERE
+				d.public
+				AND t.id_training = ?
+				AND d.end > NOW()
+				AND s.status IN (?, ?)
 			ORDER BY
 				d.start',
 			$trainingId,

--- a/app/src/Training/Dates/UpcomingTrainingDates.php
+++ b/app/src/Training/Dates/UpcomingTrainingDates.php
@@ -107,22 +107,11 @@ final class UpcomingTrainingDates
 					JOIN training_date_status s ON d.key_status = s.id_status
 					LEFT JOIN training_venues v ON d.key_venue = v.id_venue
 					LEFT JOIN training_cooperations c ON d.key_cooperation = c.id_cooperation
-					JOIN (
-						SELECT
-							t2.id_training,
-							d2.key_venue,
-							d2.start
-						FROM
-							trainings t2
-							JOIN training_dates d2 ON t2.id_training = d2.key_training
-							JOIN training_date_status s2 ON d2.key_status = s2.id_status
-						WHERE
-							(d2.public != ? OR TRUE = ?)
-							AND d2.end > NOW()
-							AND s2.status IN (?, ?)
-					) u ON t.id_training = u.id_training AND (v.id_venue = u.key_venue OR u.key_venue IS NULL) AND d.start = u.start
 				WHERE
-					t.key_successor IS NULL
+					(d.public != ? OR TRUE = ?)
+					AND d.end > NOW()
+					AND s.status IN (?, ?)
+					AND t.key_successor IS NULL
 					AND t.key_discontinued IS NULL
 					AND l.language = ?
 				ORDER BY

--- a/app/src/Training/Price.php
+++ b/app/src/Training/Price.php
@@ -71,10 +71,19 @@ final readonly class Price
 
 	private function formatCurrency(float $price): string
 	{
-		$formatter = new NumberFormatter('cs_CZ', NumberFormatter::CURRENCY);
-		if (fmod($price, 1) === (float)0) {
-			$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+		// Creating one costs an order of magnitude more than using it, one per setting so none of them is changed later
+		/** @var array<string, NumberFormatter> $formatters */
+		static $formatters = [];
+		$wholeNumber = fmod($price, 1) === (float)0;
+		$key = $wholeNumber ? 'whole' : 'fraction';
+		if (!isset($formatters[$key])) {
+			$formatter = new NumberFormatter('cs_CZ', NumberFormatter::CURRENCY);
+			if ($wholeNumber) {
+				$formatter->setAttribute(NumberFormatter::FRACTION_DIGITS, 0);
+			}
+			$formatters[$key] = $formatter;
 		}
+		$formatter = $formatters[$key];
 
 		$currency = 'CZK';
 		$formatted = $formatter->formatCurrency($price, $currency);


### PR DESCRIPTION
Easy perf wins.

`IntlDateFormatter` was built per call, so a page with 148 dates built 148 of them: 7.7 ms against 0.45 ms on the server, 8 to 10 percent of that page, and every page showing dates gains. `NumberFormatter` in `Price` had the same shape for far fewer calls, kept one per fraction setting rather than mutating one.

The training dates self-join was a `MIN()` with a `GROUP BY` until 50c3897 removed the aggregate on purpose and left the join behind, since when it has only ever matched rows to themselves. Both copies return the same rows without it, checked over the whole history with the date filter relaxed. The suite cannot see that, because the database double never runs the SQL.